### PR TITLE
parity(skills): add Cloudflare temporary deploy helper

### DIFF
--- a/crates/hermes-cli/src/cli.rs
+++ b/crates/hermes-cli/src/cli.rs
@@ -516,6 +516,15 @@ pub enum CliCommand {
         payload: Option<String>,
     },
 
+    /// Cloudflare workflow helpers.
+    Cloudflare {
+        /// Action: parse-temporary-deploy-output.
+        action: Option<String>,
+        /// Run parser self-test.
+        #[arg(long)]
+        selftest: bool,
+    },
+
     /// Microsoft Teams meeting summary pipeline.
     TeamsPipeline {
         /// Action: list/show/run/fetch/subscriptions/subscribe/renew-subscription/delete-subscription/maintain-subscriptions/token-health/validate.
@@ -1015,6 +1024,32 @@ mod tests {
                 assert!(!yes);
             }
             _ => panic!("Expected ACP command with --version"),
+        }
+    }
+
+    #[test]
+    fn cli_parse_cloudflare_parser() {
+        let cli = Cli::try_parse_from(vec![
+            "hermes",
+            "cloudflare",
+            "parse-temporary-deploy-output",
+        ])
+        .unwrap();
+        match cli.command {
+            Some(CliCommand::Cloudflare { action, selftest }) => {
+                assert_eq!(action.as_deref(), Some("parse-temporary-deploy-output"));
+                assert!(!selftest);
+            }
+            _ => panic!("Expected Cloudflare command"),
+        }
+
+        let selftest = Cli::try_parse_from(vec!["hermes", "cloudflare", "--selftest"]).unwrap();
+        match selftest.command {
+            Some(CliCommand::Cloudflare { action, selftest }) => {
+                assert!(action.is_none());
+                assert!(selftest);
+            }
+            _ => panic!("Expected Cloudflare command"),
         }
     }
 

