### PR TITLE
fix(cli): repair invalidated OpenAI one-shot auth

### DIFF
--- a/crates/hermes-cli/src/main/entrypoint.rs
+++ b/crates/hermes-cli/src/main/entrypoint.rs
@@ -15,6 +15,11 @@ async fn main() {
     let global_model_override = cli.model.clone();
     let global_provider_override = cli.provider.clone();
     let global_allow_tools_override = cli.allow_tools;
+    let oneshot_auth_model_hint = global_model_override.clone().or_else(|| {
+        load_config(cli.config_dir.as_deref())
+            .ok()
+            .and_then(|config| config.model)
+    });
 
     // Initialize tracing
     init_tracing(
@@ -84,7 +89,7 @@ async fn main() {
             if let Some(provider) = oneshot_auto_verify_oauth_provider(
                 err,
                 global_provider_override.as_deref(),
-                global_model_override.as_deref(),
+                oneshot_auth_model_hint.as_deref(),
             ) {
                 eprintln!(
                     "Detected OAuth auth failure for provider '{}' in one-shot mode; running `hermes-ultra auth verify {}` and retrying once...",
@@ -122,42 +127,51 @@ async fn main() {
                     global_allow_tools_override,
                 )
                 .await;
-                if provider == "nous" {
-                    if let Err(retry_err) = &result {
-                        if oneshot_auto_verify_oauth_provider(
-                            retry_err,
-                            Some(provider.as_str()),
-                            global_model_override.as_deref(),
-                        )
-                        .as_deref()
-                            == Some("nous")
-                        {
+                if let Err(retry_err) = &result {
+                    if let Some(login_provider) = oneshot_auto_verify_oauth_provider(
+                        retry_err,
+                        Some(provider.as_str()),
+                        oneshot_auth_model_hint.as_deref(),
+                    ) {
+                        if !oneshot_oauth_provider_supports_login(&login_provider) {
                             eprintln!(
-                                "Nous OAuth still invalid; launching `hermes-ultra auth login nous` and retrying once..."
+                                "OAuth still invalid for provider '{}'. Run `hermes-ultra auth login {}` in a real terminal, then retry.",
+                                login_provider, login_provider
                             );
-                            if let Err(login_err) = run_auth(
+                        } else if !oneshot_login_prompt_available() {
+                            eprintln!(
+                                "OAuth still invalid for provider '{}', but this process is not attached to an interactive terminal. Run `hermes-ultra auth login {}` in a real terminal, then retry.",
+                                login_provider, login_provider
+                            );
+                        } else {
+                            let force_fresh = oneshot_auth_requires_fresh_login(retry_err);
+                            let freshness = if force_fresh { "fresh " } else { "" };
+                            eprintln!(
+                                "OAuth still invalid for provider '{}'; launching `hermes-ultra auth login {}` for a {}login and retrying once...",
+                                login_provider, login_provider, freshness
+                            );
+                            if let Err(login_err) = run_oneshot_oauth_login_repair(
                                 cli.clone(),
-                                Some("login".to_string()),
-                                Some("nous".to_string()),
-                                None,
-                                None,
-                                None,
-                                None,
-                                false,
+                                &login_provider,
+                                force_fresh,
                             )
                             .await
                             {
                                 eprintln!(
-                                    "Warning: automatic `auth login nous` failed: {}",
-                                    login_err
+                                    "Warning: automatic `auth login {}` failed: {}",
+                                    login_provider, login_err
+                                );
+                                eprintln!(
+                                    "Action required: run `hermes-ultra auth login {}` in a real terminal, then retry this command.",
+                                    login_provider
                                 );
                             } else {
                                 if let Err(hydrate_err) =
                                     hydrate_provider_env_from_vault_for_cli(&cli).await
                                 {
                                     eprintln!(
-                                        "Warning: automatic credential hydration after `auth login nous` failed: {}",
-                                        hydrate_err
+                                        "Warning: automatic credential hydration after `auth login {}` failed: {}",
+                                        login_provider, hydrate_err
                                     );
                                 }
                                 result = hermes_cli::commands::handle_cli_chat(
@@ -668,4 +682,3 @@ fn init_tracing(verbose: bool, interactive_tui: bool) {
     }
     init_telemetry_from_env("hermes-cli", default);
 }
-

--- a/crates/hermes-cli/src/main/startup_helpers.rs
+++ b/crates/hermes-cli/src/main/startup_helpers.rs
@@ -14,10 +14,40 @@ fn oneshot_auth_is_refreshable(message: &str) -> bool {
         || message.contains("403")
         || message.contains("unauthorized")
         || message.contains("invalid token")
+        || message.contains("token_invalidated")
         || message.contains("token expired")
         || message.contains("authentication failed")
+        || message.contains("authentication token has been invalidated")
         || message.contains("invalid_grant")
         || message.contains("expired")
+}
+
+fn oneshot_auth_requires_fresh_login(err: &AgentError) -> bool {
+    let Some(message) = auth_error_message(err) else {
+        return false;
+    };
+    message.contains("token_invalidated")
+        || message.contains("authentication token has been invalidated")
+        || message.contains("invalid_grant")
+        || message.contains("refresh token")
+        || message.contains("stored nous auth state is invalid")
+        || message.contains("missing refresh token")
+}
+
+fn oneshot_oauth_provider_supports_login(provider: &str) -> bool {
+    matches!(
+        normalize_auth_provider(provider).as_str(),
+        "nous"
+            | "openai"
+            | "openai-codex"
+            | "anthropic"
+            | "qwen-oauth"
+            | "google-gemini-cli"
+    )
+}
+
+fn oneshot_login_prompt_available() -> bool {
+    std::io::stdin().is_terminal() && std::io::stdout().is_terminal()
 }
 
 fn infer_oauth_provider_from_error_message(message: &str) -> Option<String> {
@@ -56,6 +86,88 @@ fn infer_oauth_provider_from_error_message(message: &str) -> Option<String> {
         return Some("openai".to_string());
     }
     None
+}
+
+async fn run_fresh_openai_oneshot_login(cli: &Cli, provider: &str) -> Result<(), AgentError> {
+    let provider = normalize_auth_provider(provider);
+    let token_store = FileTokenStore::new(secret_vault_path_for_cli(cli)).await?;
+    token_store.remove(&provider).await?;
+    let _ = clear_provider_auth_state(&provider)?;
+    let manager = AuthManager::new(token_store);
+    match provider.as_str() {
+        "openai" => {
+            let state = login_openai_device_code(CodexDeviceCodeOptions::default()).await?;
+            let auth_path = save_openai_auth_state(&state)?;
+            let expires_at = state
+                .tokens
+                .expires_in
+                .filter(|secs| *secs > 0)
+                .map(|secs| chrono::Utc::now() + chrono::Duration::seconds(secs));
+            manager
+                .save_credential(OAuthCredential {
+                    provider,
+                    access_token: state.tokens.access_token,
+                    refresh_token: state.tokens.refresh_token,
+                    token_type: "bearer".to_string(),
+                    scope: None,
+                    expires_at,
+                })
+                .await?;
+            println!("OpenAI OAuth fresh login complete; credential saved as provider 'openai'.");
+            println!("Saved OAuth state: {}", auth_path.display());
+            Ok(())
+        }
+        "openai-codex" => {
+            let state = login_openai_codex_device_code(CodexDeviceCodeOptions::default()).await?;
+            let auth_path = save_codex_auth_state(&state)?;
+            let expires_at = state
+                .tokens
+                .expires_in
+                .filter(|secs| *secs > 0)
+                .map(|secs| chrono::Utc::now() + chrono::Duration::seconds(secs));
+            manager
+                .save_credential(OAuthCredential {
+                    provider,
+                    access_token: state.tokens.access_token,
+                    refresh_token: state.tokens.refresh_token,
+                    token_type: "bearer".to_string(),
+                    scope: None,
+                    expires_at,
+                })
+                .await?;
+            println!(
+                "OpenAI Codex OAuth fresh login complete; credential saved as provider 'openai-codex'."
+            );
+            println!("Saved OAuth state: {}", auth_path.display());
+            Ok(())
+        }
+        _ => Err(AgentError::Config(format!(
+            "fresh OpenAI one-shot login does not support provider '{}'",
+            provider
+        ))),
+    }
+}
+
+async fn run_oneshot_oauth_login_repair(
+    cli: Cli,
+    provider: &str,
+    force_fresh: bool,
+) -> Result<(), AgentError> {
+    let provider = normalize_auth_provider(provider);
+    if force_fresh && matches!(provider.as_str(), "openai" | "openai-codex") {
+        return run_fresh_openai_oneshot_login(&cli, &provider).await;
+    }
+    run_auth(
+        cli,
+        Some("login".to_string()),
+        Some(provider),
+        None,
+        None,
+        None,
+        None,
+        false,
+    )
+    .await
 }
 
 fn query_is_local_slash_command(query: &str) -> bool {
@@ -144,4 +256,3 @@ fn oneshot_auto_verify_oauth_provider(
     }
     None
 }
-

--- a/crates/hermes-cli/src/main/tests.rs
+++ b/crates/hermes-cli/src/main/tests.rs
@@ -589,6 +589,18 @@ mod tests {
             oneshot_auto_verify_oauth_provider(&openai, Some("openai"), Some("openai:gpt-5.5")),
             Some("openai".to_string())
         );
+        let openai_invalidated = AgentError::LlmApi(
+            r#"API error 401 Unauthorized: {"error":{"message":"Your authentication token has been invalidated. Please try signing in again.","code":"token_invalidated"}}"#
+                .to_string(),
+        );
+        assert_eq!(
+            oneshot_auto_verify_oauth_provider(
+                &openai_invalidated,
+                Some("openai"),
+                Some("openai:gpt-5.5")
+            ),
+            Some("openai".to_string())
+        );
         let codex = AgentError::LlmApi("API error 401 Unauthorized: chatgpt.com codex".to_string());
         assert_eq!(
             oneshot_auto_verify_oauth_provider(&codex, None, Some("openai-codex:codex-mini")),
@@ -657,8 +669,39 @@ mod tests {
         assert!(oneshot_auth_is_refreshable(
             "api error 401 unauthorized token expired"
         ));
+        assert!(oneshot_auth_is_refreshable("token_invalidated"));
         assert!(oneshot_auth_is_refreshable("invalid_grant"));
         assert!(!oneshot_auth_is_refreshable("api error 404 not found"));
+    }
+
+    #[test]
+    fn oneshot_auth_requires_fresh_login_for_invalidated_tokens() {
+        let invalidated = AgentError::LlmApi(
+            "API error 401 Unauthorized: token_invalidated authentication token has been invalidated"
+                .to_string(),
+        );
+        assert!(oneshot_auth_requires_fresh_login(&invalidated));
+
+        let refreshable = AgentError::LlmApi("API error 401 Unauthorized".to_string());
+        assert!(!oneshot_auth_requires_fresh_login(&refreshable));
+    }
+
+    #[test]
+    fn oneshot_oauth_login_repair_supports_promptable_providers() {
+        for provider in [
+            "nous",
+            "openai",
+            "openai-codex",
+            "anthropic",
+            "qwen-oauth",
+            "google-gemini-cli",
+        ] {
+            assert!(
+                oneshot_oauth_provider_supports_login(provider),
+                "{provider} should support one-shot login repair"
+            );
+        }
+        assert!(!oneshot_oauth_provider_supports_login("openrouter"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- detect OpenAI/OpenAI-Codex token_invalidated one-shot failures as fresh-login auth failures
- use configured default model as the one-shot auth provider hint when no --model override is passed
- after verify+retry still fails, launch interactive login only when attached to a real TTY; otherwise print the exact terminal repair command

## Verification
- cargo fmt --all --check
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-cli oneshot -- --nocapture
- CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo check -p hermes-cli --all-targets
- git diff --check
- repo-local target absent
- non-interactive one-shot smoke now prints auth verify + terminal login repair hint for invalidated OpenAI token

## Notes
- scripts/clippy-warning-gate.sh --check -- -p hermes-cli was started but stopped after excessive runtime before a warning summary; not counted as passed.