### PR TITLE
test(architecture): enforce Rust module size policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
         run: cargo fmt --all --check
       - name: Clippy Warning Gate
         run: bash scripts/clippy-warning-gate.sh --check
+      - name: Rust module size policy
+        run: cargo test -p hermes-source-parity-tests --test rust_module_size_policy -- --nocapture
       - name: Placeholder gate
         run: bash scripts/check-runtime-placeholders.sh
       - name: Tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,16 @@
 6. 可对照的行为应通过 `crates/hermes-parity-tests/fixtures/<module>/*.json` 提供 golden；新增用例时同步更新 `scripts/record_fixtures.py`（若适用）。
 7. 单个 PR 尽量只移植一个模块；commit message 建议：`parity(<module>): port from python …`
 
+## Rust 模块规模策略
+
+- 以职责边界优先拆分模块；行数只是架构烟雾报警器，不是唯一目标。
+- `<800` 行通常最理想；`800-1,500` 行若职责单一可接受。
+- `1,501-2,500` 行需要在报告中可见；`2,501-4,000` 行进入 review pressure。
+- `4,001-5,000` 行视为 exceptional，应作为后续拆分候选。
+- `>5,000` 行是硬失败，除非是 generated / vendored / 明确 allowlist 的临时例外。
+- 策略文档与 gate：`docs/architecture/rust-module-size-policy.md`，
+  `cargo test -p hermes-source-parity-tests --test rust_module_size_policy -- --nocapture`。
+
 ## 禁止事项
 
 - 不要随意改动 workspace 成员结构（新增 crate 需有明确动机并更新根 `Cargo.toml`）。

--- a/crates/hermes-source-parity-tests/tests/cli_command_contract.rs
+++ b/crates/hermes-source-parity-tests/tests/cli_command_contract.rs
@@ -21,6 +21,43 @@ fn load_fixture() -> CliCommandContractFixture {
     serde_json::from_str(&raw).expect("parse command_actions fixture")
 }
 