--- a/crates/hermes-cli/src/cloudflare.rs
+++ b/crates/hermes-cli/src/cloudflare.rs
@@ -1,0 +1,213 @@
+use hermes_core::AgentError;
+use regex::Regex;
+use serde::Serialize;
+use std::io::Read;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TemporaryDeployFacts {
+    pub live_url: Option<String>,
+    pub claim_url: Option<String>,
+    pub account: Option<String>,
+    pub account_state: Option<String>,
+    pub expires_minutes: Option<u32>,
+    pub deployed: bool,
+}
+
+fn first_match(pattern: &Regex, text: &str) -> Option<String> {
+    pattern.find(text).map(|m| {
+        m.as_str()
+            .trim_end_matches(&['.', ',', ')', ';', ']'][..])
+            .to_string()
+    })
+}
+
+pub fn parse_temporary_deploy_output(text: &str) -> TemporaryDeployFacts {
+    let live_url =
+        Regex::new(r"https://[A-Za-z0-9._-]+\.workers\.dev\S*").expect("valid live URL regex");
+    let claim_url =
+        Regex::new(r"(?i)https://\S*claim\S*claimToken=\S*").expect("valid claim URL regex");
+    let account = Regex::new(r"(?i)Account:\s*(?P<name>.+?)\s*\((?P<state>created|reused)\)")
+        .expect("valid account regex");
+    let claim_within =
+        Regex::new(r"(?i)Claim within:\s*(?P<minutes>\d+)\s*minutes?").expect("valid claim regex");
+    let deployed = Regex::new(r"(?im)^\s*(Deployed|Uploaded)\b").expect("valid deploy regex");
+
+    let account_match = account.captures(text);
+    let expires_minutes = claim_within
+        .captures(text)
+        .and_then(|caps| caps.name("minutes"))
+        .and_then(|m| m.as_str().parse::<u32>().ok());
+
+    TemporaryDeployFacts {
+        live_url: first_match(&live_url, text),
+        claim_url: first_match(&claim_url, text),
+        account: account_match
+            .as_ref()
+            .and_then(|caps| caps.name("name"))
+            .map(|m| m.as_str().trim().to_string()),
+        account_state: account_match
+            .as_ref()
+            .and_then(|caps| caps.name("state"))
+            .map(|m| m.as_str().to_ascii_lowercase()),
+        expires_minutes,
+        deployed: deployed.is_match(text),
+    }
+}
+
+fn cloudflare_help() -> &'static str {
+    "Usage:\n  hermes cloudflare parse-temporary-deploy-output < wrangler.log\n  npx wrangler@latest deploy --temporary 2>&1 | hermes cloudflare parse-temporary-deploy-output\n  hermes cloudflare --selftest\n\nActions:\n  parse-temporary-deploy-output   Parse wrangler temporary deploy output into JSON\n  parse-temporary-deploy          Alias for parse-temporary-deploy-output\n  parse                           Alias for parse-temporary-deploy-output"
+}
+
+fn run_selftest() -> Result<(), AgentError> {
+    const SAMPLE: &str = r#"
+Continuing means you accept Cloudflare's Terms of Service and Privacy Policy.
+
+Temporary account ready:
+     Account:        example-name (created)
+     Claim within:   60 minutes
+     Claim URL:      https://dash.cloudflare.com/claim-preview?claimToken=abc123XYZ
+
+Uploaded example-worker
+Deployed example-worker triggers
+     https://example-worker.example-name.workers.dev
+"#;
+    let facts = parse_temporary_deploy_output(SAMPLE);
+    if facts.live_url.as_deref() != Some("https://example-worker.example-name.workers.dev")
+        || facts.claim_url.as_deref()
+            != Some("https://dash.cloudflare.com/claim-preview?claimToken=abc123XYZ")
+        || facts.account.as_deref() != Some("example-name")
+        || facts.account_state.as_deref() != Some("created")
+        || facts.expires_minutes != Some(60)
+        || !facts.deployed
+    {
+        return Err(AgentError::Config(format!(
+            "Cloudflare temporary deploy parser selftest failed: {:?}",
+            facts
+        )));
+    }
+    println!("selftest: OK");
+    Ok(())
+}
+
+pub async fn handle_cli_cloudflare(
+    action: Option<String>,
+    selftest: bool,
+) -> Result<(), AgentError> {
+    if selftest || action.as_deref() == Some("selftest") {
+        return run_selftest();
+    }
+
+    match action.as_deref().unwrap_or("help") {
+        "parse-temporary-deploy-output" | "parse-temporary-deploy" | "parse" => {
+            let mut input = String::new();
+            std::io::stdin()
+                .read_to_string(&mut input)
+                .map_err(|e| AgentError::Io(format!("read stdin: {}", e)))?;
+            let facts = parse_temporary_deploy_output(&input);
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&facts)
+                    .map_err(|e| AgentError::Config(format!("serialize parse result: {}", e)))?
+            );
+            if facts.live_url.is_some() {
+                Ok(())
+            } else {
+                Err(AgentError::Config(
+                    "wrangler output did not contain a workers.dev live URL".to_string(),
+                ))
+            }
+        }
+        "help" | "-h" | "--help" => {
+            println!("{}", cloudflare_help());
+            Ok(())
+        }
+        other => Err(AgentError::Config(format!(
+            "Unknown cloudflare action '{}'.\n{}",
+            other,
+            cloudflare_help()
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_CREATED: &str = r#"
+Temporary account ready:
+     Account:        Serene Temple (created)
+     Claim within:   60 minutes
+     Claim URL:      https://dash.cloudflare.com/claim-preview?claimToken=abc123XYZ
+
+Uploaded example-worker
+Deployed example-worker triggers
+     https://example-worker.serene-temple.workers.dev
+"#;
+
+    const SAMPLE_REUSED: &str = r#"
+Temporary account ready:
+     Account:        example-name (reused)
+     Claim within:   42 minutes
+     Claim URL:      https://dash.cloudflare.com/claim-preview?claimToken=def456
+Deployed example-worker triggers
+     https://example-worker.example-name.workers.dev
+"#;
+
+    const SAMPLE_NO_TEMP: &str = r#"
+Error: You are not logged in.
+To continue without logging in, rerun this command with `--temporary`.
+"#;
+
+    #[test]
+    fn parses_created_temporary_deploy_output() {
+        let facts = parse_temporary_deploy_output(SAMPLE_CREATED);
+        assert_eq!(
+            facts.live_url.as_deref(),
+            Some("https://example-worker.serene-temple.workers.dev")
+        );
+        assert_eq!(
+            facts.claim_url.as_deref(),
+            Some("https://dash.cloudflare.com/claim-preview?claimToken=abc123XYZ")
+        );
+        assert_eq!(facts.account.as_deref(), Some("Serene Temple"));
+        assert_eq!(facts.account_state.as_deref(), Some("created"));
+        assert_eq!(facts.expires_minutes, Some(60));
+        assert!(facts.deployed);
+    }
+
+    #[test]
+    fn parses_reused_temporary_deploy_output() {
+        let facts = parse_temporary_deploy_output(SAMPLE_REUSED);
+        assert_eq!(
+            facts.live_url.as_deref(),
+            Some("https://example-worker.example-name.workers.dev")
+        );
+        assert_eq!(facts.account_state.as_deref(), Some("reused"));
+        assert_eq!(facts.expires_minutes, Some(42));
+        assert!(facts.deployed);
+    }
+
+    #[test]
+    fn missing_temporary_deploy_facts_stays_structured() {
+        let facts = parse_temporary_deploy_output(SAMPLE_NO_TEMP);
+        assert_eq!(facts.live_url, None);
+        assert_eq!(facts.claim_url, None);
+        assert_eq!(facts.account, None);
+        assert!(!facts.deployed);
+    }
+
+    #[test]
+    fn trims_url_trailing_punctuation() {
+        let facts = parse_temporary_deploy_output(
+            "Deployed demo\nhttps://demo.temp.workers.dev).\nClaim URL: https://dash.cloudflare.com/claim-preview?claimToken=tok];",
+        );
+        assert_eq!(
+            facts.live_url.as_deref(),
+            Some("https://demo.temp.workers.dev")
+        );
+        assert_eq!(
+            facts.claim_url.as_deref(),
+            Some("https://dash.cloudflare.com/claim-preview?claimToken=tok")
+        );
+    }
+}

--- a/crates/hermes-cli/src/lib.rs
+++ b/crates/hermes-cli/src/lib.rs
@@ -18,6 +18,7 @@ pub mod billing;
 pub mod checklist;
 pub mod claw_migrate;
 pub mod cli;
+pub mod cloudflare;
 pub mod commands;
 pub mod config_env;
 pub mod copilot_auth;

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -880,6 +880,9 @@ async fn main() {
             )
             .await
         }
+        CliCommand::Cloudflare { action, selftest } => {
+            hermes_cli::cloudflare::handle_cli_cloudflare(action, selftest).await
+        }
         CliCommand::TeamsPipeline {
             action,
             id,

--- a/docs/parity/PARITY_DASHBOARD.md
+++ b/docs/parity/PARITY_DASHBOARD.md
@@ -1,14 +1,14 @@
 # Parity Dashboard
 
-_Generated from source artifacts: `2026-06-26T21:00:26.907458+00:00`_
+_Generated from source artifacts: `2026-06-26T22:00:28.543161+00:00`_
 
 ## Snapshot
 
-- Upstream target: `upstream/main` @ `5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`
-- Workstream snapshot generated: `2026-06-23T05:17:48-06:00`
+- Upstream target: `upstream/main` @ `9b2af36d5aea3118ac6cfb15a2802f92fe0b5eda`
+- Workstream snapshot generated: `2026-06-26T15:22:04-06:00`
 - Parity matrix generated: `2026-06-12T11:29:13.798398+00:00`
-- Queue snapshot generated: `2026-06-26T21:00:26.742687+00:00`
-- Proof snapshot generated: `2026-06-26T21:00:26.907458+00:00`
+- Queue snapshot generated: `2026-06-26T21:33:31.127926+00:00`
+- Proof snapshot generated: `2026-06-26T22:00:28.543161+00:00`
 
 ## Gate Status
 
@@ -18,7 +18,7 @@ _Generated from source artifacts: `2026-06-26T21:00:26.907458+00:00`_
 - SOTA harness matrix: **PASS**
 - Behavioral similarity diff: **PASS**
 - Deep problem-solving diff: **PASS**
-- Release gate failures: max_queue_pending_commits (actual=18.0, limit=0)
+- Release gate failures: max_queue_pending_commits (actual=31.0, limit=0)
 - CI gate failures: max_commits_behind (actual=5880.0, limit=5500); max_upstream_patch_missing (actual=5657.0, limit=5000)
 - CI gate warnings: none
 
@@ -74,10 +74,10 @@ _Generated from source artifacts: `2026-06-26T21:00:26.907458+00:00`_
 
 | Metric | Value |
 | --- | ---: |
-| Total commits in queue | 7116 |
-| Pending | 18 |
-| Ported | 489 |
-| Superseded | 6533 |
+| Total commits in queue | 7173 |
+| Pending | 31 |
+| Ported | 490 |
+| Superseded | 6576 |
 
 ## Tree/Patch Drift
 

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 18.0,
+        "actual": 31.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "pass"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-26T21:00:26.907458+00:00",
+  "generated_at_utc": "2026-06-26T22:00:28.543161+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 18.0,
+    "max_queue_pending_commits": 31.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,22 +299,22 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 76,
-      "pending": 18,
-      "ported": 489,
-      "superseded": 6533
+      "pending": 31,
+      "ported": 490,
+      "superseded": 6576
     },
     "by_target_ticket": {
-      "20": 3202,
+      "20": 3234,
       "21": 130,
-      "22": 960,
-      "23": 488,
+      "22": 968,
+      "23": 489,
       "24": 23,
       "25": 146,
-      "26": 2167
+      "26": 2183
     },
     "overrides_path": "docs/parity/queue-overrides.json",
     "patch_equivalent_count": 6,
-    "total_commits": 7116
+    "total_commits": 7173
   },
   "release_gate": {
     "checks": [
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 18.0,
+        "actual": 31.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-26T21:00:26.907458+00:00`
+Generated: `2026-06-26T22:00:28.543161+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-26T21:00:26.907458+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 18.0 |
+| `max_queue_pending_commits` | 31.0 |
 
 ## GPAR Ticket Completion
 
@@ -93,13 +93,13 @@ Generated: `2026-06-26T21:00:26.907458+00:00`
 
 ## Queue Summary
 
-- Upstream missing commits tracked: `7116`.
+- Upstream missing commits tracked: `7173`.
 - By target ticket:
-  - `#20`: `3202`
+  - `#20`: `3234`
   - `#21`: `130`
-  - `#22`: `960`
-  - `#23`: `488`
+  - `#22`: `968`
+  - `#23`: `489`
   - `#24`: `23`
   - `#25`: `146`
-  - `#26`: `2167`
+  - `#26`: `2183`
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -5693,6 +5693,21 @@
       "disposition": "ported",
       "owner": "rust-runtime",
       "notes": "Kanban injected-guidance refactor is represented locally by Rust Kanban command/runtime behavior plus v2 kanban-worker and kanban-orchestrator skills that explicitly state the lifecycle is auto-injected while retaining deeper playbooks. Rust Kanban tests cover command parsing, task state, attachments, and goal-loop behavior."
+    },
+    "ff08e60c63ada076aecc0c3243e2cfc9258db4f8": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Cloudflare temporary deploy optional skill is ported as a Rust-loaded web-development skill. The upstream Python output parser is replaced by the Rust-native `hermes cloudflare parse-temporary-deploy-output` CLI helper with parser unit tests and generated docs."
+    },
+    "97888fed483c1e867666b6beb4eb03e409cc9481": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream fixes browser executable auto-detection in a Python-era installer. Hermes Agent Ultra install.sh is release-asset/source-build only, has no find_system_browser/AGENT_BROWSER_EXECUTABLE_PATH browser fallback, and scripts/install.ps1 is not shipped, so the Snap Chromium repair path is not applicable locally."
+    },
+    "233ef98afe2f156dd916c8f4e7f98d16676de4ee": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream hardens docker/stage2-hook.sh symlink chown behavior. This Rust checkout does not ship docker/stage2-hook.sh, so there is no local stage2 recursive chown surface to port."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,25 +1,25 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-26T21:00:26.742687+00:00`
+Generated: `2026-06-26T21:33:31.127926+00:00`
 
