### PR TITLE
fix(cli): run elite check through native gate

### DIFF
--- a/crates/hermes-cli/src/commands/command_ops_eval/performance_autopilot.rs
+++ b/crates/hermes-cli/src/commands/command_ops_eval/performance_autopilot.rs
@@ -3,19 +3,39 @@ async fn run_autopilot_probe_command(
     cwd: &Path,
     max_tail: usize,
 ) -> serde_json::Value {
+    run_autopilot_probe_command_with_timeout(command, cwd, max_tail, autopilot_probe_timeout())
+        .await
+}
+
+fn autopilot_probe_timeout() -> Duration {
+    std::env::var("HERMES_AUTOPILOT_PROBE_TIMEOUT_SECS")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .filter(|secs| (1..=3600).contains(secs))
+        .map(Duration::from_secs)
+        .unwrap_or_else(|| Duration::from_secs(600))
+}
+
+async fn run_autopilot_probe_command_with_timeout(
+    command: &str,
+    cwd: &Path,
+    max_tail: usize,
+    timeout: Duration,
+) -> serde_json::Value {
     let started = chrono::Utc::now();
-    let output = tokio::process::Command::new("bash")
+    let mut child = tokio::process::Command::new("bash");
+    child
         .arg("-lc")
         .arg(command)
         .current_dir(cwd)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .output()
-        .await;
+        .kill_on_drop(true);
+    let output = tokio::time::timeout(timeout, child.output()).await;
     let finished = chrono::Utc::now();
     match output {
-        Ok(output) => serde_json::json!({
+        Ok(Ok(output)) => serde_json::json!({
             "command": command,
             "exit_code": output.status.code().unwrap_or(-1),
             "ok": output.status.success(),
@@ -25,7 +45,7 @@ async fn run_autopilot_probe_command(
             "stdout_tail": tail_chars(&String::from_utf8_lossy(&output.stdout), max_tail),
             "stderr_tail": tail_chars(&String::from_utf8_lossy(&output.stderr), max_tail),
         }),
-        Err(err) => serde_json::json!({
+        Ok(Err(err)) => serde_json::json!({
             "command": command,
             "exit_code": -1,
             "ok": false,
@@ -34,6 +54,16 @@ async fn run_autopilot_probe_command(
             "duration_ms": (finished - started).num_milliseconds().max(0),
             "stdout_tail": "",
             "stderr_tail": format!("spawn failed: {err}"),
+        }),
+        Err(_) => serde_json::json!({
+            "command": command,
+            "exit_code": -1,
+            "ok": false,
+            "started_at": started.to_rfc3339(),
+            "finished_at": finished.to_rfc3339(),
+            "duration_ms": (finished - started).num_milliseconds().max(0),
+            "stdout_tail": "",
+            "stderr_tail": format!("timed out after {}ms", timeout.as_millis()),
         }),
     }
 }
@@ -737,4 +767,3 @@ async fn run_performance_autopilot_native(
     write_performance_autopilot_markdown(&md_path, &report)?;
     Ok((report, json_path, md_path))
 }
-

--- a/crates/hermes-cli/src/commands/command_ops_eval/release_gates.rs
+++ b/crates/hermes-cli/src/commands/command_ops_eval/release_gates.rs
@@ -91,7 +91,7 @@ async fn run_slo_auto_rollback_native(
     Ok((report, path))
 }
 
-async fn run_elite_sync_gate_native(
+pub async fn run_elite_sync_gate_native(
     repo_root: &Path,
 ) -> Result<(serde_json::Value, PathBuf), AgentError> {
     let path = report_path_with_stamp(repo_root, "elite-sync-gate");

--- a/crates/hermes-cli/src/commands/tests/runtime_parity_ops.rs
+++ b/crates/hermes-cli/src/commands/tests/runtime_parity_ops.rs
@@ -685,6 +685,24 @@ fn native_performance_autopilot_env_writer_uses_safe_actions() {
 }
 
 #[tokio::test]
+async fn autopilot_probe_command_times_out_instead_of_hanging() {
+    let repo = tempdir().expect("repo");
+    let report = run_autopilot_probe_command_with_timeout(
+        "sleep 2",
+        repo.path(),
+        200,
+        Duration::from_millis(50),
+    )
+    .await;
+    assert_eq!(report["ok"].as_bool(), Some(false));
+    assert_eq!(report["exit_code"].as_i64(), Some(-1));
+    assert!(report["stderr_tail"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("timed out after"));
+}
+
+#[tokio::test]
 async fn native_slo_auto_rollback_runs_rollback_on_violation() {
     let repo = tempdir().expect("repo");
     let rollback_marker = repo.path().join("rollback.marker");

--- a/crates/hermes-cli/src/main/doctor_routes.rs
+++ b/crates/hermes-cli/src/main/doctor_routes.rs
@@ -35,15 +35,24 @@ fn build_elite_doctor_diagnostics(cli: &Cli) -> serde_json::Value {
         .filter(|v| !v.trim().is_empty())
         .unwrap_or_else(|| "relaxed".to_string());
 
-    let elite_gate_script = std::env::var("HERMES_ELITE_GATE_CMD")
+    let elite_gate_override = std::env::var("HERMES_ELITE_GATE_CMD")
         .ok()
-        .filter(|v| !v.trim().is_empty())
-        .unwrap_or_else(|| "python3 scripts/run-elite-sync-gate.py".to_string());
-    let gate_available = {
+        .filter(|v| !v.trim().is_empty());
+    let elite_gate_runner = if elite_gate_override.is_some() {
+        "shell_override"
+    } else {
+        "native"
+    };
+    let elite_gate_command = elite_gate_override
+        .as_deref()
+        .unwrap_or("native rust elite sync gate");
+    let gate_available = if elite_gate_override.is_some() {
         let script_path = std::env::current_dir()
             .ok()
             .map(|cwd| cwd.join("scripts").join("run-elite-sync-gate.py"));
         script_path.as_ref().map(|p| p.exists()).unwrap_or(false)
+    } else {
+        true
     };
 
     serde_json::json!({
@@ -71,7 +80,8 @@ fn build_elite_doctor_diagnostics(cli: &Cli) -> serde_json::Value {
             "counters": policy_counters,
         },
         "elite_gate": {
-            "command": elite_gate_script,
+            "command": elite_gate_command,
+            "runner": elite_gate_runner,
             "script_available": gate_available,
         }
     })
@@ -437,7 +447,10 @@ async fn run_doctor(
         elite["tool_policy"]["preset"].as_str().unwrap_or("unknown")
     );
     println!(
-        "  elite gate script... {}",
+        "  elite gate runner... {} {}",
+        elite["elite_gate"]["runner"]
+            .as_str()
+            .unwrap_or("unknown"),
         if elite["elite_gate"]["script_available"]
             .as_bool()
             .unwrap_or(false)
@@ -1198,12 +1211,8 @@ async fn run_update(_check: bool) -> Result<(), AgentError> {
     Ok(())
 }
 
-async fn run_elite_check(_cli: Cli, json: bool, strict: bool) -> Result<(), AgentError> {
-    let base_cmd = std::env::var("HERMES_ELITE_GATE_CMD")
-        .ok()
-        .filter(|v| !v.trim().is_empty())
-        .unwrap_or_else(|| "python3 scripts/run-elite-sync-gate.py --repo-root .".to_string());
-    let mut cmdline = base_cmd;
+async fn run_legacy_elite_check(cmdline: String, json: bool, strict: bool) -> Result<(), AgentError> {
+    let mut cmdline = cmdline;
     if json {
         cmdline.push_str(" --json");
     }
@@ -1224,6 +1233,50 @@ async fn run_elite_check(_cli: Cli, json: bool, strict: bool) -> Result<(), Agen
         return Err(AgentError::Config(format!(
             "elite-check failed (status={})",
             output.status
+        )));
+    }
+    Ok(())
+}
+
+async fn run_elite_check(_cli: Cli, json: bool, strict: bool) -> Result<(), AgentError> {
+    if let Some(cmdline) = std::env::var("HERMES_ELITE_GATE_CMD")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+    {
+        return run_legacy_elite_check(cmdline, json, strict).await;
+    }
+
+    let repo_root = std::env::current_dir()
+        .map_err(|e| AgentError::Io(format!("resolve elite-check repo root: {}", e)))?;
+    let (report, report_path) =
+        hermes_cli::commands::run_elite_sync_gate_native(&repo_root).await?;
+    let ok = report
+        .get("ok")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false);
+    let summary = report.get("summary").cloned().unwrap_or_default();
+    let passed = summary
+        .get("passed_sections")
+        .and_then(|value| value.as_u64())
+        .unwrap_or(0);
+    let total = summary
+        .get("total_sections")
+        .and_then(|value| value.as_u64())
+        .unwrap_or(0);
+
+    if json {
+        let body = serde_json::to_string_pretty(&report)
+            .map_err(|e| AgentError::Config(format!("serialize elite-check report: {}", e)))?;
+        println!("{}", body);
+    } else {
+        let status = if ok { "PASSED" } else { "FAILED" };
+        println!("[elite-sync-gate] {status} (passed={passed}/{total})");
+        println!("[elite-sync-gate] Report: {}", report_path.display());
+    }
+
+    if strict && !ok {
+        return Err(AgentError::Config(format!(
+            "elite-check failed (passed={passed}/{total})"
         )));
     }
     Ok(())

--- a/crates/hermes-cli/src/main/tests/env_profile_diagnostics/doctor_resume_dump.rs
+++ b/crates/hermes-cli/src/main/tests/env_profile_diagnostics/doctor_resume_dump.rs
@@ -73,6 +73,41 @@ fn doctor_elite_diagnostics_payload_has_required_sections() {
 }
 
 #[test]
+fn doctor_elite_diagnostics_defaults_to_native_gate() {
+    use clap::Parser;
+
+    let previous = std::env::var("HERMES_ELITE_GATE_CMD").ok();
+    std::env::remove_var("HERMES_ELITE_GATE_CMD");
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let cfg = tmp.path().join("cfg");
+    let cli = Cli::parse_from([
+        "hermes-ultra",
+        "--config-dir",
+        cfg.to_str().expect("utf8 path"),
+        "doctor",
+    ]);
+    let payload = build_elite_doctor_diagnostics(&cli);
+    assert_eq!(
+        payload["elite_gate"]["runner"].as_str(),
+        Some("native")
+    );
+    assert_eq!(
+        payload["elite_gate"]["command"].as_str(),
+        Some("native rust elite sync gate")
+    );
+    assert_eq!(
+        payload["elite_gate"]["script_available"].as_bool(),
+        Some(true)
+    );
+
+    match previous {
+        Some(value) => std::env::set_var("HERMES_ELITE_GATE_CMD", value),
+        None => std::env::remove_var("HERMES_ELITE_GATE_CMD"),
+    }
+}
+
+#[test]
 fn resolve_resume_session_file_prefers_latest_modified_file() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let cli = cli_for_temp_state_root(tmp.path());
@@ -520,4 +555,3 @@ async fn run_dump_writes_real_saved_session_export_with_system_prompt() {
         .as_str()
         .is_some_and(|p| p.ends_with("abc123.json")));
 }
-


### PR DESCRIPTION
## Summary

Moves top-level `hermes-agent-ultra elite-check` to the existing Rust-native elite sync gate by default, preserving `HERMES_ELITE_GATE_CMD` as an explicit legacy shell override.

## What Changed

- Exposes the native elite sync gate through `hermes_cli::commands` for the binary entrypoint.
- Routes `elite-check` to the native Rust gate unless `HERMES_ELITE_GATE_CMD` is set.
- Adds bounded timeout handling for autopilot probe shell commands so release gates fail closed instead of hanging indefinitely.
- Updates `doctor --deep` human output to show `elite gate runner... native ✓`.
- Adds coverage for native runner diagnostics and probe timeout behavior.

## Verification

- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo fmt --all --check`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-cli --lib runtime_parity_ops -- --nocapture` -> 59 passed
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-cli --bin hermes-agent-ultra env_profile_diagnostics -- --nocapture` -> 61 passed
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-source-parity-tests --test rust_module_size_policy -- --nocapture` -> reported/review/exceptional/hard-limit all 0
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 scripts/clippy-warning-gate.sh --check -- -p hermes-cli` -> seen=193 allowlist=193 new=0 stale=0
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo build -p hermes-cli --bins`
- `/Volumes/wd_black/cargo-targets/debug/hermes-agent-ultra doctor --deep` -> `elite gate runner... native ✓`
- `HERMES_ELITE_GATE_CMD='printf wrapper-ok' /Volumes/wd_black/cargo-targets/debug/hermes-agent-ultra elite-check` -> wrapper override still works
- `test ! -d target && echo no-repo-target`
