### PR TITLE
fix(gateway): keep API preflight status out of mailbox

### DIFF
--- a/crates/hermes-config/src/config/agent_loop_behavior.rs
+++ b/crates/hermes-config/src/config/agent_loop_behavior.rs
@@ -45,6 +45,12 @@ pub struct AgentLoopBehaviorConfig {
     /// Character budget for injected LSP context block.
     #[serde(default = "default_agent_lsp_context_max_chars")]
     pub lsp_context_max_chars: usize,
+    /// Emit a preflight context-compression status before the first LLM call.
+    #[serde(
+        default = "default_agent_preflight_context_compress",
+        deserialize_with = "deserialize_boolish"
+    )]
+    pub preflight_context_compress: bool,
     /// Optional provider request service tier. `fast` maps to provider `priority`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub service_tier: Option<String>,
@@ -103,6 +109,10 @@ fn default_agent_lsp_context_max_chars() -> usize {
     2_800
 }
 
+fn default_agent_preflight_context_compress() -> bool {
+    true
+}
+
 impl Default for AgentLoopBehaviorConfig {
     fn default() -> Self {
         Self {
@@ -117,6 +127,7 @@ impl Default for AgentLoopBehaviorConfig {
             code_index_max_symbols: default_agent_code_index_max_symbols(),
             lsp_context_enabled: default_agent_lsp_context_enabled(),
             lsp_context_max_chars: default_agent_lsp_context_max_chars(),
+            preflight_context_compress: default_agent_preflight_context_compress(),
             service_tier: None,
             api_max_retries: None,
             prefill_messages_file: None,

--- a/crates/hermes-config/src/config/tests.rs
+++ b/crates/hermes-config/src/config/tests.rs
@@ -379,6 +379,7 @@ display:
       tool_progress: off
 agent:
   service_tier: fast
+  preflight_context_compress: "false"
 "#,
         )
         .expect("display config");
@@ -393,6 +394,7 @@ agent:
             cfg.agent.normalized_service_tier().as_deref(),
             Some("priority")
         );
+        assert!(!cfg.agent.preflight_context_compress);
 
         let disabled: GatewayConfig = serde_yaml::from_str(
             r#"

--- a/crates/hermes-config/src/loader/tests/user_config_patch.rs
+++ b/crates/hermes-config/src/loader/tests/user_config_patch.rs
@@ -501,6 +501,23 @@ fn apply_patch_dotted_agent_api_max_retries() {
 }
 
 #[test]
+fn apply_patch_dotted_agent_preflight_context_compress() {
+    let mut c = GatewayConfig::default();
+    assert!(c.agent.preflight_context_compress);
+
+    apply_user_config_patch(&mut c, "agent.preflight_context_compress", "false").unwrap();
+
+    assert!(!c.agent.preflight_context_compress);
+    assert_eq!(
+        user_config_field_display(&c, "agent.preflight_context_compress").unwrap(),
+        "false"
+    );
+    apply_user_config_patch(&mut c, "agent.preflightContextCompress", "on").unwrap();
+    assert!(c.agent.preflight_context_compress);
+    assert!(apply_user_config_patch(&mut c, "agent.preflight_context_compress", "nope").is_err());
+}
+
+#[test]
 fn apply_patch_dotted_delegation_provider_model_runtime_values() {
     let mut c = GatewayConfig::default();
 

--- a/crates/hermes-config/src/loader/user_config_patch.rs
+++ b/crates/hermes-config/src/loader/user_config_patch.rs
@@ -1,4 +1,4 @@
-const CONFIG_PATCH_HELP: &str = "model, personality, max_turns, system_prompt, prefill_messages_file, model_switch.persist_switch_by_default, budget.max_result_size_chars, budget.max_aggregate_chars, proxy.http, proxy.socks, security.allow_private_urls, web.backend|search_backend|extract_backend|crawl_backend, display.busy_input_mode|busy_ack_enabled|memory_notifications, sessions.auto_prune|retention_days|vacuum_after_prune|min_interval_hours, kanban.dispatch_in_gateway, agent.api_max_retries, delegation.model|provider|base_url|api_key|max_spawn_depth, llm.<provider>.api_key|api_key_env|base_url|model|models|discover_models|api_mode|command|args|request_timeout_seconds|oauth_token_url|oauth_client_id, auxiliary.<task>.provider|model|base_url|api_key|timeout|download_timeout, smart_model_routing.enabled|max_simple_chars|max_simple_words|cheap_model.model|cheap_model.provider";
+const CONFIG_PATCH_HELP: &str = "model, personality, max_turns, system_prompt, prefill_messages_file, model_switch.persist_switch_by_default, budget.max_result_size_chars, budget.max_aggregate_chars, proxy.http, proxy.socks, security.allow_private_urls, web.backend|search_backend|extract_backend|crawl_backend, display.busy_input_mode|busy_ack_enabled|memory_notifications, sessions.auto_prune|retention_days|vacuum_after_prune|min_interval_hours, kanban.dispatch_in_gateway, agent.api_max_retries|preflight_context_compress, delegation.model|provider|base_url|api_key|max_spawn_depth, llm.<provider>.api_key|api_key_env|base_url|model|models|discover_models|api_mode|command|args|request_timeout_seconds|oauth_token_url|oauth_client_id, auxiliary.<task>.provider|model|base_url|api_key|timeout|download_timeout, smart_model_routing.enabled|max_simple_chars|max_simple_words|cheap_model.model|cheap_model.provider";
 
 fn mask_secret(s: &str) -> String {
     if s.is_empty() {
@@ -239,6 +239,10 @@ fn apply_user_config_patch_dotted(
                 ))
             })?);
         }
+        ["agent", "preflight_context_compress"] | ["agent", "preflightContextCompress"] => {
+            config.agent.preflight_context_compress =
+                parse_config_bool("agent.preflight_context_compress", value)?;
+        }
         ["delegation", "model"] => {
             config.delegation.model = Some(value.to_string());
         }
@@ -262,7 +266,7 @@ fn apply_user_config_patch_dotted(
             let entry = config
                 .auxiliary
                 .entry((*task).to_string())
-                .or_insert_with(crate::config::AuxiliaryTaskConfig::default);
+                .or_default();
             match *field {
                 "provider" => entry.provider = value.to_string(),
                 "model" => entry.model = value.to_string(),
@@ -296,7 +300,7 @@ fn apply_user_config_patch_dotted(
             let entry = config
                 .llm_providers
                 .entry((*provider).to_string())
-                .or_insert_with(LlmProviderConfig::default);
+                .or_default();
             match *field {
                 "api_key" => entry.api_key = Some(value.to_string()),
                 "api_key_env" => entry.api_key_env = Some(value.to_string()),
@@ -505,6 +509,9 @@ pub fn user_config_field_display(config: &GatewayConfig, key: &str) -> Result<St
             .api_max_retries
             .map(|value| value.to_string())
             .unwrap_or_else(|| "(not set)".to_string())),
+        ["agent", "preflight_context_compress"] | ["agent", "preflightContextCompress"] => {
+            Ok(config.agent.preflight_context_compress.to_string())
+        }
         ["delegation", "model"] => Ok(config
             .delegation
             .model

--- a/crates/hermes-gateway/src/platforms/api_server.rs
+++ b/crates/hermes-gateway/src/platforms/api_server.rs
@@ -611,6 +611,22 @@ impl PlatformAdapter for ApiServerAdapter {
         Ok(())
     }
 
+    async fn send_or_update_status(
+        &self,
+        chat_id: &str,
+        status_key: &str,
+        text: &str,
+        _parse_mode: Option<ParseMode>,
+    ) -> Result<(), GatewayError> {
+        debug!(
+            chat_id = chat_id,
+            status_key = status_key,
+            text = text,
+            "API server status update ignored for HTTP response mailbox"
+        );
+        Ok(())
+    }
+
     async fn edit_message(
         &self,
         chat_id: &str,

--- a/crates/hermes-gateway/src/platforms/api_server/tests.rs
+++ b/crates/hermes-gateway/src/platforms/api_server/tests.rs
@@ -548,6 +548,44 @@ async fn responses_endpoint_accepts_input_and_quoted_false_without_storing() {
 }
 
 #[tokio::test]
+async fn status_updates_do_not_complete_pending_http_mailbox() {
+    let adapter = ApiServerAdapter::new(ApiServerConfig::default());
+    let (reply_tx, mut reply_rx) = mpsc::channel(1);
+    adapter
+        .mailbox
+        .write()
+        .await
+        .pending
+        .insert("api-session".to_string(), reply_tx);
+
+    adapter
+        .send_or_update_status(
+            "api-session",
+            "lifecycle",
+            "Preflight compression check: 6% context usage, no compression needed",
+            None,
+        )
+        .await
+        .expect("status update");
+
+    let status_result =
+        tokio::time::timeout(std::time::Duration::from_millis(20), reply_rx.recv()).await;
+    assert!(
+        status_result.is_err(),
+        "status update must not satisfy API response"
+    );
+
+    adapter
+        .send_message("api-session", "final assistant reply", None)
+        .await
+        .expect("final reply");
+    let final_reply = tokio::time::timeout(std::time::Duration::from_secs(1), reply_rx.recv())
+        .await
+        .expect("final timeout");
+    assert_eq!(final_reply.as_deref(), Some("final assistant reply"));
+}
+
+#[tokio::test]
 async fn api_jobs_endpoint_crud_filters_and_actions() {
     let (tx, _rx) = mpsc::channel(1);
     let state = ApiTestState::new(tx);

--- a/crates/hermes-http/src/lib.rs
+++ b/crates/hermes-http/src/lib.rs
@@ -970,6 +970,7 @@ pub fn build_agent_config(config: &GatewayConfig, model: &str) -> AgentConfig {
         code_index_max_symbols: config.agent.code_index_max_symbols,
         lsp_context_enabled: config.agent.lsp_context_enabled,
         lsp_context_max_chars: config.agent.lsp_context_max_chars,
+        preflight_context_compress: config.agent.preflight_context_compress,
         ..AgentConfig::default()
     }
 }
@@ -1126,6 +1127,16 @@ mod tests {
                 .and_then(|cfg| cfg.request_timeout_seconds),
             Some(45.5)
         );
+    }
+
+    #[test]
+    fn build_agent_config_maps_preflight_context_compress() {
+        let mut config = GatewayConfig::default();
+        config.agent.preflight_context_compress = false;
+
+        let agent_config = build_agent_config(&config, "openai:dynamic");
+
+        assert!(!agent_config.preflight_context_compress);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Keep API-server lifecycle/status updates out of the pending HTTP response mailbox so `/v1/chat/completions` cannot return preflight status text instead of the final assistant reply.
- Add first-class `agent.preflight_context_compress` config support in Rust config, `hermes config set/get`, and the gateway `AgentConfig` bridge.
- Add targeted regression coverage for config parsing/mapping and API-server mailbox behavior.

Fixes #594.
Supersedes the stale implementation approach in #595 by patching the current split modules and fixing the default API status path, not only the opt-out config path.

## Verification
- `python3 scripts/generate-upstream-patch-queue.py --repo-root . --local-ref main --upstream-remote upstream --upstream-branch main --no-fetch`
  - Refreshed evidence showed current upstream has 141 pending deltas; generated docs were not committed to keep this PR scoped and mergeable.
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-config display_config_accepts_boolish_verbose_gate_and_platform_modes -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-config apply_patch_dotted_agent_preflight_context_compress -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-http build_agent_config_maps_preflight_context_compress -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-gateway --features api-server status_updates_do_not_complete_pending_http_mailbox -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo check -p hermes-cli`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo fmt --all --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `git diff --check`
- `test ! -d target`

## Clippy
- Attempted targeted `cargo clippy -p hermes-config -p hermes-http -p hermes-gateway --features api-server --tests -- -D warnings`.
- It fails on existing broad Clippy debt in unrelated modules, including `runtime_surface.rs`, `python_yaml_compat.rs`, and `hermes-intelligence` files.
- I fixed the two Clippy nits surfaced in the touched `user_config_patch.rs` file (`or_default`).