+fn read_source(root: &Path, path: &str) -> String {
+    std::fs::read_to_string(root.join(path)).unwrap_or_else(|err| panic!("read {path}: {err}"))
+}
+
+fn read_included_source_tree(root: &Path, entry_path: &str, include_dir: &str) -> String {
+    let include_root = root.join(include_dir);
+    let entry_source = read_source(root, entry_path);
+    let include_re =
+        Regex::new(r#"include!\("([^"]+\.rs)"\);"#).expect("include regex should compile");
+    let mut combined = entry_source.clone();
+    for cap in include_re.captures_iter(&entry_source) {
+        let include_name = &cap[1];
+        let include_path = include_root.join(include_name);
+        let source = std::fs::read_to_string(&include_path)
+            .unwrap_or_else(|err| panic!("read include {include_name} from {entry_path}: {err}"));
+        combined.push_str("\n\n");
+        combined.push_str(&source);
+    }
+    combined
+}
+
+fn read_main_module_sources(root: &Path) -> String {
+    read_included_source_tree(
+        root,
+        "crates/hermes-cli/src/main.rs",
+        "crates/hermes-cli/src",
+    )
+}
+
+fn read_commands_module_sources(root: &Path) -> String {
+    read_included_source_tree(
+        root,
+        "crates/hermes-cli/src/commands/mod.rs",
+        "crates/hermes-cli/src/commands",
+    )
+}
+
 fn function_body<'a>(source: &'a str, fn_name: &str) -> Option<&'a str> {
     let fn_re = Regex::new(&format!(
         r"(?m)^(?:pub\s+)?(?:async\s+)?fn\s+{}\b",
@@ -139,16 +176,8 @@ fn cli_action_contract_matches_fixture() {
     let root = repo_root();
 
     let sources: BTreeMap<&str, String> = [
-        (
-            "main",
-            std::fs::read_to_string(root.join("crates/hermes-cli/src/main.rs"))
-                .expect("read main.rs"),
-        ),
-        (
-            "commands",
-            std::fs::read_to_string(root.join("crates/hermes-cli/src/commands.rs"))
-                .expect("read commands.rs"),
-        ),
+        ("main", read_main_module_sources(&root)),
+        ("commands", read_commands_module_sources(&root)),
     ]
     .into_iter()
     .collect();

--- a/crates/hermes-source-parity-tests/tests/global_parity_governance.rs
+++ b/crates/hermes-source-parity-tests/tests/global_parity_governance.rs
@@ -2,6 +2,9 @@ use std::path::PathBuf;
 
 use serde_json::Value;
 
+mod support;
+use support::rust_test_exists;
+
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
 }
@@ -12,23 +15,6 @@ fn read_json(path: &str) -> Value {
         .unwrap_or_else(|e| panic!("failed reading {}: {}", full.display(), e));
     serde_json::from_str(&raw)
         .unwrap_or_else(|e| panic!("failed parsing {}: {}", full.display(), e))
-}
-
-fn rust_test_exists(file: &str, name: &str) -> bool {
-    let full = repo_root().join(file);
-    let source = std::fs::read_to_string(&full)
-        .unwrap_or_else(|e| panic!("failed reading referenced Rust file {}: {}", file, e));
-    let needle = format!("fn {name}");
-    let Some(index) = source.find(&needle) else {
-        return false;
-    };
-    let line_start = source[..index].rfind('\n').map(|idx| idx + 1).unwrap_or(0);
-    source[..line_start]
-        .lines()
-        .rev()
-        .map(str::trim)
-        .take_while(|line| !line.is_empty() && line.starts_with("#["))
-        .any(|line| line == "#[test]" || line.starts_with("#[tokio::test"))
 }
 
 #[test]

--- a/crates/hermes-source-parity-tests/tests/hermes_cli_test_coverage_contract.rs
+++ b/crates/hermes-source-parity-tests/tests/hermes_cli_test_coverage_contract.rs
@@ -3,6 +3,9 @@ use std::path::PathBuf;
 
 use serde_json::Value;
 
+mod support;
+use support::rust_test_exists;
+
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
 }
@@ -13,19 +16,6 @@ fn read_json(path: &str) -> Value {
         .unwrap_or_else(|e| panic!("failed reading {}: {}", full.display(), e));
     serde_json::from_str(&raw)
         .unwrap_or_else(|e| panic!("failed parsing {}: {}", full.display(), e))
-}
-
-fn rust_test_exists(file: &str, name: &str) -> bool {
-    let full = repo_root().join(file);
-    let source = std::fs::read_to_string(&full)
-        .unwrap_or_else(|e| panic!("failed reading referenced Rust file {}: {}", file, e));
-    let needle = format!("fn {name}");
-    let Some(index) = source.find(&needle) else {
-        return false;
-    };
-    let start = index.saturating_sub(400);
-    let prefix = &source[start..index];
-    prefix.contains("#[test]") || prefix.contains("#[tokio::test]")
 }
 
 #[test]

--- a/crates/hermes-source-parity-tests/tests/python_test_suite_coverage_contract.rs
+++ b/crates/hermes-source-parity-tests/tests/python_test_suite_coverage_contract.rs
@@ -3,6 +3,9 @@ use std::path::PathBuf;
 
 use serde_json::Value;
 
+mod support;
+use support::rust_test_exists;
+
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
 }