-- Range: `main..upstream/main`; total commits tracked: `7116`.
+- Range: `main..upstream/main`; total commits tracked: `7173`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
-| #20 | GPAR-01 tests+CI parity | 3202 |
+| #20 | GPAR-01 tests+CI parity | 3234 |
 | #21 | GPAR-02 skills parity | 130 |
-| #22 | GPAR-03 UX parity | 960 |
-| #23 | GPAR-04 gateway/plugin-memory parity | 488 |
+| #22 | GPAR-03 UX parity | 968 |
+| #23 | GPAR-04 gateway/plugin-memory parity | 489 |
 | #24 | GPAR-05 environments+parsers+benchmarks | 23 |
 | #25 | GPAR-06 packaging/docs/install parity | 146 |
-| #26 | GPAR-07 upstream queue backfill | 2167 |
+| #26 | GPAR-07 upstream queue backfill | 2183 |
 
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 76 |
-| pending | 18 |
-| ported | 489 |
-| superseded | 6533 |
+| pending | 31 |
+| ported | 490 |
+| superseded | 6576 |
 
 ## First 100 Pending Commits
 
@@ -28,8 +28,6 @@ Generated: `2026-06-26T21:00:26.742687+00:00`
 | `2609bcccca30` | #25 | feat(i18n): add complete Spanish translation |
 | `defeda8c559f` | #22 | docs: sync documentation with current implementation |
 | `7130d60861a9` | #22 | feat(providers): remove google-gemini-cli + google-antigravity OAuth providers (#50492) |
