### PR TITLE
fix(openai): resolve dynamic model for ChatGPT Codex

### DIFF
--- a/crates/hermes-agent/src/agent_loop.rs
+++ b/crates/hermes-agent/src/agent_loop.rs
@@ -48,8 +48,8 @@ use crate::lsp_context::{build_lsp_context_note, LspContextConfig};
 use crate::memory_manager::{MemoryManager, StreamingContextScrubber};
 use crate::plugins::{HookResult, HookType, PluginManager, ToolExecutionMiddlewareContext};
 use crate::provider::{
-    is_codex_chatgpt_token, AnthropicProvider, GenericProvider, OpenAiProvider, OpenRouterProvider,
-    OPENAI_CODEX_BASE_URL,
+    is_codex_chatgpt_token, is_openai_dynamic_model_alias, AnthropicProvider, GenericProvider,
+    OpenAiProvider, OpenRouterProvider, OPENAI_CODEX_BASE_URL, OPENAI_CODEX_DYNAMIC_WIRE_MODEL,
 };
 use crate::providers_extra::{
     CopilotProvider, KimiProvider, MiniMaxProvider, NousProvider, QwenProvider,

--- a/crates/hermes-agent/src/agent_loop/methods_prompt_llm.rs
+++ b/crates/hermes-agent/src/agent_loop/methods_prompt_llm.rs
@@ -543,11 +543,14 @@ impl AgentLoop {
             self.interrupt.check_interrupt()?;
             let result = if let Some(rt) = route {
                 let (provider_name, _) = self.extract_provider_and_model(model);
+                let runtime_provider_name = rt.provider.as_deref().unwrap_or(provider_name.as_str());
+                let wire_model_name =
+                    Self::runtime_wire_model_for_provider(runtime_provider_name, &effective_model_name);
                 let mode = rt.api_mode.as_ref().unwrap_or(&self.config.api_mode);
                 let extra_body_for_call = self.extra_body_for_api_mode(mode);
                 let pool = self.credential_pool_for_route(rt);
                 let routed_provider = self.build_runtime_provider(
-                    rt.provider.as_deref().unwrap_or(provider_name.as_str()),
+                    runtime_provider_name,
                     &effective_model_name,
                     rt.base_url.as_deref(),
                     rt.api_key_env.as_deref(),
@@ -563,7 +566,7 @@ impl AgentLoop {
                                 tool_schemas,
                                 effective_max_tokens,
                                 self.config.temperature,
-                                Some(&effective_model_name),
+                                Some(&wire_model_name),
                                 extra_body_for_call.as_ref(),
                             )
                             .await
@@ -574,26 +577,34 @@ impl AgentLoop {
                             rt.routing_reason,
                             e
                         );
+                        let fallback_wire_model_name = Self::runtime_wire_model_for_provider(
+                            active_provider.as_str(),
+                            &effective_model_name,
+                        );
                         self.llm_provider
                             .chat_completion(
                                 &api_messages,
                                 tool_schemas,
                                 effective_max_tokens,
                                 self.config.temperature,
-                                Some(&effective_model_name),
+                                Some(&fallback_wire_model_name),
                                 default_extra_body.as_ref(),
                             )
                             .await
                     }
                 }
             } else {
+                let wire_model_name = Self::runtime_wire_model_for_provider(
+                    active_provider.as_str(),
+                    &effective_model_name,
+                );
                 self.llm_provider
                     .chat_completion(
                         &api_messages,
                         tool_schemas,
                         effective_max_tokens,
                         self.config.temperature,
-                        Some(&effective_model_name),
+                        Some(&wire_model_name),
                         default_extra_body.as_ref(),
                     )
                     .await
@@ -729,8 +740,14 @@ impl AgentLoop {
                                         rt.api_mode.as_ref().unwrap_or(&self.config.api_mode);
                                     let extra_body_for_call = self.extra_body_for_api_mode(mode);
                                     let pool = self.credential_pool_for_route(rt);
+                                    let runtime_provider_name =
+                                        rt.provider.as_deref().unwrap_or(provider_name.as_str());
+                                    let wire_model_name = Self::runtime_wire_model_for_provider(
+                                        runtime_provider_name,
+                                        model_name,
+                                    );
                                     match self.build_runtime_provider(
-                                        rt.provider.as_deref().unwrap_or(provider_name.as_str()),
+                                        runtime_provider_name,
                                         model_name,
                                         rt.base_url.as_deref(),
                                         rt.api_key_env.as_deref(),
@@ -745,37 +762,45 @@ impl AgentLoop {
                                                     &[],
                                                     effective_max_tokens,
                                                     self.config.temperature,
-                                                    Some(model_name),
+                                                    Some(&wire_model_name),
                                                     extra_body_for_call.as_ref(),
                                                 )
                                                 .await
                                         }
                                         Err(_) => {
+                                            let (fallback_provider_name, fallback_model_name) = self
+                                                .extract_provider_and_model(
+                                                    self.config.model.as_str(),
+                                                );
+                                            let fallback_wire_model_name =
+                                                Self::runtime_wire_model_for_provider(
+                                                    fallback_provider_name.as_str(),
+                                                    fallback_model_name,
+                                                );
                                             self.llm_provider
                                                 .chat_completion(
                                                     &api_messages,
                                                     &[],
                                                     effective_max_tokens,
                                                     self.config.temperature,
-                                                    Some(
-                                                        self.extract_provider_and_model(
-                                                            self.config.model.as_str(),
-                                                        )
-                                                        .1,
-                                                    ),
+                                                    Some(&fallback_wire_model_name),
                                                     default_extra_body.as_ref(),
                                                 )
                                                 .await
                                         }
                                     }
                                 } else {
+                                    let wire_model_name = Self::runtime_wire_model_for_provider(
+                                        provider_name.as_str(),
+                                        model_name,
+                                    );
                                     self.llm_provider
                                         .chat_completion(
                                             &api_messages,
                                             &[],
                                             effective_max_tokens,
                                             self.config.temperature,
-                                            Some(model_name),
+                                            Some(&wire_model_name),
                                             default_extra_body.as_ref(),
                                         )
                                         .await
@@ -845,6 +870,13 @@ impl AgentLoop {
                                             model,
                                             fallback
                                         );
+                                        let (fallback_provider_name, fallback_model_name) =
+                                            self.extract_provider_and_model(&fallback);
+                                        let fallback_wire_model_name =
+                                            Self::runtime_wire_model_for_provider(
+                                                fallback_provider_name.as_str(),
+                                                fallback_model_name,
+                                            );
                                         let fallback_result = self
                                             .llm_provider
                                             .chat_completion(
@@ -852,7 +884,7 @@ impl AgentLoop {
                                                 tool_schemas,
                                                 effective_max_tokens,
                                                 self.config.temperature,
-                                                Some(self.extract_provider_and_model(&fallback).1),
+                                                Some(&fallback_wire_model_name),
                                                 default_extra_body.as_ref(),
                                             )
                                             .await;
@@ -946,7 +978,7 @@ impl AgentLoop {
         on_chunk: &(dyn Fn(StreamChunk) + Send + Sync),
     ) -> Result<StreamCollectOutcome, AgentError> {
         let api_messages = self.messages_for_api_call(ctx);
-        let (_, active_model_name) = self.extract_provider_and_model(active_model);
+        let (active_provider_name, active_model_name) = self.extract_provider_and_model(active_model);
         let default_extra_body = self.extra_body_for_api_mode(&self.config.api_mode);
         let effective_max_tokens = max_tokens_override.or(self.config.max_tokens);
         let max_stream_retries = std::env::var("HERMES_STREAM_RETRIES")
@@ -958,11 +990,14 @@ impl AgentLoop {
         'stream_attempt: for stream_attempt in 0..=max_stream_retries {
             let mut stream = if let Some(rt) = route {
                 let (provider_name, model_name) = self.extract_provider_and_model(active_model);
+                let runtime_provider_name = rt.provider.as_deref().unwrap_or(provider_name.as_str());
+                let wire_model_name =
+                    Self::runtime_wire_model_for_provider(runtime_provider_name, model_name);
                 let mode = rt.api_mode.as_ref().unwrap_or(&self.config.api_mode);
                 let extra_body_for_call = self.extra_body_for_api_mode(mode);
                 let pool = self.credential_pool_for_route(rt);
                 match self.build_runtime_provider(
-                    rt.provider.as_deref().unwrap_or(provider_name.as_str()),
+                    runtime_provider_name,
                     model_name,
                     rt.base_url.as_deref(),
                     rt.api_key_env.as_deref(),
@@ -975,7 +1010,7 @@ impl AgentLoop {
                         tool_schemas,
                         effective_max_tokens,
                         self.config.temperature,
-                        Some(model_name),
+                        Some(&wire_model_name),
                         extra_body_for_call.as_ref(),
                     ),
                     Err(e) => {
@@ -984,26 +1019,33 @@ impl AgentLoop {
                             rt.routing_reason,
                             e
                         );
+                        let (fallback_provider_name, fallback_model_name) =
+                            self.extract_provider_and_model(self.config.model.as_str());
+                        let fallback_wire_model_name = Self::runtime_wire_model_for_provider(
+                            fallback_provider_name.as_str(),
+                            fallback_model_name,
+                        );
                         self.llm_provider.chat_completion_stream(
                             &api_messages,
                             tool_schemas,
                             effective_max_tokens,
                             self.config.temperature,
-                            Some(
-                                self.extract_provider_and_model(self.config.model.as_str())
-                                    .1,
-                            ),
+                            Some(&fallback_wire_model_name),
                             default_extra_body.as_ref(),
                         )
                     }
                 }
             } else {
+                let wire_model_name = Self::runtime_wire_model_for_provider(
+                    active_provider_name.as_str(),
+                    active_model_name,
+                );
                 self.llm_provider.chat_completion_stream(
                     &api_messages,
                     tool_schemas,
                     effective_max_tokens,
                     self.config.temperature,
-                    Some(active_model_name),
+                    Some(&wire_model_name),
                     default_extra_body.as_ref(),
                 )
             };

--- a/crates/hermes-agent/src/agent_loop/methods_runtime_provider.rs
+++ b/crates/hermes-agent/src/agent_loop/methods_runtime_provider.rs
@@ -18,6 +18,18 @@ impl AgentLoop {
         (fallback_provider, model)
     }
 
+    pub(crate) fn runtime_wire_model_for_provider(provider: &str, model: &str) -> String {
+        let provider = provider.trim().to_ascii_lowercase();
+        let canonical = hermes_core::providers::canonical_provider_id(provider.as_str());
+        let is_openai_codex_provider = matches!(provider.as_str(), "openai" | "codex" | "openai-codex")
+            || matches!(canonical.as_str(), "openai" | "codex" | "openai-codex");
+        if is_openai_codex_provider && is_openai_dynamic_model_alias(model) {
+            OPENAI_CODEX_DYNAMIC_WIRE_MODEL.to_string()
+        } else {
+            model.trim().to_string()
+        }
+    }
+
     fn runtime_provider_config(&self, provider: &str) -> Option<&RuntimeProviderConfig> {
         let provider = provider.trim();
         if provider.is_empty() {
@@ -884,7 +896,9 @@ impl AgentLoop {
         };
         let normalized_model_name =
             crate::model_normalize::normalize_model_for_provider(model_name, provider);
-        let model_name = normalized_model_name.as_str();
+        let wire_model_name =
+            Self::runtime_wire_model_for_provider(provider, normalized_model_name.as_str());
+        let model_name = wire_model_name.as_str();
 
         let provider_obj: Arc<dyn LlmProvider> = match provider {
             "openai" | "codex" | "openai-codex" => {

--- a/crates/hermes-agent/src/agent_loop/tests_runtime.rs
+++ b/crates/hermes-agent/src/agent_loop/tests_runtime.rs
@@ -126,6 +126,30 @@
     }
 
     #[test]
+    fn test_runtime_wire_model_remaps_openai_dynamic_only() {
+        assert_eq!(
+            AgentLoop::runtime_wire_model_for_provider("openai", "dynamic"),
+            OPENAI_CODEX_DYNAMIC_WIRE_MODEL
+        );
+        assert_eq!(
+            AgentLoop::runtime_wire_model_for_provider("codex", "openai:dynamic"),
+            OPENAI_CODEX_DYNAMIC_WIRE_MODEL
+        );
+        assert_eq!(
+            AgentLoop::runtime_wire_model_for_provider("openai-codex", "codex:dynamic"),
+            OPENAI_CODEX_DYNAMIC_WIRE_MODEL
+        );
+        assert_eq!(
+            AgentLoop::runtime_wire_model_for_provider("openrouter", "dynamic"),
+            "dynamic"
+        );
+        assert_eq!(
+            AgentLoop::runtime_wire_model_for_provider("openai", "gpt-5.5"),
+            "gpt-5.5"
+        );
+    }
+
+    #[test]
     fn test_smart_model_routing_codex_provider_alias_builds_runtime() {
         use futures::stream::BoxStream;
 

--- a/crates/hermes-agent/src/api_bridge.rs
+++ b/crates/hermes-agent/src/api_bridge.rs
@@ -20,7 +20,10 @@ use hermes_core::{
 };
 
 use crate::credential_pool::CredentialPool;
-use crate::provider::{codex_cloudflare_headers, OPENAI_CODEX_BASE_URL};
+use crate::provider::{
+    codex_cloudflare_headers, is_openai_dynamic_model_alias, OPENAI_CODEX_BASE_URL,
+    OPENAI_CODEX_DYNAMIC_WIRE_MODEL,
+};
 use crate::rate_limit::RateLimitTracker;
 
 const CODEX_RESPONSES_BETA_HEADER: &str = "responses=2026-02-06";
@@ -53,6 +56,7 @@ pub struct CodexProvider {
     pub api_key: String,
     pub model: String,
     pub headers: Vec<(String, String)>,
+    chatgpt_codex_backend: bool,
     client: Client,
     request_timeout: Option<Duration>,
     pub rate_limiter: Option<Arc<RateLimitTracker>>,
@@ -67,6 +71,7 @@ impl CodexProvider {
             api_key: api_key.into(),
             model: "codex-mini-latest".to_string(),
             headers: Vec::new(),
+            chatgpt_codex_backend: false,
             client: build_codex_http_client(request_timeout),
             request_timeout,
             rate_limiter: None,
@@ -123,10 +128,21 @@ impl CodexProvider {
     }
 
     fn uses_chatgpt_codex_backend(&self) -> bool {
-        self.base_url
-            .trim()
-            .to_ascii_lowercase()
-            .contains("chatgpt.com/backend-api/codex")
+        self.chatgpt_codex_backend
+            || self
+                .base_url
+                .trim()
+                .to_ascii_lowercase()
+                .contains("chatgpt.com/backend-api/codex")
+    }
+
+    fn effective_wire_model(&self, requested_model: &str) -> String {
+        let requested_model = requested_model.trim();
+        if self.uses_chatgpt_codex_backend() && is_openai_dynamic_model_alias(requested_model) {
+            OPENAI_CODEX_DYNAMIC_WIRE_MODEL.to_string()
+        } else {
+            requested_model.to_string()
+        }
     }
 
     fn request_headers(&self, api_key: &str) -> Vec<(String, String)> {
@@ -173,10 +189,12 @@ impl CodexProvider {
 
     pub fn openai_pro(api_key: impl Into<String>, model: impl Into<String>) -> Self {
         let api_key = api_key.into();
-        Self::new(api_key.as_str())
+        let mut provider = Self::new(api_key.as_str())
             .with_model(model)
             .with_base_url(OPENAI_CODEX_BASE_URL)
-            .with_headers(codex_cloudflare_headers(Some(api_key.as_str())))
+            .with_headers(codex_cloudflare_headers(Some(api_key.as_str())));
+        provider.chatgpt_codex_backend = true;
+        provider
     }
 
     async fn check_rate_limit(&self) {
@@ -331,6 +349,9 @@ impl CodexProvider {
         if self.uses_chatgpt_codex_backend() {
             body["stream"] = serde_json::json!(true);
             body["store"] = serde_json::json!(false);
+        }
+        if let Some(model) = body.get("model").and_then(Value::as_str) {
+            body["model"] = serde_json::json!(self.effective_wire_model(model));
         }
         body
     }
@@ -537,7 +558,7 @@ impl LlmProvider for CodexProvider {
         extra_body: Option<&Value>,
     ) -> Result<LlmResponse, AgentError> {
         self.check_rate_limit().await;
-        let effective_model = model.unwrap_or(&self.model);
+        let effective_model = self.effective_wire_model(model.unwrap_or(&self.model));
         let api_key = self.effective_api_key();
 
         let body = self.build_body(
@@ -545,7 +566,7 @@ impl LlmProvider for CodexProvider {
             tools,
             max_tokens,
             temperature,
-            effective_model,
+            effective_model.as_str(),
             extra_body,
             false,
         );
@@ -572,7 +593,9 @@ impl LlmProvider for CodexProvider {
         }
 
         if self.uses_chatgpt_codex_backend() {
-            return self.collect_streaming_response(resp, effective_model).await;
+            return self
+                .collect_streaming_response(resp, effective_model.as_str())
+                .await;
         }
 
         let resp_json: Value = resp
@@ -600,7 +623,7 @@ impl LlmProvider for CodexProvider {
 
         async_stream::stream! {
             provider.check_rate_limit().await;
-            let effective_model = model.as_deref().unwrap_or(&provider.model);
+            let effective_model = provider.effective_wire_model(model.as_deref().unwrap_or(&provider.model));
             let api_key = provider.effective_api_key();
 
             let body = provider.build_body(
@@ -608,7 +631,7 @@ impl LlmProvider for CodexProvider {
                 &tools,
                 max_tokens,
                 temperature,
-                effective_model,
+                effective_model.as_str(),
                 extra_body.as_ref(),
                 true,
             );
@@ -830,6 +853,71 @@ mod tests {
         assert!(body.get("strict_tool_calls").is_none());
         assert!(body.get("provider_strict").is_none());
         assert_eq!(body["input"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn openai_pro_dynamic_alias_uses_supported_chatgpt_wire_model() {
+        let provider = CodexProvider::openai_pro("token", "dynamic");
+        assert_eq!(
+            provider.effective_wire_model("dynamic"),
+            OPENAI_CODEX_DYNAMIC_WIRE_MODEL
+        );
+        assert_eq!(
+            provider.effective_wire_model("openai:dynamic"),
+            OPENAI_CODEX_DYNAMIC_WIRE_MODEL
+        );
+        assert_eq!(
+            provider.effective_wire_model("openai-codex:dynamic"),
+            OPENAI_CODEX_DYNAMIC_WIRE_MODEL
+        );
+        assert_eq!(provider.effective_wire_model("gpt-5.5"), "gpt-5.5");
+        assert_eq!(
+            provider.effective_wire_model("dynamic-runtime-model"),
+            "dynamic-runtime-model"
+        );
+
+        let body = provider.build_body(
+            &[Message::user("Say ok")],
+            &[],
+            None,
+            None,
+            provider.effective_wire_model("dynamic").as_str(),
+            None,
+            false,
+        );
+
+        assert_eq!(body["model"], OPENAI_CODEX_DYNAMIC_WIRE_MODEL);
+        assert_eq!(body["stream"], true);
+        assert_eq!(body["store"], false);
+    }
+
+    #[test]
+    fn openai_pro_extra_body_cannot_restore_dynamic_wire_model() {
+        let provider = CodexProvider::openai_pro("token", "dynamic");
+        let extra_body = serde_json::json!({
+            "model": "dynamic",
+            "service_tier": "priority"
+        });
+
+        let body = provider.build_body(
+            &[Message::user("Say ok")],
+            &[],
+            None,
+            None,
+            OPENAI_CODEX_DYNAMIC_WIRE_MODEL,
+            Some(&extra_body),
+            false,
+        );
+
+        assert_eq!(body["model"], OPENAI_CODEX_DYNAMIC_WIRE_MODEL);
+        assert_eq!(body["service_tier"], "priority");
+    }
+
+    #[test]
+    fn codex_api_dynamic_alias_stays_literal_outside_chatgpt_backend() {
+        let provider = CodexProvider::new("sk-test").with_model("dynamic");
+
+        assert_eq!(provider.effective_wire_model("dynamic"), "dynamic");
     }
 
     #[test]

--- a/crates/hermes-agent/src/provider.rs
+++ b/crates/hermes-agent/src/provider.rs
@@ -46,6 +46,7 @@ struct ChatRequestParams<'a> {
 
 const ACP_MULTIMODAL_PREFIX: &str = "__hermes_acp_parts_json__:";
 pub const OPENAI_CODEX_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
+pub const OPENAI_CODEX_DYNAMIC_WIRE_MODEL: &str = "gpt-5.4";
 const CODEX_CLOUDFLARE_ORIGINATOR: &str = "codex_cli_rs";
 
 fn request_timeout_duration(seconds: Option<f64>) -> Option<Duration> {
@@ -150,6 +151,42 @@ pub fn codex_chatgpt_account_id(token: &str) -> Option<String> {
 
 pub fn is_codex_chatgpt_token(token: &str) -> bool {
     codex_chatgpt_account_id(token).is_some()
+}
+
+pub fn is_openai_dynamic_model_alias(model: &str) -> bool {
+    matches!(
+        model.trim().to_ascii_lowercase().as_str(),
+        "dynamic" | "openai:dynamic" | "codex:dynamic" | "openai-codex:dynamic"
+    )
+}
+
+pub fn resolve_openai_chatgpt_dynamic_wire_model(requested_model: &str, api_key: &str) -> String {
+    let requested_model = requested_model.trim();
+    if is_openai_dynamic_model_alias(requested_model) && is_codex_chatgpt_token(api_key) {
+        OPENAI_CODEX_DYNAMIC_WIRE_MODEL.to_string()
+    } else {
+        requested_model.to_string()
+    }
+}
+
+fn is_native_openai_base_url(base_url: &str) -> bool {
+    let base_url = base_url.trim().to_ascii_lowercase();
+    base_url.contains("api.openai.com") || base_url.contains("chatgpt.com/backend-api/codex")
+}
+
+fn resolve_openai_compatible_dynamic_wire_model(
+    requested_model: &str,
+    api_key: &str,
+    base_url: &str,
+) -> String {
+    let requested_model = requested_model.trim();
+    if is_openai_dynamic_model_alias(requested_model)
+        && (is_codex_chatgpt_token(api_key) || is_native_openai_base_url(base_url))
+    {
+        OPENAI_CODEX_DYNAMIC_WIRE_MODEL.to_string()
+    } else {
+        requested_model.to_string()
+    }
 }
 
 fn parse_acp_multimodal_parts(content: &str) -> Option<Vec<Value>> {
@@ -765,6 +802,14 @@ impl GenericProvider {
             );
         }
         self.apply_opencode_go_reasoning_controls(&mut body, effective_model);
+        if body
+            .get("model")
+            .and_then(Value::as_str)
+            .is_some_and(is_openai_dynamic_model_alias)
+            && !is_openai_dynamic_model_alias(effective_model)
+        {
+            body["model"] = serde_json::json!(effective_model);
+        }
         body
     }
 
@@ -1061,14 +1106,18 @@ impl LlmProvider for GenericProvider {
     ) -> Result<LlmResponse, AgentError> {
         self.check_rate_limit().await;
 
-        let effective_model = model.unwrap_or(&self.model);
         let api_key = self.effective_api_key();
+        let effective_model = resolve_openai_compatible_dynamic_wire_model(
+            model.unwrap_or(&self.model),
+            &api_key,
+            &self.base_url,
+        );
         let body = self.chat_request_body(ChatRequestParams {
             messages,
             tools,
             max_tokens,
             temperature,
-            effective_model,
+            effective_model: effective_model.as_str(),
             extra_body,
             stream: false,
         });
@@ -1119,14 +1168,18 @@ impl LlmProvider for GenericProvider {
         async_stream::stream! {
             provider.check_rate_limit().await;
 
-            let effective_model = model.as_deref().unwrap_or(&provider.model);
             let api_key = provider.effective_api_key();
+            let effective_model = resolve_openai_compatible_dynamic_wire_model(
+                model.as_deref().unwrap_or(&provider.model),
+                &api_key,
+                &provider.base_url,
+            );
             let mut body = provider.chat_request_body(ChatRequestParams {
                 messages: &messages,
                 tools: &tools,
                 max_tokens,
                 temperature,
-                effective_model,
+                effective_model: effective_model.as_str(),
                 extra_body: extra_body.as_ref(),
                 stream: true,
             });
@@ -2892,6 +2945,74 @@ mod tests {
             .unwrap()
             .starts_with("codex_cli_rs/"));
         assert_eq!(headers.get("ChatGPT-Account-ID").unwrap(), "acct-request");
+    }
+
+    #[test]
+    fn chatgpt_oauth_dynamic_alias_resolves_to_supported_wire_model() {
+        let token = codex_jwt_with_account(Some("acct-dynamic"));
+
+        assert_eq!(
+            resolve_openai_chatgpt_dynamic_wire_model("dynamic", token.as_str()),
+            OPENAI_CODEX_DYNAMIC_WIRE_MODEL
+        );
+        assert_eq!(
+            resolve_openai_chatgpt_dynamic_wire_model("openai:dynamic", token.as_str()),
+            OPENAI_CODEX_DYNAMIC_WIRE_MODEL
+        );
+        assert_eq!(
+            resolve_openai_chatgpt_dynamic_wire_model("gpt-5.5", token.as_str()),
+            "gpt-5.5"
+        );
+        assert_eq!(
+            resolve_openai_chatgpt_dynamic_wire_model("dynamic", "sk-standard-api-key"),
+            "dynamic"
+        );
+        assert_eq!(
+            resolve_openai_chatgpt_dynamic_wire_model("dynamic", "not-a-jwt"),
+            "dynamic"
+        );
+        assert_eq!(
+            resolve_openai_compatible_dynamic_wire_model(
+                "dynamic",
+                "not-a-jwt",
+                "https://api.openai.com/v1"
+            ),
+            OPENAI_CODEX_DYNAMIC_WIRE_MODEL
+        );
+        assert_eq!(
+            resolve_openai_compatible_dynamic_wire_model(
+                "dynamic",
+                "not-a-jwt",
+                "https://example.test/v1"
+            ),
+            "dynamic"
+        );
+    }
+
+    #[test]
+    fn openai_compatible_extra_body_cannot_restore_dynamic_wire_model() {
+        let provider = GenericProvider::new(
+            "https://api.openai.com/v1",
+            "sk-test",
+            OPENAI_CODEX_DYNAMIC_WIRE_MODEL,
+        );
+        let extra_body = serde_json::json!({
+            "model": "dynamic",
+            "service_tier": "priority"
+        });
+
+        let body = provider.chat_request_body(ChatRequestParams {
+            messages: &[Message::user("Say ok")],
+            tools: &[],
+            max_tokens: None,
+            temperature: None,
+            effective_model: OPENAI_CODEX_DYNAMIC_WIRE_MODEL,
+            extra_body: Some(&extra_body),
+            stream: false,
+        });
+
+        assert_eq!(body["model"], OPENAI_CODEX_DYNAMIC_WIRE_MODEL);
+        assert_eq!(body["service_tier"], "priority");
     }
 
     #[test]

--- a/crates/hermes-app-runtime/src/lib.rs
+++ b/crates/hermes-app-runtime/src/lib.rs
@@ -12,6 +12,7 @@ use hermes_agent::agent_loop::{
     CheapModelRouteConfig, RetryConfig, RuntimeProviderConfig, SmartModelRoutingConfig,
     ToolRegistry as AgentToolRegistry,
 };
+use hermes_agent::provider::is_openai_dynamic_model_alias;
 use hermes_agent::smart_model_routing::ApiMode;
 use hermes_agent::{AgentCallbacks, AgentConfig, AgentLoop};
 use hermes_config::{normalize_service_tier, GatewayConfig, LlmProviderConfig};
@@ -626,6 +627,19 @@ pub fn query_mode_remediation_target_from_catalog(
     let (provider, model_id) = split_provider_model(provider_model);
     let provider = provider.trim().to_ascii_lowercase();
     if provider.is_empty() || model_id.trim().is_empty() || catalog.is_empty() {
+        return None;
+    }
+    if model_id.trim().eq_ignore_ascii_case("dynamic")
+        || provider_model.trim().eq_ignore_ascii_case("dynamic")
+    {
+        return None;
+    }
+    let runtime_provider = normalize_runtime_provider_name(provider.as_str());
+    if matches!(
+        runtime_provider.as_str(),
+        "openai" | "openai-codex" | "codex"
+    ) && is_openai_dynamic_model_alias(model_id)
+    {
         return None;
     }
     let close_matches = rank_catalog_model_candidates(model_id.trim(), catalog, 5);
@@ -1438,6 +1452,16 @@ mod tests {
         assert_eq!(
             remediation.close_matches.first().map(String::as_str),
             Some("qwen/qwen3.6-max-preview")
+        );
+    }
+
+    #[test]
+    fn query_mode_remediation_preserves_openai_dynamic_alias() {
+        let catalog = vec!["gpt-4o-mini".to_string(), "gpt-5.4-mini".to_string()];
+
+        assert!(query_mode_remediation_target_from_catalog("openai:dynamic", &catalog).is_none());
+        assert!(
+            query_mode_remediation_target_from_catalog("openai-codex:dynamic", &catalog).is_none()
         );
     }
 

--- a/crates/hermes-cli/src/commands/command_cli_chat_skills.rs
+++ b/crates/hermes-cli/src/commands/command_cli_chat_skills.rs
@@ -19,9 +19,25 @@ fn resolve_cli_chat_provider_model(
 }
 
 async fn query_mode_remediation_target(provider_model: &str) -> Option<QueryModelRemediation> {
+    if hermes_agent::provider::is_openai_dynamic_model_alias(provider_model) {
+        return None;
+    }
     let (provider, model_id) = split_provider_model(provider_model);
     let provider = provider.trim().to_ascii_lowercase();
     if provider.is_empty() || model_id.trim().is_empty() {
+        return None;
+    }
+    if model_id.trim().eq_ignore_ascii_case("dynamic")
+        || provider_model.trim().eq_ignore_ascii_case("dynamic")
+    {
+        return None;
+    }
+    let runtime_provider = crate::app::normalize_runtime_provider_name(provider.as_str());
+    if matches!(
+        runtime_provider.as_str(),
+        "openai" | "openai-codex" | "codex"
+    ) && hermes_agent::provider::is_openai_dynamic_model_alias(model_id)
+    {
         return None;
     }
     let catalog = provider_model_ids(&provider).await;
@@ -138,18 +154,25 @@ pub async fn handle_cli_chat(
     match query {
         Some(q) => {
             let mut active_model = current_model.clone();
-            if let Some(remediation) = query_mode_remediation_target(&active_model).await {
-                println!(
-                    "[Model remediation: {} -> {}. Close matches: {}]",
-                    active_model,
-                    remediation.next_model,
-                    if remediation.close_matches.is_empty() {
-                        "(none)".to_string()
-                    } else {
-                        remediation.close_matches.join(", ")
-                    }
-                );
-                active_model = remediation.next_model;
+            let active_dynamic_selector = active_model.trim().eq_ignore_ascii_case("dynamic")
+                || active_model
+                    .trim()
+                    .to_ascii_lowercase()
+                    .ends_with(":dynamic");
+            if !active_dynamic_selector {
+                if let Some(remediation) = query_mode_remediation_target(&active_model).await {
+                    println!(
+                        "[Model remediation: {} -> {}. Close matches: {}]",
+                        active_model,
+                        remediation.next_model,
+                        if remediation.close_matches.is_empty() {
+                            "(none)".to_string()
+                        } else {
+                            remediation.close_matches.join(", ")
+                        }
+                    );
+                    active_model = remediation.next_model;
+                }
             }
             let outcome = match run_noninteractive_query(
                 &config,

--- a/crates/hermes-provider-runtime/src/lib.rs
+++ b/crates/hermes-provider-runtime/src/lib.rs
@@ -950,7 +950,7 @@ impl LlmProvider for NoBackendProvider {
 mod tests {
     use super::*;
     use hermes_agent::provider_profiles;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{body_partial_json, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn env_test_lock() -> std::sync::MutexGuard<'static, ()> {
@@ -986,21 +986,39 @@ mod tests {
         }
     }
 
+    fn codex_sse_response_body(text: &str, model: &str) -> String {
+        let delta = serde_json::json!({ "delta": text });
+        let completed = serde_json::json!({
+            "response": {
+                "output": [
+                    {
+                        "type": "message",
+                        "content": [
+                            { "type": "output_text", "text": text }
+                        ]
+                    }
+                ],
+                "model": model,
+                "status": "completed",
+                "usage": {
+                    "input_tokens": 1,
+                    "output_tokens": 1
+                }
+            }
+        });
+        format!("event: response.output_text.delta\ndata: {delta}\n\nevent: response.completed\ndata: {completed}\n\n")
+    }
+
     #[tokio::test]
     async fn build_provider_routes_chatgpt_openai_oauth_to_responses_backend() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/responses"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "output": [
-                    {
-                        "type": "message",
-                        "content": [{"type": "output_text", "text": "openai-pro-ok"}]
-                    }
-                ],
-                "model": "gpt-5.5",
-                "status": "completed"
-            })))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(codex_sse_response_body("openai-pro-ok", "gpt-5.5")),
+            )
             .expect(1)
             .mount(&server)
             .await;
@@ -1033,20 +1051,60 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn build_provider_remaps_openai_dynamic_for_chatgpt_oauth_backend() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/responses"))
+            .and(body_partial_json(serde_json::json!({
+                "model": "gpt-5.4"
+            })))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(codex_sse_response_body("dynamic-ok", "gpt-5.4")),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut config = GatewayConfig::default();
+        config.llm_providers.insert(
+            "openai".to_string(),
+            LlmProviderConfig {
+                api_key: Some("eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiJ1c2VyLXh5eiIsImV4cCI6OTk5OTk5OTk5OSwiaHR0cHM6Ly9hcGkub3BlbmFpLmNvbS9hdXRoIjp7ImNoYXRncHRfYWNjb3VudF9pZCI6ImFjY3QtZHluYW1pYy1wYXJpdHkiLCJjaGF0Z3B0X3BsYW5fdHlwZSI6InBsdXMifX0.sig".to_string()),
+                base_url: Some(server.uri()),
+                ..LlmProviderConfig::default()
+            },
+        );
+
+        let provider = build_provider(&config, "openai:dynamic");
+        let response = provider
+            .chat_completion(
+                &[hermes_core::Message::user("hello")],
+                &[],
+                None,
+                None,
+                Some("dynamic"),
+                None,
+            )
+            .await
+            .expect("OpenAI dynamic alias should resolve before the ChatGPT Codex request");
+
+        assert_eq!(response.message.content.as_deref(), Some("dynamic-ok"));
+        assert_eq!(response.model, "gpt-5.4");
+        server.verify().await;
+    }
+
+    #[tokio::test]
     async fn provider_auth_resolver_supplies_openai_oauth_token() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/responses"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "output": [
-                    {
-                        "type": "message",
-                        "content": [{"type": "output_text", "text": "resolver-oauth-ok"}]
-                    }
-                ],
-                "model": "gpt-5.5",
-                "status": "completed"
-            })))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(codex_sse_response_body("resolver-oauth-ok", "gpt-5.5")),
+            )
             .expect(1)
             .mount(&server)
             .await;


### PR DESCRIPTION
## Summary
- resolve OpenAI/Codex `dynamic` aliases to a ChatGPT Codex-supported wire model before requests leave the Rust runtime
- add final request-body guards so `extra_body.model = "dynamic"` cannot reintroduce the unsupported literal model
- preserve `openai:dynamic` as a runtime selector in query mode instead of catalog-remediating it to unsupported `gpt-4o-mini`
- align mocked ChatGPT Codex provider tests with the real SSE `/responses` path

## Verification
- `~/.local/bin/hermes-ultra auth verify openai`
- live one-shot: `cargo run -p hermes-cli --bin hermes-agent-ultra -- --ignore-rules --provider openai --model openai:dynamic -z "Reply exactly: HERMES_DYNAMIC_ONESHOT_OK"` returned `HERMES_DYNAMIC_ONESHOT_OK`
- live interactive TUI: `cargo run -p hermes-cli --bin hermes-agent-ultra -- --ignore-rules --provider openai --model openai:dynamic`, status showed `openai:dynamic | lane:on (live)`, and prompt returned `HERMES_DYNAMIC_SMOKE_OK`
- `cargo fmt --all --check`
- `cargo test -p hermes-app-runtime query_mode_remediation -- --nocapture`
- `cargo test -p hermes-agent openai_pro_extra_body_cannot_restore_dynamic_wire_model -- --nocapture`
- `cargo test -p hermes-agent openai_compatible_extra_body_cannot_restore_dynamic_wire_model -- --nocapture`
- `cargo test -p hermes-agent runtime_wire_model -- --nocapture`
- `cargo test -p hermes-agent dynamic_alias -- --nocapture`
- `cargo test -p hermes-provider-runtime oauth -- --nocapture`
- `cargo check -p hermes-cli --bins`
- `cargo check -p hermes-agent --all-targets`
- `cargo check -p hermes-app-runtime --all-targets`
- `cargo check -p hermes-provider-runtime --all-targets`
- `git diff --check`
- `test ! -d target`

All Cargo verification used `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0`.