@@ -16,17 +19,6 @@ fn read_text(path: &str) -> String {
 fn read_json(path: &str) -> Value {
     let raw = read_text(path);
     serde_json::from_str(&raw).unwrap_or_else(|e| panic!("failed parsing {path}: {e}"))
-}
-
-fn rust_test_exists(file: &str, name: &str) -> bool {
-    let source = read_text(file);
-    let needle = format!("fn {name}");
-    let Some(index) = source.find(&needle) else {
-        return false;
-    };
-    let start = index.saturating_sub(500);
-    let prefix = &source[start..index];
-    prefix.contains("#[test]") || prefix.contains("#[tokio::test")
 }
 
 #[test]

--- a/crates/hermes-source-parity-tests/tests/rust_module_size_policy.rs
+++ b/crates/hermes-source-parity-tests/tests/rust_module_size_policy.rs
@@ -1,0 +1,250 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const IDEAL_LIMIT: usize = 800;
+const HEALTHY_LIMIT: usize = 1_500;
+const REVIEW_PRESSURE_LIMIT: usize = 2_500;
+const EXCEPTIONAL_LIMIT: usize = 4_000;
+const HARD_LIMIT: usize = 5_000;
+
+const ALLOWLIST_PATH: &str = "docs/architecture/rust-module-size-allowlist.txt";
+
+#[derive(Debug, Clone)]
+struct RustFile {
+    path: String,
+    lines: usize,
+}
+
+#[derive(Debug, Clone)]
+struct AllowlistEntry {
+    max_lines: usize,
+    reason: String,
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn should_skip_dir(path: &Path) -> bool {
+    matches!(
+        path.file_name().and_then(|name| name.to_str()),
+        Some(
+            ".git"
+                | ".github"
+                | ".pytest_cache"
+                | ".sync-reports"
+                | "node_modules"
+                | "target"
+                | "third_party"
+        )
+    )
+}
+
+fn repo_relative_path(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn count_lines(path: &Path) -> usize {
+    let bytes =
+        fs::read(path).unwrap_or_else(|err| panic!("failed reading {}: {err}", path.display()));
+    if bytes.is_empty() {
+        return 0;
+    }
+    let newline_count = bytes.iter().filter(|byte| **byte == b'\n').count();
+    if bytes.ends_with(b"\n") {
+        newline_count
+    } else {
+        newline_count + 1
+    }
+}
+
+fn collect_rust_files(root: &Path, dir: &Path, files: &mut Vec<RustFile>) {
+    if should_skip_dir(dir) {
+        return;
+    }
+
+    let entries =
+        fs::read_dir(dir).unwrap_or_else(|err| panic!("failed reading {}: {err}", dir.display()));
+    for entry in entries {
+        let entry = entry
+            .unwrap_or_else(|err| panic!("failed reading dir entry in {}: {err}", dir.display()));
+        let path = entry.path();
+        let file_type = entry
+            .file_type()
+            .unwrap_or_else(|err| panic!("failed reading file type for {}: {err}", path.display()));
+
+        if file_type.is_dir() {
+            collect_rust_files(root, &path, files);
+        } else if path.extension().and_then(|ext| ext.to_str()) == Some("rs") {
+            files.push(RustFile {
+                path: repo_relative_path(root, &path),
+                lines: count_lines(&path),
+            });
+        }
+    }
+}
+
+fn parse_allowlist(root: &Path) -> BTreeMap<String, AllowlistEntry> {
+    let path = root.join(ALLOWLIST_PATH);
+    let raw = fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("failed reading {}: {err}", path.display()));
+    let mut entries = BTreeMap::new();
+
+    for (line_idx, raw_line) in raw.lines().enumerate() {
+        let line_number = line_idx + 1;
+        let line = raw_line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        let parts = line.split('|').map(str::trim).collect::<Vec<_>>();
+        assert_eq!(
+            parts.len(),
+            3,
+            "{ALLOWLIST_PATH}:{line_number} must use `path|max_lines|reason`"
+        );
+
+        let repo_path = parts[0];
+        assert!(
+            repo_path.ends_with(".rs"),
+            "{ALLOWLIST_PATH}:{line_number} allowlist path must be a Rust file"
+        );
+        assert!(
+            !repo_path.starts_with('/')
+                && !repo_path.contains("..")
+                && !repo_path.starts_with("third_party/"),
+            "{ALLOWLIST_PATH}:{line_number} allowlist path must be first-party and repo-relative"
+        );
+
+        let max_lines = parts[1].parse::<usize>().unwrap_or_else(|err| {
+            panic!("{ALLOWLIST_PATH}:{line_number} invalid max_lines: {err}")
+        });
+        assert!(
+            max_lines > HARD_LIMIT,
+            "{ALLOWLIST_PATH}:{line_number} max_lines must be greater than the {HARD_LIMIT}-line hard limit"
+        );
+
+        let reason = parts[2].to_string();
+        assert!(
+            reason.len() >= 24,
+            "{ALLOWLIST_PATH}:{line_number} reason must be specific enough to be useful"
+        );
+
+        assert!(
+            entries
+                .insert(repo_path.to_string(), AllowlistEntry { max_lines, reason })
+                .is_none(),
+            "{ALLOWLIST_PATH}:{line_number} duplicate allowlist entry for {repo_path}"
+        );
+    }
+
+    entries
+}
+
+fn tier_name(lines: usize) -> &'static str {
+    match lines {
+        0..=IDEAL_LIMIT => "ideal",
+        _ if lines <= HEALTHY_LIMIT => "healthy",
+        _ if lines <= REVIEW_PRESSURE_LIMIT => "reported-pressure",
+        _ if lines <= EXCEPTIONAL_LIMIT => "review-pressure",
+        _ if lines <= HARD_LIMIT => "exceptional",
+        _ => "hard-limit",
+    }
+}
+
+fn print_tier_report(files: &[RustFile]) {
+    let mut counts: BTreeMap<&'static str, usize> = BTreeMap::new();
+    for file in files {
+        *counts.entry(tier_name(file.lines)).or_default() += 1;
+    }
+
+    eprintln!("Rust module size policy report:");
+    eprintln!("  scanned: {} first-party Rust files", files.len());
+    for tier in [
+        "ideal",
+        "healthy",
+        "reported-pressure",
+        "review-pressure",
+        "exceptional",
+        "hard-limit",
+    ] {
+        eprintln!(
+            "  {tier}: {}",
+            counts.get(tier).copied().unwrap_or_default()
+        );
+    }
+
+    eprintln!("  largest first-party Rust files:");
+    for file in files.iter().take(25) {
+        eprintln!("    {:>5} {}", file.lines, file.path);
+    }
+}
+
+#[test]
+fn first_party_rust_modules_respect_size_redline() {
+    let root = repo_root();
+    let mut files = Vec::new();
+    collect_rust_files(&root, &root, &mut files);
+    files.sort_by(|left, right| {
+        right
+            .lines
+            .cmp(&left.lines)
+            .then(left.path.cmp(&right.path))
+    });
+    assert!(
+        !files.is_empty(),
+        "module-size policy scan found no Rust files"
+    );
+
+    let allowlist = parse_allowlist(&root);
+    let files_by_path = files
+        .iter()
+        .map(|file| (file.path.as_str(), file))
+        .collect::<BTreeMap<_, _>>();
+
+    let mut stale_allowlist_entries = Vec::new();
+    for (path, entry) in &allowlist {
+        let Some(file) = files_by_path.get(path.as_str()) else {
+            stale_allowlist_entries.push(format!("{path}: file not found"));
+            continue;
+        };
+        if file.lines <= HARD_LIMIT {
+            stale_allowlist_entries.push(format!(
+                "{path}: {} lines no longer needs a hard-limit exception",
+                file.lines
+            ));
+        }
+        if file.lines > entry.max_lines {
+            stale_allowlist_entries.push(format!(
+                "{path}: {} lines exceeds allowlisted max {} ({})",
+                file.lines, entry.max_lines, entry.reason
+            ));
+        }
+    }
+
+    let allowlisted_paths = allowlist.keys().cloned().collect::<BTreeSet<_>>();
+    let hard_limit_violations = files
+        .iter()
+        .filter(|file| file.lines > HARD_LIMIT && !allowlisted_paths.contains(&file.path))
+        .map(|file| format!("{} lines: {}", file.lines, file.path))
+        .collect::<Vec<_>>();
+
+    print_tier_report(&files);
+
+    assert!(
+        stale_allowlist_entries.is_empty(),
+        "stale or invalid Rust module-size allowlist entries:\n{}",
+        stale_allowlist_entries.join("\n")
+    );
+    assert!(
+        hard_limit_violations.is_empty(),
+        "first-party Rust files over {HARD_LIMIT} lines need refactoring or a justified allowlist entry in {ALLOWLIST_PATH}:\n{}",
+        hard_limit_violations.join("\n")
+    );
+}

--- a/crates/hermes-source-parity-tests/tests/sota_harness_contracts.rs
+++ b/crates/hermes-source-parity-tests/tests/sota_harness_contracts.rs
@@ -3,6 +3,9 @@ use std::path::{Path, PathBuf};
 
 use serde_json::Value;
 
+mod support;
+use support::rust_test_exists;
+
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
 }