-| `ff08e60c63ad` | #21 | feat(skills): add cloudflare-temporary-deploy optional skill (#50849) |
-| `97888fed483c` | #25 | fix(install): drop system-browser fallback + auto-repair stale snap override |
 | `a911bcda18cf` | #22 | docs: stop recommending pip install; curl installer is the only supported path (#51743) |
 | `6da615c77cf8` | #26 | fix(desktop): scope onboarding runtime check to connected provider |
 | `d8fe1c0b4195` | #20 | test(desktop): cover scoped onboarding runtime readiness checks |
@@ -38,8 +36,23 @@ Generated: `2026-06-26T21:00:26.742687+00:00`
 | `1fe013ee16f1` | #20 | feat(pets): polish generate flow and reduce hatch CPU pressure |
 | `e92b5c6af8be` | #20 | feat(pets): quality-first OpenRouter model chain + stronger atlas gates + global pet-gen notifications |
 | `7078d9d1e29d` | #26 | fix(pets): raise generation timeouts for the slow quality-first model path |
+| `f168631be0ce` | #20 | fix(agent): gate verify-on-stop nudge off for messaging surfaces |
 | `b8d220f2684c` | #26 | feat(desktop): wire project settings and shell chrome |
 | `890e890281e4` | #26 | chore(desktop): update package lock |
 | `e7d2f0b93ca2` | #24 | fix(windows): suppress console flashes and harden gateway restarts |
 | `ff813659880f` | #26 | feat(desktop): in-app spot editor for the file preview pane |
