### PR TITLE
release: bump Hermes Agent Ultra to v0.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,7 +1487,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-acp"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1544,7 +1544,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-app-runtime"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-auth"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -1582,7 +1582,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-cli"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "aes-gcm",
  "arboard",
@@ -1641,14 +1641,14 @@ dependencies = [
 
 [[package]]
 name = "hermes-cli-ui"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "hermes-config"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "chrono",
  "directories",
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-core"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1683,7 +1683,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-cron"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-environments"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "hermes-config",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-eval"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-gateway"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "aes",
  "async-trait",
@@ -1792,7 +1792,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-http"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1819,7 +1819,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-intelligence"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-mcp"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1859,7 +1859,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-parity-tests"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "hermes-core",
  "hermes-intelligence",
@@ -1871,7 +1871,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-protocol-parity-tests"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "hermes-acp",
@@ -1886,7 +1886,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-provider-runtime"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -1901,7 +1901,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-skills"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1927,7 +1927,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-source-parity-tests"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "regex",
  "serde",
@@ -1936,7 +1936,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-telemetry"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "base64",
  "once_cell",
@@ -1952,7 +1952,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-tool-planning"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "hermes-agent",
@@ -1966,7 +1966,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-tools"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.18.1"
+version = "0.19.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/sheawinkler/hermes-agent-ultra"

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -989,7 +989,7 @@
     "2bd1977d8fad185c9b4be47884f7e87f1add0ce3": {
       "disposition": "superseded",
       "owner": "rust-runtime",
-      "notes": "Upstream Python v0.17.0 release metadata is superseded by Hermes Agent Ultra Rust release train: workspace version is 0.18.1 and docs/releases/v0.17.0, v0.18.0, and v0.18.1 record the local Rust release lineage."
+      "notes": "Upstream Python v0.17.0 release metadata is superseded by Hermes Agent Ultra Rust release train: workspace version is 0.19.0 and docs/releases/v0.17.0, v0.18.0, v0.18.1, and v0.19.0 record the local Rust release lineage."
     },
     "2c02583c2b19f72b3904481c9d219e325b35ef10": {
       "disposition": "ported",

--- a/docs/releases/v0.19.0.md
+++ b/docs/releases/v0.19.0.md
@@ -1,0 +1,90 @@
+# Hermes Agent Ultra v0.19.0
+
+Release date: 2026-06-28
+
+This minor release is the parity-and-architecture consolidation cut. Since `v0.18.1`, Hermes Agent Ultra moved a large tranche of upstream-compatible behavior into first-class Rust runtime surfaces, cleared the Rust module-size pressure ledger, proved interactive provider/session behavior, and replaced the top-level elite release gate with the Rust-native gate path by default.
+
+## Release Snapshot
+
+| Signal | v0.19.0 State |
+| --- | ---: |
+| Commits since `v0.18.1` | 137 non-merge commits |
+| Diff footprint since `v0.18.1` | 866 files, +350,270 / -172,853 |
+| Workspace version | `0.19.0` |
+| First-party Rust files scanned | 705 |
+| Module-size reported-pressure | 0 |
+| Module-size review-pressure | 0 |
+| Module-size exceptional | 0 |
+| Module-size hard-limit | 0 |
+| Runtime language posture | Rust runtime; no Python runtime fallback added |
+| Interactive provider smoke | PASS, `openai:dynamic` returned `HERMES_SMOKE_OK` |
+| Interactive TTY smoke | PASS, startup/help/quit |
+| Resume smoke | PASS, synthetic `resume latest` restored 2 messages |
+| Elite gate runner | Rust-native by default |
+
+## Minimal Flow
+
+```text
+upstream/parity backlog
+        |
+        v
+Rust runtime implementations + source-parity contracts
+        |
+        v
+module architecture pressure ledger
+        |
+        v
+reported=0 | review=0 | exceptional=0 | hard-limit=0
+        |
+        v
+interactive smoke: provider + TTY + resume + doctor/status
+        |
+        v
+v0.19.0 release
+```
+
+## Behavioral And Functional Changes
+
+- Added and hardened Rust-native parity surfaces across agent loop behavior, provider routing, OAuth/auth state handling, MCP/ACP/protocol runtime, gateway/platform behavior, browser/tool backends, source parity contracts, and release/runtime diagnostics.
+- Preserved upstream-compatible user surfaces while keeping Hermes Ultra-specific behavior explicit and tested instead of hidden behind Python fallbacks.
+- Verified both `hermes-ultra` and `hermes-agent-ultra` entrypoints from rebuilt binaries.
+- Verified `openai:dynamic` query mode with tools disabled: provider-backed query returned exactly `HERMES_SMOKE_OK`.
+- Verified OpenAI and OpenAI-Codex auth status surfaces report credentials and OAuth state present without exposing secret values.
+- Verified TTY interactive startup, slash-command dispatch via `/help`, `/quit` clean exit, and synthetic `resume latest` restoration.
+
+## Procedural And Architecture Changes
+
+- Cleared the Rust module-size policy pressure tiers by splitting large Rust files into cohesive sidecars while preserving behavior.
+- Strengthened source-parity harnesses so recursive `include!`, `mod tests;`, and sidecar module layouts remain covered after refactors.
+- Updated parity source references after structural splits.
+- Moved `elite-check` to the Rust-native elite sync gate by default while preserving `HERMES_ELITE_GATE_CMD` as an explicit legacy shell override.
+- Added bounded probe timeouts so release-gate command probes fail closed instead of hanging indefinitely.
+- Kept build artifacts off the repo/local target path with `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets`.
+
+## Exceptional-To-Upstream Posture
+
+| Area | Why this is exceptional rather than merely equivalent |
+| --- | --- |
+| Runtime posture | First-class Rust surfaces replace brittle Python runtime fallback paths. |
+| Verification | Behavior is tracked by source-parity contracts, module-size policy, clippy warning budgets, and interactive smoke evidence. |
+| Architecture | Large files are now split into navigable subsystem sidecars with zero pressure-tier debt. |
+| Release gate | `elite-check` is Rust-native by default and timeout-bounded. |
+| Coexistence | `hermes-ultra` and `hermes-agent-ultra` run as distinct rebuilt entrypoints while auth/status/session paths remain coherent. |
+
+## Verification
+
+```bash
+contextlattice_agent_policy_pack --agent codex_gpt5 --project hermes-agent-ultra --query "Proceed with interactive smoke matrix, version bump, release only if behavior proven after PR 684 and PR 685 native elite gate"
+/Volumes/wd_black/cargo-targets/debug/hermes-ultra --version
+/Volumes/wd_black/cargo-targets/debug/hermes-agent-ultra --version
+/Volumes/wd_black/cargo-targets/debug/hermes-agent-ultra status
+/Volumes/wd_black/cargo-targets/debug/hermes-agent-ultra doctor --deep
+/Volumes/wd_black/cargo-targets/debug/hermes-agent-ultra auth status openai
+/Volumes/wd_black/cargo-targets/debug/hermes-agent-ultra auth status codex
+HERMES_QUERY_DISABLE_TOOLS=1 /Volumes/wd_black/cargo-targets/debug/hermes-agent-ultra --provider openai --model openai:dynamic chat --query 'Reply with exactly HERMES_SMOKE_OK and nothing else.'
+/Volumes/wd_black/cargo-targets/debug/hermes-ultra hermes
+/Volumes/wd_black/cargo-targets/debug/hermes-agent-ultra --config-dir "$synthetic_state" resume latest
+CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-source-parity-tests --test rust_module_size_policy -- --nocapture
+```
+
+Hosted GitHub CI/CD remains optional. Local deterministic gates plus interactive smoke evidence are authoritative for this release cut.


### PR DESCRIPTION
## Summary
- Bump the Hermes Agent Ultra workspace from `0.18.1` to `0.19.0`.
- Add `docs/releases/v0.19.0.md` with parity, architecture, interactive smoke, and native elite-gate evidence.
- Update parity release-lineage notes so the upstream Python release metadata disposition points at the current Rust release train.

## Verification
- ContextLattice policy pack: reachable, `degraded=false`.
- Interactive smoke matrix passed before the bump:
  - `hermes-ultra --version`
  - `hermes-agent-ultra --version`
  - `hermes-agent-ultra status`
  - `hermes-agent-ultra doctor --deep`
  - `auth status openai`
  - `auth status codex`
  - provider query using `--provider openai --model openai:dynamic` returned exactly `HERMES_SMOKE_OK`
  - TTY `/help` and `/quit`
  - synthetic `resume latest` restored a 2-message session
- `scripts/check-runtime-placeholders.sh`
- `scripts/check-rust-runtime-no-python.sh`
- `jq empty docs/parity/queue-overrides.json docs/parity/upstream-missing-queue.json`
- `git diff --check`
- `cargo fmt --all --check`
- `cargo metadata --format-version 1 --no-deps` reports `hermes-cli` version `0.19.0`
- `cargo test -p hermes-source-parity-tests --test rust_module_size_policy -- --nocapture`
  - scanned 705 first-party Rust files
  - reported-pressure 0
  - review-pressure 0
  - exceptional 0
  - hard-limit 0
- `cargo build --workspace` passed before commit with `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0`
- `test ! -d target` passed; build artifacts stayed off the repo-local target path.