@@ -13,19 +16,6 @@ fn read_json(path: &str) -> Value {
         .unwrap_or_else(|e| panic!("failed reading {}: {}", full.display(), e));
     serde_json::from_str(&raw)
         .unwrap_or_else(|e| panic!("failed parsing {}: {}", full.display(), e))
-}
-
-fn rust_test_exists(file: &str, name: &str) -> bool {
-    let full = repo_root().join(file);
-    let source = std::fs::read_to_string(&full)
-        .unwrap_or_else(|e| panic!("failed reading referenced Rust file {}: {}", file, e));
-    let needle = format!("fn {name}");
-    let Some(index) = source.find(&needle) else {
-        return false;
-    };
-    let start = index.saturating_sub(500);
-    let prefix = &source[start..index];
-    prefix.contains("#[test]") || prefix.contains("#[tokio::test]")
 }
 
 #[test]

--- a/crates/hermes-source-parity-tests/tests/support/mod.rs
+++ b/crates/hermes-source-parity-tests/tests/support/mod.rs
@@ -1,0 +1,120 @@
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+pub fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn canonical_rust_source_path(file: &str) -> &str {
+    match file {
+        "crates/hermes-cli/src/commands.rs" => "crates/hermes-cli/src/commands/mod.rs",
+        _ => file,
+    }
+}
+
+fn include_target(line: &str) -> Option<&str> {
+    line.trim()
+        .strip_prefix("include!(\"")
+        .and_then(|rest| rest.strip_suffix("\");"))
+}
+
+fn declares_sidecar_tests(line: &str) -> bool {
+    line.trim() == "mod tests;"
+}
+
+fn sidecar_test_candidates(path: &Path) -> Vec<PathBuf> {
+    let Some(parent) = path.parent() else {
+        return Vec::new();
+    };
+    if path.file_name().and_then(|name| name.to_str()) == Some("mod.rs") {
+        return vec![parent.join("tests.rs"), parent.join("tests/mod.rs")];
+    }
+
+    let Some(stem) = path.file_stem().and_then(|stem| stem.to_str()) else {
+        return Vec::new();
+    };
+    vec![
+        parent.join(stem).join("tests.rs"),
+        parent.join(stem).join("tests/mod.rs"),
+    ]
+}
+
+fn append_sidecar_tests(path: &Path, source: &mut String, seen: &mut BTreeSet<PathBuf>) {
+    let candidates = sidecar_test_candidates(path);
+    if let Some(candidate) = candidates.iter().find(|candidate| candidate.exists()) {
+        append_source_with_includes(candidate, source, seen);
+        return;
+    }
+    let rendered = candidates
+        .iter()
+        .map(|candidate| candidate.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    panic!(
+        "{} declares `mod tests;` but no sidecar test module exists at: {}",
+        path.display(),
+        rendered
+    );
+}
+
+fn append_source_with_includes(path: &Path, source: &mut String, seen: &mut BTreeSet<PathBuf>) {
+    let path = path.to_path_buf();
+    if !seen.insert(path.clone()) {
+        return;
+    }
+
+    let raw = std::fs::read_to_string(&path).unwrap_or_else(|err| {
+        panic!(
+            "failed reading referenced Rust file {}: {}",
+            path.display(),
+            err
+        )
+    });
+    source.push_str(&raw);
+    source.push('\n');
+
+    let parent = path
+        .parent()
+        .unwrap_or_else(|| panic!("referenced Rust file has no parent: {}", path.display()));
+    for line in raw.lines() {
+        if let Some(target) = include_target(line) {
+            append_source_with_includes(&parent.join(target), source, seen);
+        } else if declares_sidecar_tests(line) {
+            append_sidecar_tests(&path, source, seen);
+        }
+    }
+}
+
+pub fn read_rust_source_with_includes(file: &str) -> String {
+    let full = repo_root().join(canonical_rust_source_path(file));
+    let mut source = String::new();
+    let mut seen = BTreeSet::new();
+    append_source_with_includes(&full, &mut source, &mut seen);
+    source
+}
+
+fn has_test_attribute_immediately_before(source: &str, index: usize) -> bool {
+    let line_start = source[..index].rfind('\n').map(|idx| idx + 1).unwrap_or(0);
+    for line in source[..line_start].lines().rev() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if !trimmed.starts_with("#[") {
+            return false;
+        }
+        if trimmed == "#[test]" || trimmed.starts_with("#[tokio::test") {
+            return true;
+        }
+    }
+    false
+}
+
+pub fn rust_test_exists(file: &str, name: &str) -> bool {
+    let source = read_rust_source_with_includes(file);
+    let needle = format!("fn {name}");
+    let Some(index) = source.find(&needle) else {
+        return false;
+    };
+    has_test_attribute_immediately_before(&source, index)
+}