-| `233ef98afe2f` | #20 | fix(docker): skip symlinked stage2 chown targets (#52789) |
+| `1c8594b634e4` | #20 | fix(desktop): show remote backend updates without counts |
+| `594380d44a45` | #20 | fix(tui): make stop interrupt queued desktop turns |
+| `dd980aaba1d1` | #26 | feat(desktop): Alt+wheel to scale the pet, never cropped |
+| `7d1b72a15d34` | #26 | feat(desktop): zoom the pet toward the cursor |
+| `bf60bbb6c59b` | #26 | refactor(desktop): collapse overlay zoom-anchor math |
+| `62fe9fd1011a` | #22 | style(desktop,tui): fix all lint/type/formatting issues |
+| `3cf900eb67c0` | #20 | fix(install): discard managed lockfile churn before stashing |
+| `2e322466b14e` | #20 | feat(dashboard-auth): drain shared-bearer-secret provider plugin |
+| `81ac562bf0e5` | #26 | feat(desktop): inline embed detection + module primitives |
+| `0c190083cd9a` | #26 | feat(desktop): lazy embed renderers + fenced diagrams/alerts |
+| `e36d9862ece4` | #26 | feat(desktop): render embeds, fences and alerts in assistant markdown |
+| `da0ed979facd` | #26 | feat(desktop): zoomable primitive — open full, pan/zoom, copy |
+| `8559246bfb04` | #26 | feat(desktop): rebuild the clarify prompt to match the chat UI |
+| `54b50037e1e4` | #26 | fix(desktop): treat a pending prompt as paused-on-you, not working |
+| `db6ced47128d` | #26 | feat(desktop): consent gate for inline embeds (per-embed / per-service) |