--- a/crates/hermes-source-parity-tests/tests/ui_tui_source_coverage_contract.rs
+++ b/crates/hermes-source-parity-tests/tests/ui_tui_source_coverage_contract.rs
@@ -3,6 +3,9 @@ use std::path::PathBuf;
 
 use serde_json::Value;
 
+mod support;
+use support::rust_test_exists;
+
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
 }
@@ -13,19 +16,6 @@ fn read_json(path: &str) -> Value {
         .unwrap_or_else(|e| panic!("failed reading {}: {}", full.display(), e));
     serde_json::from_str(&raw)
         .unwrap_or_else(|e| panic!("failed parsing {}: {}", full.display(), e))
-}
-
-fn rust_test_exists(file: &str, name: &str) -> bool {
-    let full = repo_root().join(file);
-    let source = std::fs::read_to_string(&full)
-        .unwrap_or_else(|e| panic!("failed reading referenced Rust file {}: {}", file, e));
-    let needle = format!("fn {name}");
-    let Some(index) = source.find(&needle) else {
-        return false;
-    };
-    let start = index.saturating_sub(400);
-    let prefix = &source[start..index];
-    prefix.contains("#[test]") || prefix.contains("#[tokio::test]")
 }
 
 #[test]

--- a/docs/architecture/rust-module-size-allowlist.txt
+++ b/docs/architecture/rust-module-size-allowlist.txt
@@ -1,0 +1,12 @@
+# First-party Rust files above the 5,000-line hard limit.
+#
+# Format:
+# path|max_lines|reason
+#
+# Rules:
+# - path is repository-relative and must point to a tracked `.rs` file.
+# - max_lines must be greater than 5000 and at least the current line count.
+# - reason must explain why the exception is generated, vendored, or temporarily
+#   justified with a concrete follow-up.
+#
+# Keep this file empty unless a hard-limit exception is genuinely needed.

--- a/docs/architecture/rust-module-size-policy.md
+++ b/docs/architecture/rust-module-size-policy.md
@@ -1,0 +1,42 @@
+# Rust Module Size Policy
+
+Hermes favors small, cohesive Rust modules with explicit ownership boundaries.
+Line count is not architecture by itself, but it is a useful smoke alarm when a
+file starts collecting unrelated reasons to change.
+
+## Thresholds
+
+| Lines | Policy |
+| --- | --- |
+| `< 800` | Ideal for most modules. |
+| `800-1,500` | Healthy when the file is cohesive. |
+| `1,501-2,500` | Reported pressure; consider extracting tests, helpers, or submodules. |
+| `2,501-4,000` | Review pressure; new work should avoid growing the file unless it reduces total complexity. |
+| `4,001-5,000` | Exceptional; active refactor candidate. |
+| `> 5,000` | Hard failure unless generated, vendored, or explicitly allowlisted with a justification and owner path. |
+
+## Enforcement
+
+The Rust governance test `rust_module_size_policy` scans first-party `.rs`
+files across the repository. It excludes vendored/generated dependency trees
+such as `third_party/` and build artifacts such as `target/`.
+
+Run it directly:
+
+```bash
+cargo test -p hermes-source-parity-tests --test rust_module_size_policy -- --nocapture
+```
+
+The test always prints a tier report. It fails only when a first-party Rust file
+crosses the 5,000-line hard limit without an entry in
+`docs/architecture/rust-module-size-allowlist.txt`.
+
+## Refactor Guidance
+
+- Split by responsibility first, not by arbitrary line chunks.
+- Prefer extracting test modules, provider-specific code, protocol codecs, and
+  pure helpers before changing runtime behavior.
+- Keep public module re-exports stable when splitting live surfaces.
+- Add targeted tests for moved behavior before claiming a split is semantics-preserving.
+- Do not hide a large live file behind an allowlist unless the exception is
+  generated, vendored, or has a concrete follow-up plan.


### PR DESCRIPTION
## Summary
- add Phase 1 Rust module size policy docs and an explicit hard-limit allowlist file
- enforce the 5,000-line first-party Rust redline via `hermes-source-parity-tests`
- report architecture pressure tiers in CI before the full workspace test run
- update source-governance helpers so existing parity/test fixtures understand split Rust source trees (`include!` shards and `mod tests;` sidecars)

## Current module-size report
- scanned: 457 first-party Rust files
- ideal: 321
- healthy: 75
- reported-pressure: 26
- review-pressure: 26
- exceptional: 9
- hard-limit: 0

## Verification
All Cargo commands used `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0`.

- `cargo fmt --all --check`
- `cargo test -p hermes-source-parity-tests --test rust_module_size_policy -- --nocapture`
- `cargo test -p hermes-source-parity-tests`
- `git diff --check`
- `test ! -d target`