--- a/docs/parity/workstream-status.json
+++ b/docs/parity/workstream-status.json
@@ -1,11 +1,11 @@
 {
-  "generated_at_utc": "2026-06-23T05:17:48-06:00",
-  "head_sha": "f708494a083f916d02ab4ce056dc2cc2233f242c",
+  "generated_at_utc": "2026-06-26T15:22:04-06:00",
+  "head_sha": "79cd74ca3a2d7314e54e4a7d350db9b833142cf1",
   "states": {
     "complete": 7
   },
   "upstream_ref": "upstream/main",
-  "upstream_sha": "5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4",
+  "upstream_sha": "9b2af36d5aea3118ac6cfb15a2802f92fe0b5eda",
   "workstreams": [
     {
       "evidence": [
@@ -39,8 +39,8 @@
       ],
       "metrics": {
         "divergence_documented": true,
-        "local_skill_files": 890,
-        "upstream_skill_files": 894
+        "local_skill_files": 917,
+        "upstream_skill_files": 895
       },
       "state": "complete",
       "title": "Skills parity",

--- a/docs/parity/workstream-status.md
+++ b/docs/parity/workstream-status.md
@@ -1,7 +1,7 @@
 # Workstream Status
 
-- Local HEAD: `f708494a083f916d02ab4ce056dc2cc2233f242c`
-- Upstream: `upstream/main` (`5ecf3bf0e0726b8b33682bb5c3aad9679b7b5be4`)
+- Local HEAD: `79cd74ca3a2d7314e54e4a7d350db9b833142cf1`
+- Upstream: `upstream/main` (`9b2af36d5aea3118ac6cfb15a2802f92fe0b5eda`)
 
 | Workstream | Title | State |
 | --- | --- | --- |
@@ -33,7 +33,7 @@
 - State: **complete**
 - Upstream skills catalogs audited against local tree.
 - Intentional divergence documented for skills and optional-skills vendoring.
-- Metrics: `{"divergence_documented": true, "local_skill_files": 890, "upstream_skill_files": 894}`
+- Metrics: `{"divergence_documented": true, "local_skill_files": 917, "upstream_skill_files": 895}`
 
 ## WS5 — UX parity
 

--- a/optional-skills/web-development/cloudflare-temporary-deploy/SKILL.md
+++ b/optional-skills/web-development/cloudflare-temporary-deploy/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: cloudflare-temporary-deploy
+description: Deploy a Worker live, no account, via wrangler --temporary.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [cloudflare, workers, wrangler, deploy, temporary, agent, serverless, web-development]
+    category: web-development
+---
+
+# Cloudflare Temporary Deploy Skill
+
+Deploy a Cloudflare Worker to a live `workers.dev` URL with zero account setup, using `wrangler deploy --temporary`. Cloudflare provisions a throwaway account, deploys, and prints a claim URL valid for 60 minutes; unclaimed accounts auto-delete. This gives an agent a tight write -> deploy -> verify loop without OAuth, signup, or token copy-paste.
+
+This skill does not cover production deploys. Use `wrangler login` plus a permanent account for those. It also does not cover non-Worker Cloudflare products beyond the temporary-account limits below.
+
+## When to Use
+
+Load this skill when the user wants to:
+
+- Ship agent-written code to a live URL without first creating a Cloudflare account.
+- Iterate in a background/autonomous session where browser OAuth would be a hard stop.
+- Prototype or evaluate Workers quickly with a throwaway, claimable target.
+- Build a self-verifying deploy loop: deploy, `curl` the live URL, confirm output matches the code, redeploy.
+
+## When NOT to Use
+
+- Production or CI/CD: use a permanent account with `wrangler login` or `CLOUDFLARE_API_TOKEN`. `--temporary` errors out if credentials are present.
+- Wrangler is already authenticated: `--temporary` returns an error by design. Run `wrangler logout` first only if the user explicitly wants a throwaway deploy.
+- Long-lived hosting: temporary deployments are deleted after 60 minutes unless claimed.
+
+## Prerequisites
+
+- Wrangler 4.102.0 or later. This is the version that introduced `--temporary`. Verify with `npx wrangler@latest --version`.
+- Node 18+ with `npx`, `npm`, `yarn`, or `pnpm`. No global install is required.
+- No Cloudflare credentials present. `--temporary` only works when Wrangler is unauthenticated: no OAuth login, no `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_API_KEY` env var, and no cached `~/.wrangler` or `~/.config/.wrangler` OAuth session in the shell you use.
+- Network egress to `cloudflare.com` and `workers.dev`.
+- Using `--temporary` accepts Cloudflare's Terms of Service and Privacy Policy.
+
+## How to Run
+
+Use the terminal tool for every step. Always pin Wrangler with `wrangler@latest` or a version `>=4.102.0` so you do not accidentally run an old global binary that lacks `--temporary`.
+
+1. Scaffold a minimal Worker if the project does not already exist.
+
+   `wrangler.jsonc`:
+
+   ```jsonc
+   {
+     "name": "hello-agent",
+     "main": "src/index.ts",
+     "compatibility_date": "2025-01-01"
+   }
+   ```
+
+   `src/index.ts`:
+
+   ```typescript
+   export default {
+     async fetch(): Promise<Response> {
+       return new Response("hello cloudflare");
+     },
+   };
+   ```
+
+2. Deploy with `--temporary` from the project directory.
+
+   ```bash
+   npx wrangler@latest deploy --temporary
+   ```
+
+   The proof-of-work check adds a short automatic delay. On success, Wrangler prints an `Account: <name> (created)` or `(reused)` line, a `Claim URL`, and the live `https://<worker>.<account>.workers.dev` URL.
+
+3. Parse the URLs from deploy output with Hermes' Rust parser.
+
+   ```bash
+   npx wrangler@latest deploy --temporary 2>&1 | hermes cloudflare parse-temporary-deploy-output
+   ```
+
+   The parser prints JSON with `live_url`, `claim_url`, `account`, `account_state`, `expires_minutes`, and `deployed`. It exits non-zero if no live `workers.dev` URL is present, so scripts can branch on failure.
+
+4. Verify the deploy is actually live. Do not trust the deploy log alone.
+
+   ```bash
+   curl -sS <live_url>
+   ```
+
+   Confirm the body matches what the Worker code returns.
+
+5. Iterate. Edit the Worker, then redeploy with the same command. Within the 60-minute window Wrangler reuses the cached temporary account, so the URL stays stable. `curl` again to confirm the change.
+
+6. Hand the claim URL to the user. Tell them to open it within 60 minutes to keep the deployment and resources. If they do not claim it, everything auto-deletes. Treat the claim URL as a secret because it grants ownership of the temporary account.
+
+## Quick Reference
+
+| Step | Command |
+|---|---|
+| Check version | `npx wrangler@latest --version` |
+| Deploy without account | `npx wrangler@latest deploy --temporary` |
+| Deploy and parse URLs | `npx wrangler@latest deploy --temporary 2>&1 \| hermes cloudflare parse-temporary-deploy-output` |
+| Parser self-test | `hermes cloudflare --selftest` |
+| Verify live URL | `curl -sS <live_url>` |
+| Clear cached temporary account | `npx wrangler@latest logout` |
+
+## Temporary Account Product Limits
+
+| Product | Limit on a temporary account |
+|---|---|
+| Workers | Deploys to `workers.dev` |
+| Static Assets | Up to 1,000 files, 5 MiB each |
+| KV | Allowed |
+| D1 | 1 database, 100 MB per DB / 100 MB total |
+| Durable Objects | Allowed |
+| Hyperdrive | 2 configs, 10 connections |
+| Queues | Up to 10 |
+| SSL/TLS certs | Allowed |
+
+## Pitfalls
+
+- `--temporary` may be hidden from `wrangler deploy --help` and is not a global flag. Do not conclude the flag is missing only because help omits it. Check the version instead.
+- A stale globally-installed `wrangler` older than 4.102.0 lacks the flag. Prefer `npx wrangler@latest` or a pinned version at or above 4.102.0.
+- If `wrangler login` was run, or if `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_API_KEY` is set, `--temporary` errors. Either unset the variable for this shell or log out, but never strip a user's real credentials without telling them.
+- Creating temporary accounts too fast can rate-limit. Reuse the cached account within the 60-minute window instead of forcing a new one.
+- The 60-minute expiry is hard. If the deploy must outlive an hour, the user must claim it.
+- `curl` can briefly serve the old body after a redeploy. A `(reused)` account line plus a new version ID can confirm deployment while edge caches catch up; re-curl or add a cache-busting query string.
+- Do not log the claim URL into shared transcripts as a harmless link. It is credential-equivalent.
+
+## Verification
+
+- `npx wrangler@latest --version` returns 4.102.0 or newer.
+- `npx wrangler@latest deploy --temporary` prints a `workers.dev` live URL and a `claim-preview?claimToken=` claim URL.
+- `npx wrangler@latest deploy --temporary 2>&1 | hermes cloudflare parse-temporary-deploy-output` prints structured JSON and exits zero.
+- `curl -sS <live_url>` returns the exact body the Worker code produces.
+- A second deploy reports `Account: <name> (reused)` and the live URL is unchanged.
+- The parser self-test passes with `hermes cloudflare --selftest`.

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -190,6 +190,7 @@ hermes skills uninstall <skill-name>
 
 | Skill | Description |
 |-------|-------------|
+| [**cloudflare-temporary-deploy**](/docs/user-guide/skills/optional/web-development/web-development-cloudflare-temporary-deploy) | Deploy a Worker live, no account, via wrangler --temporary. |
 | [**page-agent**](/docs/user-guide/skills/optional/web-development/web-development-page-agent) | Embed alibaba/page-agent into your own web application — a pure-JavaScript in-page GUI agent that ships as a single &lt;script> tag or npm package and lets end-users of your site drive the UI with natural language ("click login, fill userna... |
 
 ---

--- a/website/docs/user-guide/skills/optional/web-development/web-development-cloudflare-temporary-deploy.md
+++ b/website/docs/user-guide/skills/optional/web-development/web-development-cloudflare-temporary-deploy.md
@@ -1,0 +1,155 @@
+---
+title: "Cloudflare Temporary Deploy — Deploy a Worker live, no account, via wrangler --temporary"
+sidebar_label: "Cloudflare Temporary Deploy"
+description: "Deploy a Worker live, no account, via wrangler --temporary"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Cloudflare Temporary Deploy
+
+Deploy a Worker live, no account, via wrangler --temporary.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/web-development/cloudflare-temporary-deploy` |
+| Path | `optional-skills/web-development/cloudflare-temporary-deploy` |
+| Version | `1.0.0` |
+| Author | Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `cloudflare`, `workers`, `wrangler`, `deploy`, `temporary`, `agent`, `serverless`, `web-development` |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Cloudflare Temporary Deploy Skill
+
+Deploy a Cloudflare Worker to a live `workers.dev` URL with zero account setup, using `wrangler deploy --temporary`. Cloudflare provisions a throwaway account, deploys, and prints a claim URL valid for 60 minutes; unclaimed accounts auto-delete. This gives an agent a tight write -> deploy -> verify loop without OAuth, signup, or token copy-paste.
+
+This skill does not cover production deploys. Use `wrangler login` plus a permanent account for those. It also does not cover non-Worker Cloudflare products beyond the temporary-account limits below.
+
+## When to Use
+
+Load this skill when the user wants to:
+
+- Ship agent-written code to a live URL without first creating a Cloudflare account.
+- Iterate in a background/autonomous session where browser OAuth would be a hard stop.
+- Prototype or evaluate Workers quickly with a throwaway, claimable target.
+- Build a self-verifying deploy loop: deploy, `curl` the live URL, confirm output matches the code, redeploy.
+
+## When NOT to Use
+
+- Production or CI/CD: use a permanent account with `wrangler login` or `CLOUDFLARE_API_TOKEN`. `--temporary` errors out if credentials are present.
+- Wrangler is already authenticated: `--temporary` returns an error by design. Run `wrangler logout` first only if the user explicitly wants a throwaway deploy.
+- Long-lived hosting: temporary deployments are deleted after 60 minutes unless claimed.
+
+## Prerequisites
+
+- Wrangler 4.102.0 or later. This is the version that introduced `--temporary`. Verify with `npx wrangler@latest --version`.
+- Node 18+ with `npx`, `npm`, `yarn`, or `pnpm`. No global install is required.
+- No Cloudflare credentials present. `--temporary` only works when Wrangler is unauthenticated: no OAuth login, no `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_API_KEY` env var, and no cached `~/.wrangler` or `~/.config/.wrangler` OAuth session in the shell you use.
+- Network egress to `cloudflare.com` and `workers.dev`.
+- Using `--temporary` accepts Cloudflare's Terms of Service and Privacy Policy.
+
+## How to Run
+
+Use the terminal tool for every step. Always pin Wrangler with `wrangler@latest` or a version `>=4.102.0` so you do not accidentally run an old global binary that lacks `--temporary`.
+
+1. Scaffold a minimal Worker if the project does not already exist.
+
+   `wrangler.jsonc`:
+
+   ```jsonc
+   {
+     "name": "hello-agent",
+     "main": "src/index.ts",
+     "compatibility_date": "2025-01-01"
+   }
+   ```
+
+   `src/index.ts`:
+
+   ```typescript
+   export default {
+     async fetch(): Promise<Response> {
+       return new Response("hello cloudflare");
+     },
+   };
+   ```
+
+2. Deploy with `--temporary` from the project directory.
+
+   ```bash
+   npx wrangler@latest deploy --temporary
+   ```
+
+   The proof-of-work check adds a short automatic delay. On success, Wrangler prints an `Account: <name> (created)` or `(reused)` line, a `Claim URL`, and the live `https://<worker>.<account>.workers.dev` URL.
+
+3. Parse the URLs from deploy output with Hermes' Rust parser.
+
+   ```bash
+   npx wrangler@latest deploy --temporary 2>&1 | hermes cloudflare parse-temporary-deploy-output
+   ```
+
+   The parser prints JSON with `live_url`, `claim_url`, `account`, `account_state`, `expires_minutes`, and `deployed`. It exits non-zero if no live `workers.dev` URL is present, so scripts can branch on failure.
+
+4. Verify the deploy is actually live. Do not trust the deploy log alone.
+
+   ```bash
+   curl -sS <live_url>
+   ```
+
+   Confirm the body matches what the Worker code returns.
+
+5. Iterate. Edit the Worker, then redeploy with the same command. Within the 60-minute window Wrangler reuses the cached temporary account, so the URL stays stable. `curl` again to confirm the change.
+
+6. Hand the claim URL to the user. Tell them to open it within 60 minutes to keep the deployment and resources. If they do not claim it, everything auto-deletes. Treat the claim URL as a secret because it grants ownership of the temporary account.
+
+## Quick Reference
+
+| Step | Command |
+|---|---|
+| Check version | `npx wrangler@latest --version` |
+| Deploy without account | `npx wrangler@latest deploy --temporary` |
+| Deploy and parse URLs | `npx wrangler@latest deploy --temporary 2>&1 \| hermes cloudflare parse-temporary-deploy-output` |
+| Parser self-test | `hermes cloudflare --selftest` |
+| Verify live URL | `curl -sS <live_url>` |
+| Clear cached temporary account | `npx wrangler@latest logout` |
+
+## Temporary Account Product Limits
+
+| Product | Limit on a temporary account |
+|---|---|
+| Workers | Deploys to `workers.dev` |
+| Static Assets | Up to 1,000 files, 5 MiB each |
+| KV | Allowed |
+| D1 | 1 database, 100 MB per DB / 100 MB total |
+| Durable Objects | Allowed |
+| Hyperdrive | 2 configs, 10 connections |
+| Queues | Up to 10 |
+| SSL/TLS certs | Allowed |
+
+## Pitfalls
+
+- `--temporary` may be hidden from `wrangler deploy --help` and is not a global flag. Do not conclude the flag is missing only because help omits it. Check the version instead.
+- A stale globally-installed `wrangler` older than 4.102.0 lacks the flag. Prefer `npx wrangler@latest` or a pinned version at or above 4.102.0.
+- If `wrangler login` was run, or if `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_API_KEY` is set, `--temporary` errors. Either unset the variable for this shell or log out, but never strip a user's real credentials without telling them.
+- Creating temporary accounts too fast can rate-limit. Reuse the cached account within the 60-minute window instead of forcing a new one.
+- The 60-minute expiry is hard. If the deploy must outlive an hour, the user must claim it.
+- `curl` can briefly serve the old body after a redeploy. A `(reused)` account line plus a new version ID can confirm deployment while edge caches catch up; re-curl or add a cache-busting query string.
+- Do not log the claim URL into shared transcripts as a harmless link. It is credential-equivalent.
+
+## Verification
+
+- `npx wrangler@latest --version` returns 4.102.0 or newer.
+- `npx wrangler@latest deploy --temporary` prints a `workers.dev` live URL and a `claim-preview?claimToken=` claim URL.
+- `npx wrangler@latest deploy --temporary 2>&1 | hermes cloudflare parse-temporary-deploy-output` prints structured JSON and exits zero.
+- `curl -sS <live_url>` returns the exact body the Worker code produces.
+- A second deploy reports `Account: <name> (reused)` and the live URL is unchanged.
+- The parser self-test passes with `hermes cloudflare --selftest`.


### PR DESCRIPTION
## Summary
- Add a Rust-native `hermes cloudflare parse-temporary-deploy-output` helper for parsing `wrangler deploy --temporary` output into structured JSON.
- Add the optional `cloudflare-temporary-deploy` web-development skill and generated docs page/catalog entry.
- Classify two non-applicable upstream rows as superseded: Python-era Snap browser fallback installer repair and absent Docker `stage2-hook.sh` symlink chown hardening.
- Refresh parity queue/proof/dashboard/workstream artifacts against current `upstream/main` (`9b2af36d5aea3118ac6cfb15a2802f92fe0b5eda`).

## Parity note
Current upstream advanced while this branch was open. The branch closes 3 rows from the prior queue (`ff08e60c63ad`, `97888fed483c`, `233ef98afe2f`), but the refreshed current queue now reports 31 pending because new upstream commits arrived.

## Verification
- `python3` Cloudflare skill metadata/content check: passed
- `pytest tests/website/test_generate_skill_docs.py -q`: 7 passed
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-cli cloudflare -- --nocapture`: 5 passed, 566 filtered out
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo run -p hermes-cli --bin hermes-agent-ultra -- cloudflare --selftest`: selftest OK
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-skills -- --nocapture`: 98 passed + doc-tests passed
- `cargo fmt --all --check`: passed
- `scripts/check-rust-runtime-no-python.sh`: passed
- `scripts/check-runtime-placeholders.sh`: passed
- `git diff --check`: passed
- `git diff --cached --check`: passed
- `test ! -d target`: passed

## Notes
- No Python parser helper was added; the upstream Python parser behavior is ported into Rust CLI code.
- Cargo build/test artifacts were kept outside the repo via `/Volumes/wd_black/cargo-targets`.
