### PR TITLE
parity(runtime): close matrix invite and mcp discovery deltas

### DIFF
--- a/crates/hermes-gateway/src/platforms/matrix.rs
+++ b/crates/hermes-gateway/src/platforms/matrix.rs
@@ -210,6 +210,13 @@ pub struct RelatesTo {
     pub key: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MatrixInviteJoinRequest {
+    room_id: String,
+    is_direct: bool,
+    inviter: Option<String>,
+}
+
 #[derive(Debug)]
 struct MatrixDecryptFfiOutput {
     body: String,
@@ -740,6 +747,7 @@ pub struct MatrixAdapter {
     txn_counter: AtomicU64,
     stop_signal: Arc<Notify>,
     sync_running: AtomicBool,
+    pending_invite_joins: Arc<Mutex<HashSet<String>>>,
     pub e2ee: MatrixE2ee,
     decrypt_ffi: Option<MatrixDecryptFfiConfig>,
     native_decrypt: Option<MatrixNativeDecryptConfig>,

--- a/crates/hermes-gateway/src/platforms/matrix/adapter_impl/core_native.rs
+++ b/crates/hermes-gateway/src/platforms/matrix/adapter_impl/core_native.rs
@@ -32,6 +32,7 @@ impl MatrixAdapter {
             txn_counter: AtomicU64::new(0),
             stop_signal: Arc::new(Notify::new()),
             sync_running: AtomicBool::new(false),
+            pending_invite_joins: Arc::new(Mutex::new(HashSet::new())),
             decrypt_ffi,
             native_decrypt,
             native_runtime: AsyncMutex::new(None),

--- a/crates/hermes-gateway/src/platforms/matrix/adapter_impl/event_parsing.rs
+++ b/crates/hermes-gateway/src/platforms/matrix/adapter_impl/event_parsing.rs
@@ -233,18 +233,42 @@ impl MatrixAdapter {
     }
 
     /// Extract room IDs from the `invite` section of a sync response.
+    #[cfg(test)]
     fn parse_invites(&self, sync_response: &serde_json::Value) -> Vec<String> {
-        let allowed_users = matrix_invite_allowed_users_from_env();
-        let allow_all = matrix_invite_allow_all_from_env();
-        self.parse_invites_with_auth(sync_response, &allowed_users, allow_all)
+        self.parse_invite_join_requests(sync_response)
+            .into_iter()
+            .map(|invite| invite.room_id)
+            .collect()
     }
 
+    fn parse_invite_join_requests(
+        &self,
+        sync_response: &serde_json::Value,
+    ) -> Vec<MatrixInviteJoinRequest> {
+        let allowed_users = matrix_invite_allowed_users_from_env();
+        let allow_all = matrix_invite_allow_all_from_env();
+        self.parse_invite_join_requests_with_auth(sync_response, &allowed_users, allow_all)
+    }
+
+    #[cfg(test)]
     fn parse_invites_with_auth(
         &self,
         sync_response: &serde_json::Value,
         allowed_users: &[String],
         allow_all: bool,
     ) -> Vec<String> {
+        self.parse_invite_join_requests_with_auth(sync_response, allowed_users, allow_all)
+            .into_iter()
+            .map(|invite| invite.room_id)
+            .collect()
+    }
+
+    fn parse_invite_join_requests_with_auth(
+        &self,
+        sync_response: &serde_json::Value,
+        allowed_users: &[String],
+        allow_all: bool,
+    ) -> Vec<MatrixInviteJoinRequest> {
         sync_response
             .get("rooms")
             .and_then(|r| r.get("invite"))
@@ -254,7 +278,11 @@ impl MatrixAdapter {
                     .filter_map(|(room_id, invite)| {
                         let sender = self.invite_sender(invite);
                         matrix_invite_sender_allowed(sender, allowed_users, allow_all)
-                            .then(|| room_id.clone())
+                            .then(|| MatrixInviteJoinRequest {
+                                room_id: room_id.clone(),
+                                is_direct: self.invite_is_direct(invite),
+                                inviter: sender.map(str::to_string),
+                            })
                     })
                     .collect()
             })
@@ -290,6 +318,25 @@ impl MatrixAdapter {
                             .iter()
                             .find_map(|event| event.get("sender").and_then(|v| v.as_str()))
                     })
+            })
+    }
+
+    fn invite_is_direct(&self, invite: &serde_json::Value) -> bool {
+        invite
+            .pointer("/invite_state/events")
+            .and_then(|events| events.as_array())
+            .is_some_and(|events| {
+                events.iter().any(|event| {
+                    event.get("type").and_then(|v| v.as_str()) == Some("m.room.member")
+                        && event.get("state_key").and_then(|v| v.as_str())
+                            == Some(self.config.user_id.as_str())
+                        && event.pointer("/content/membership").and_then(|v| v.as_str())
+                            == Some("invite")
+                        && event
+                            .pointer("/content/is_direct")
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false)
+                })
             })
     }
 

--- a/crates/hermes-gateway/src/platforms/matrix/adapter_impl/media_sync.rs
+++ b/crates/hermes-gateway/src/platforms/matrix/adapter_impl/media_sync.rs
@@ -173,13 +173,9 @@ impl MatrixAdapter {
 
         let messages = self.parse_sync_events(&body).await;
 
-        // Auto-join on invite
-        let invites = self.parse_invites(&body);
-        for invite_room in invites {
-            info!(room_id = %invite_room, "Auto-joining invited room");
-            if let Err(e) = self.join_room(&invite_room).await {
-                warn!(room_id = %invite_room, error = %e, "Failed to auto-join room");
-            }
+        // Auto-join invites without blocking sync readiness on stale rooms.
+        for invite in self.parse_invite_join_requests(&body) {
+            self.schedule_invite_join(invite);
         }
 
         Ok((messages, next_batch))

--- a/crates/hermes-gateway/src/platforms/matrix/adapter_impl/rooms.rs
+++ b/crates/hermes-gateway/src/platforms/matrix/adapter_impl/rooms.rs
@@ -5,15 +5,22 @@ impl MatrixAdapter {
 
     /// Join a room by room ID or alias.
     pub async fn join_room(&self, room_id: &str) -> Result<String, GatewayError> {
+        Self::join_room_with_client(&self.client, &self.config, room_id).await
+    }
+
+    async fn join_room_with_client(
+        client: &Client,
+        config: &MatrixConfig,
+        room_id: &str,
+    ) -> Result<String, GatewayError> {
         let url = format!(
             "{}/_matrix/client/v3/join/{}",
-            self.config.homeserver_url, room_id
+            config.homeserver_url, room_id
         );
 
-        let resp = self
-            .client
+        let resp = client
             .post(&url)
-            .header("Authorization", self.auth_header())
+            .header("Authorization", format!("Bearer {}", config.access_token))
             .json(&serde_json::json!({}))
             .send()
             .await
@@ -38,6 +45,147 @@ impl MatrixAdapter {
 
         info!(room_id = %joined_room, "Joined room");
         Ok(joined_room)
+    }
+
+    fn schedule_invite_join(&self, invite: MatrixInviteJoinRequest) {
+        let room_id = invite.room_id.trim().to_string();
+        if room_id.is_empty() {
+            return;
+        }
+
+        {
+            let mut pending = self.pending_invite_joins.lock().expect("matrix invite joins");
+            if !pending.insert(room_id.clone()) {
+                debug!(room_id = %room_id, "Matrix invite join already pending");
+                return;
+            }
+        }
+
+        let pending = Arc::clone(&self.pending_invite_joins);
+        let client = self.client.clone();
+        let config = self.config.clone();
+        tokio::spawn(async move {
+            info!(room_id = %room_id, "Scheduling Matrix invite auto-join");
+            let join_result = tokio::time::timeout(
+                Duration::from_secs(45),
+                Self::join_room_with_client(&client, &config, &room_id),
+            )
+            .await;
+
+            match join_result {
+                Ok(Ok(_joined_room)) => {
+                    if invite.is_direct {
+                        if let Some(inviter) =
+                            invite.inviter.as_deref().map(str::trim).filter(|s| !s.is_empty())
+                        {
+                            if let Err(err) =
+                                Self::record_dm_room_with_client(&client, &config, &room_id, inviter)
+                                    .await
+                            {
+                                warn!(
+                                    room_id = %room_id,
+                                    inviter = %inviter,
+                                    error = %err,
+                                    "Matrix failed to record direct invite in m.direct"
+                                );
+                            }
+                        }
+                    }
+                }
+                Ok(Err(err)) => {
+                    warn!(room_id = %room_id, error = %err, "Failed to auto-join Matrix invite");
+                }
+                Err(_) => {
+                    warn!(room_id = %room_id, "Timed out auto-joining Matrix invite");
+                }
+            }
+
+            pending
+                .lock()
+                .expect("matrix invite joins")
+                .remove(&room_id);
+        });
+    }
+
+    async fn record_dm_room_with_client(
+        client: &Client,
+        config: &MatrixConfig,
+        room_id: &str,
+        inviter: &str,
+    ) -> Result<(), GatewayError> {
+        let url = format!(
+            "{}/_matrix/client/v3/user/{}/account_data/m.direct",
+            config.homeserver_url,
+            urlencoding::encode(&config.user_id)
+        );
+
+        let mut account_data = match client
+            .get(&url)
+            .header("Authorization", format!("Bearer {}", config.access_token))
+            .send()
+            .await
+        {
+            Ok(resp) if resp.status().is_success() => resp
+                .json::<serde_json::Map<String, serde_json::Value>>()
+                .await
+                .unwrap_or_default(),
+            Ok(resp) if resp.status().as_u16() == 404 => serde_json::Map::new(),
+            Ok(resp) => {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                return Err(GatewayError::ConnectionFailed(format!(
+                    "Matrix m.direct read error ({status}): {text}"
+                )));
+            }
+            Err(err) => {
+                return Err(GatewayError::ConnectionFailed(format!(
+                    "Matrix m.direct read failed: {err}"
+                )));
+            }
+        };
+
+        let rooms = account_data
+            .entry(inviter.to_string())
+            .or_insert_with(|| serde_json::Value::Array(Vec::new()));
+        if !rooms.is_array() {
+            *rooms = serde_json::Value::Array(Vec::new());
+        }
+        let rooms = rooms.as_array_mut().expect("normalized array");
+        if !rooms.iter().any(|room| room.as_str() == Some(room_id)) {
+            rooms.push(serde_json::Value::String(room_id.to_string()));
+        }
+
+        let resp = client
+            .put(&url)
+            .header("Authorization", format!("Bearer {}", config.access_token))
+            .json(&account_data)
+            .send()
+            .await
+            .map_err(|err| {
+                GatewayError::ConnectionFailed(format!("Matrix m.direct write failed: {err}"))
+            })?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(GatewayError::ConnectionFailed(format!(
+                "Matrix m.direct write error ({status}): {text}"
+            )));
+        }
+
+        info!(
+            room_id = %room_id,
+            inviter = %inviter,
+            "Recorded Matrix direct invite in m.direct"
+        );
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn pending_invite_join_count(&self) -> usize {
+        self.pending_invite_joins
+            .lock()
+            .expect("matrix invite joins")
+            .len()
     }
 
     /// Leave a room.

--- a/crates/hermes-gateway/src/platforms/matrix/tests.rs
+++ b/crates/hermes-gateway/src/platforms/matrix/tests.rs
@@ -329,6 +329,172 @@ fn parse_invites_filters_inviter_when_allowlist_is_configured() {
 }
 
 #[tokio::test]
+async fn sync_once_schedules_direct_invite_join_without_blocking() {
+    let server = MockServer::start().await;
+    let sync_body = serde_json::json!({
+        "next_batch": "s1",
+        "rooms": {
+            "invite": {
+                "!dm:test": {
+                    "invite_state": {
+                        "events": [{
+                            "type": "m.room.member",
+                            "state_key": "@bot:test",
+                            "sender": "@alice:test",
+                            "content": {
+                                "membership": "invite",
+                                "is_direct": true
+                            }
+                        }]
+                    }
+                }
+            }
+        }
+    });
+    Mock::given(method("GET"))
+        .and(path("/_matrix/client/v3/sync"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sync_body))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/_matrix/client/v3/join/!dm:test"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_delay(std::time::Duration::from_millis(250))
+                .set_body_json(serde_json::json!({"room_id": "!dm:test"})),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(
+            "/_matrix/client/v3/user/%40bot%3Atest/account_data/m.direct",
+        ))
+        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "errcode": "M_NOT_FOUND"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("PUT"))
+        .and(path(
+            "/_matrix/client/v3/user/%40bot%3Atest/account_data/m.direct",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let adapter = MatrixAdapter::new(MatrixConfig {
+        homeserver_url: server.uri(),
+        user_id: "@bot:test".into(),
+        access_token: "tok".into(),
+        room_id: None,
+        proxy: AdapterProxyConfig::default(),
+    })
+    .expect("matrix adapter");
+
+    let (messages, next_batch) = tokio::time::timeout(
+        std::time::Duration::from_millis(100),
+        adapter.sync_once(None),
+    )
+    .await
+    .expect("sync_once should not wait for delayed invite join")
+    .expect("sync_once");
+
+    assert!(messages.is_empty());
+    assert_eq!(next_batch.as_deref(), Some("s1"));
+    assert_eq!(adapter.pending_invite_join_count(), 1);
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        while adapter.pending_invite_join_count() != 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("invite join task should drain");
+}
+
+#[tokio::test]
+async fn schedule_invite_join_dedupes_room_until_task_finishes() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/_matrix/client/v3/join/!dupe:test"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_delay(std::time::Duration::from_millis(100))
+                .set_body_json(serde_json::json!({"room_id": "!dupe:test"})),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let adapter = MatrixAdapter::new(MatrixConfig {
+        homeserver_url: server.uri(),
+        user_id: "@bot:test".into(),
+        access_token: "tok".into(),
+        room_id: None,
+        proxy: AdapterProxyConfig::default(),
+    })
+    .expect("matrix adapter");
+
+    let invite = MatrixInviteJoinRequest {
+        room_id: "!dupe:test".into(),
+        is_direct: false,
+        inviter: None,
+    };
+    adapter.schedule_invite_join(invite.clone());
+    adapter.schedule_invite_join(invite);
+
+    assert_eq!(adapter.pending_invite_join_count(), 1);
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        while adapter.pending_invite_join_count() != 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("invite join task should drain");
+}
+
+#[tokio::test]
+async fn record_dm_room_appends_invite_to_existing_m_direct() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(
+            "/_matrix/client/v3/user/%40bot%3Atest/account_data/m.direct",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "@alice:test": ["!old:test"],
+            "@bob:test": "!bad-shape:test"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("PUT"))
+        .and(path(
+            "/_matrix/client/v3/user/%40bot%3Atest/account_data/m.direct",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let config = MatrixConfig {
+        homeserver_url: server.uri(),
+        user_id: "@bot:test".into(),
+        access_token: "tok".into(),
+        room_id: None,
+        proxy: AdapterProxyConfig::default(),
+    };
+    let client = reqwest::Client::new();
+
+    MatrixAdapter::record_dm_room_with_client(&client, &config, "!new:test", "@alice:test")
+        .await
+        .expect("record m.direct");
+}
+
+#[tokio::test]
 async fn test_parse_sync_encrypted_event_metadata() {
     let config = MatrixConfig {
         homeserver_url: "https://matrix.test".into(),

--- a/crates/hermes-mcp/src/client.rs
+++ b/crates/hermes-mcp/src/client.rs
@@ -240,6 +240,10 @@ pub struct McpServerConfig {
     /// Optional authentication provider for remote servers.
     #[serde(skip)]
     pub auth_provider: Option<Arc<dyn McpAuthProvider>>,
+    /// Runtime-only guard used by background discovery to prevent OAuth flows
+    /// from competing with the interactive TUI/CLI stdin reader.
+    #[serde(skip)]
+    pub suppress_interactive_oauth: bool,
 }
 
 impl std::fmt::Debug for McpServerConfig {
@@ -255,6 +259,10 @@ impl std::fmt::Debug for McpServerConfig {
             )
             .field("keepalive_interval", &self.keepalive_interval)
             .field("sampling", &self.sampling)
+            .field(
+                "suppress_interactive_oauth",
+                &self.suppress_interactive_oauth,
+            )
             .field(
                 "auth_provider",
                 &self.auth_provider.as_ref().map(|_| "<McpAuthProvider>"),
@@ -272,6 +280,7 @@ impl PartialEq for McpServerConfig {
             && self.supports_parallel_tool_calls == other.supports_parallel_tool_calls
             && self.keepalive_interval == other.keepalive_interval
             && self.sampling == other.sampling
+            && self.suppress_interactive_oauth == other.suppress_interactive_oauth
     }
 }
 
@@ -287,6 +296,7 @@ impl McpServerConfig {
             keepalive_interval: None,
             sampling: None,
             auth_provider: None,
+            suppress_interactive_oauth: false,
         }
     }
 
@@ -301,6 +311,7 @@ impl McpServerConfig {
             keepalive_interval: None,
             sampling: None,
             auth_provider: None,
+            suppress_interactive_oauth: false,
         }
     }
 
@@ -331,6 +342,13 @@ impl McpServerConfig {
     /// Set an authentication provider for remote servers.
     pub fn with_auth(mut self, provider: Arc<dyn McpAuthProvider>) -> Self {
         self.auth_provider = Some(provider);
+        self
+    }
+
+    /// Mark this config as running in background discovery, where OAuth must
+    /// fail soft instead of prompting on stdin.
+    pub fn with_interactive_oauth_suppressed(mut self) -> Self {
+        self.suppress_interactive_oauth = true;
         self
     }
 

--- a/crates/hermes-mcp/src/client/client_impl.rs
+++ b/crates/hermes-mcp/src/client/client_impl.rs
@@ -776,6 +776,7 @@ impl McpClient {
                 command,
                 &self.config.args,
                 &self.config.env,
+                self.config.suppress_interactive_oauth,
             )))
         } else if self.config.is_http() {
             let url = self

--- a/crates/hermes-mcp/src/client/manager.rs
+++ b/crates/hermes-mcp/src/client/manager.rs
@@ -295,6 +295,7 @@ impl McpManager {
                 continue;
             }
 
+            let config = config.with_interactive_oauth_suppressed();
             let sampling_config = self.sampling_config.clone();
             let sampling_callback = self.sampling_callback.clone();
             tasks.spawn(async move {

--- a/crates/hermes-mcp/src/transport.rs
+++ b/crates/hermes-mcp/src/transport.rs
@@ -308,21 +308,45 @@ pub struct StdioTransport {
     child: Option<Child>,
     /// Background task draining child stderr to an MCP log file.
     stderr_drain_task: Option<JoinHandle<()>>,
+    /// Background discovery should not let OAuth helpers prompt on stdin.
+    suppress_interactive_oauth: bool,
     /// Whether the transport has been started.
     started: bool,
 }
 
 impl StdioTransport {
     /// Create a new stdio transport for the given command.
-    pub fn new(command: impl Into<String>, args: &[String], env: &HashMap<String, String>) -> Self {
+    pub fn new(
+        command: impl Into<String>,
+        args: &[String],
+        env: &HashMap<String, String>,
+        suppress_interactive_oauth: bool,
+    ) -> Self {
         Self {
             command: command.into(),
             args: args.to_vec(),
             env: env.clone(),
             child: None,
             stderr_drain_task: None,
+            suppress_interactive_oauth,
             started: false,
         }
+    }
+
+    fn effective_child_env(&self, profile: McpSandboxProfile) -> HashMap<String, String> {
+        let mut env = sanitize_child_env(&self.env, profile);
+        if self.suppress_interactive_oauth {
+            env.insert(
+                "HERMES_MCP_BACKGROUND_DISCOVERY".to_string(),
+                "1".to_string(),
+            );
+            env.insert(
+                "HERMES_MCP_SUPPRESS_INTERACTIVE_OAUTH".to_string(),
+                "1".to_string(),
+            );
+            env.insert("MCP_NONINTERACTIVE".to_string(), "1".to_string());
+        }
+        env
     }
 }
 
@@ -349,7 +373,7 @@ impl McpTransport for StdioTransport {
                 }
             )));
         }
-        let sanitized_env = sanitize_child_env(&self.env, sandbox_profile);
+        let sanitized_env = self.effective_child_env(sandbox_profile);
 
         info!(
             "Starting MCP stdio transport: {} {:?}",
@@ -1006,10 +1030,41 @@ mod tests {
     #[test]
     fn test_stdio_transport_new() {
         let env = HashMap::new();
-        let transport = StdioTransport::new("echo", &[], &env);
+        let transport = StdioTransport::new("echo", &[], &env, false);
         assert_eq!(transport.command, "echo");
         assert!(transport.args.is_empty());
+        assert!(!transport.suppress_interactive_oauth);
         assert!(!transport.started);
+    }
+
+    #[test]
+    fn stdio_transport_marks_background_discovery_noninteractive() {
+        let mut env = HashMap::new();
+        env.insert("PATH".to_string(), "/bin".to_string());
+        let manual = StdioTransport::new("echo", &[], &env, false);
+        let background = StdioTransport::new("echo", &[], &env, true);
+
+        assert!(!manual
+            .effective_child_env(McpSandboxProfile::Balanced)
+            .contains_key("HERMES_MCP_SUPPRESS_INTERACTIVE_OAUTH"));
+
+        let child_env = background.effective_child_env(McpSandboxProfile::Balanced);
+        assert_eq!(
+            child_env
+                .get("HERMES_MCP_BACKGROUND_DISCOVERY")
+                .map(String::as_str),
+            Some("1")
+        );
+        assert_eq!(
+            child_env
+                .get("HERMES_MCP_SUPPRESS_INTERACTIVE_OAUTH")
+                .map(String::as_str),
+            Some("1")
+        );
+        assert_eq!(
+            child_env.get("MCP_NONINTERACTIVE").map(String::as_str),
+            Some("1")
+        );
     }
 
     #[test]

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 60.0,
+        "actual": 48.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "pass"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-29T22:48:59.172725+00:00",
+  "generated_at_utc": "2026-06-30T00:03:35.832910+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 60.0,
+    "max_queue_pending_commits": 48.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,9 +299,9 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 97,
-      "pending": 60,
-      "ported": 511,
-      "superseded": 6976
+      "pending": 48,
+      "ported": 514,
+      "superseded": 6985
     },
     "by_target_ticket": {
       "20": 3489,
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 60.0,
+        "actual": 48.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-29T22:48:59.172725+00:00`
+Generated: `2026-06-30T00:03:35.832910+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-29T22:48:59.172725+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 60.0 |
+| `max_queue_pending_commits` | 48.0 |
 
 ## GPAR Ticket Completion
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -6403,6 +6403,66 @@
       "disposition": "ported",
       "owner": "rust-runtime",
       "notes": "Ported in Rust Telegram intake: unauthorized users are rejected in should_process_update before TelegramAdapter::parse_update and before CLI text batching/route_message. The model now includes sender_chat for from-less channel-post authorization, and tests cover unauthorized users, allowed group senders, callback tap users, and sender_chat allowlists."
+    },
+    "e55ddc3e33b28cf036371b8d81c73109521ac3f1": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported as Rust MCP background-discovery noninteractive guard: McpManager::connect_all_parallel now marks spawned discovery configs with a runtime-only suppress_interactive_oauth flag, and StdioTransport injects HERMES_MCP_BACKGROUND_DISCOVERY/HERMES_MCP_SUPPRESS_INTERACTIVE_OAUTH/MCP_NONINTERACTIVE into child env without changing normal explicit MCP connect/login paths. Transport test covers marker isolation."
+    },
+    "11b0be8d15fc18f6a6741317cbb3f197ac7df989": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust Matrix sync: pending invite rooms are scheduled as detached, deduped auto-join tasks with a timeout instead of blocking sync_once/gateway readiness. Wiremock test proves sync_once returns before a delayed join finishes and duplicate pending joins only issue one join request."
+    },
+    "14baeefe1d0b80e67429ffb47934acc4cd399fd1": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust Matrix invite handling: direct invite metadata from invite_state is carried into the detached join request, and successful direct invite joins persist m.direct account data for the inviter/room so future identity classification can use direct-room account state. Focused test covers m.direct append/write behavior."
+    },
+    "244a6f2ceb7f58c16b3cb2186584c39524e37874": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Superseded by local Rust-first product shape: upstream fixes an Electron desktop Open setup guide button plus Python web_server route, but this repo has no apps/desktop or shipped Python web_server runtime. Rust CLI/TUI/gateway docs and setup surfaces own plugin setup guidance."
+    },
+    "fc86e35764f7b339d505092dbad3686cfa44c576": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Superseded by local Rust-first product shape: upstream remote desktop git cockpit depends on apps/desktop React stores and Python web_git/web_server endpoints absent from the shipped Rust runtime. Rust CLI/TUI/tool surfaces own git and project workflows without the Electron cockpit."
+    },
+    "4e9439cc3b33d74ad511f320dc1c5c0a66423127": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Superseded by local Rust-first product shape: upstream composer context picking through remote-aware desktop FS is an apps/desktop React behavior. This repo has no apps/desktop runtime; Rust CLI/TUI context and file access are mediated through typed tools and session state instead."
+    },
+    "453f134b3bc213f05db52b22c6a0eb18ef115339": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Superseded by local Rust-first product shape: upstream centralizes desktop remote-git REST routing across apps/desktop and Python web_server surfaces that are absent from the shipped Rust runtime. Rust project/git operations remain CLI/TUI/tool owned."
+    },
+    "db16854f343c67548933ac2e0e1d4d586bdeaaa6": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Superseded by Rust Telegram inbound-media design: the adapter does not silently download/cache user attachments before dispatch. It preserves Telegram file IDs and bounded metadata on IncomingMessage, and oversized documents/videos are dropped by size gates with tests, so the upstream Python empty-turn-on-download-failure path is absent."
+    },
+    "3f543229f28c6a0fb588a73f093b85a183d86595": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Superseded by Rust gateway clarify shape: Telegram does not implement the upstream cl:<id> clarify inline-button protocol, so there is no stale clarify button tap to expire. Rust gateway clarify is queued through ChannelClarifyBackend and answered by the next user message, while Telegram approval callbacks already alert when no pending approval exists."
+    },
+    "2ecb6f7fe60f6a240d632bbd51bcbb25ad22c161": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Superseded by Rust direct Bot API polling: there is no PTB _send_path_degraded flag or deferred heartbeat gate. Successful getUpdates clears Rust backoff/error counters immediately, while sustained polling failures or 409 conflicts mark the adapter unhealthy for the gateway watcher."
+    },
+    "7e2ca7f68da63a29e1695b5e24901cc57e32f2ac": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Superseded by Rust Telegram HTTP transport: outbound sends use a reqwest client and do not expose PTB's bot._request[1] general request pool that can be shutdown/reinitialized after a Python pool timeout. No Rust send pool reset hook exists or is needed for that Python-specific failure mode."
+    },
+    "d5ba374c038a99db99e3036d938271e70a6930fd": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Superseded by Rust direct polling: there is no PTB updater.running=true/consumer-task-dead split. Rust owns the getUpdates request directly with a timeout bounded by TELEGRAM_POLL_STALL_GRACE_SECONDS, exponential backoff, consecutive-error health gates, and immediate 409 conflict fail-closed tests."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-29T22:48:58.977453+00:00`
+Generated: `2026-06-30T00:03:35.518867+00:00`
 
 - Range: `main..upstream/main`; total commits tracked: `7644`.
 
@@ -17,16 +17,14 @@ Generated: `2026-06-29T22:48:58.977453+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 97 |
-| pending | 60 |
-| ported | 511 |
-| superseded | 6976 |
+| pending | 48 |
+| ported | 514 |
+| superseded | 6985 |
 
 ## First 100 Pending Commits
 
 | SHA | Ticket | Subject |
 | --- | ---: | --- |
-| `244a6f2ceb7f` | #20 | fix(desktop): broken "Open setup guide" button for plugin platforms |
-| `e55ddc3e33b2` | #20 | fix(mcp): suppress interactive OAuth stdin prompts during background discovery (#35927) |
 | `dbe734beff0c` | #20 | fix(dashboard-auth): exclude non-interactive providers from interactive login surfaces (#53239) |
 | `fbf748b28247` | #20 | fix(dashboard-auth): follow redirects on self-hosted OIDC discovery (#53399) |
 | `5636c22828b0` | #20 | feat(photon): upgrade spectrum-ts sidecar to v7.0.0 |
@@ -46,21 +44,14 @@ Generated: `2026-06-29T22:48:58.977453+00:00`
 | `d3d621f7c38b` | #20 | revert(windows): roll back terminal-popup PRs #53791 #53810 #53829 (#53853) |
 | `163cb24d45d8` | #22 | feat(moa): render reference-model blocks in TUI and desktop, not just CLI (#53855) |
 | `a94f657a5059` | #20 | fix(tui): route completion RPCs to the pool so they can't freeze the TUI (#53895) |
-| `db16854f343c` | #20 | fix(telegram): surface failed media downloads to user and agent, not a silent empty turn (#53912) |
 | `6f1a176b3309` | #20 | fix(gateway/discord): REST liveness probe to detect zombie clients (#26656) |
 | `9c6229ce249e` | #20 | fix(security): centralize credential-safe subprocess env (#29157) |
-| `11b0be8d15fc` | #20 | fix(gateway): avoid Matrix pending invite boot loops |
 | `d43e0cf304a1` | #20 | fix(agent): config-driven intent-ack continuation for all api_modes (#27881) (#53943) |
 | `a8c862900b9c` | #20 | fix(tui): sanitize replay history on WebUI/TUI session resume (#29086) (#53939) |
-| `3f543229f28c` | #20 | fix(telegram): notify user when clarify button tap arrives after expiry |
 | `c9df4bc094fb` | #20 | fix(gateway): default restart_drain_timeout to 0 to kill systemd crash loop (#54066) |
-| `2ecb6f7fe60f` | #20 | fix(telegram): clear send_path_degraded on successful reconnect (#35205) (#54076) |
-| `7e2ca7f68da6` | #20 | fix(telegram): reset send pool after pool timeouts |
 | `fde1c8570ffe` | #20 | fix(tui_gateway): suppress WS peer-hangup teardown error flood (#50005) (#54126) |
-| `14baeefe1d0b` | #20 | fix(matrix): record DM rooms in m.direct on invite to prevent group misclassification |
 | `7c0a5def58fb` | #23 | fix(memory/holographic): close DB connection on shutdown instead of leaking to GC (#54133) |
 | `6d879d486b19` | #20 | fix(dashboard): close PTY WebSocket on child EOF to stop FD leak (#54028) (#54123) |
-| `d5ba374c038a` | #20 | fix(telegram): detect wedged getUpdates consumer via pending_update_count |
 | `5c2c85c5452f` | #20 | fix(tui): start MCP discovery for websocket sessions |
 | `61622bb56a7a` | #20 | fix(tui): use role=user for model switch marker to avoid HTTP 400 on strict providers (#48338) |
 | `cb982ad997c5` | #20 | fix(windows): hide console-window flash on backend git/gh/wmic/bash subprocess spawns |
@@ -68,9 +59,6 @@ Generated: `2026-06-29T22:48:58.977453+00:00`
 | `eeca59f48919` | #20 | fix(windows): hide remaining backend console-flash legs missed on main |
 | `a10727a555ad` | #26 | fix(browser): extend first-open timeout and surface daemon errors |
 | `7bb8aa3bd55d` | #20 | test(browser): cover open timeout diagnostics and failed navigate title |
-| `fc86e35764f7` | #20 | feat(desktop): make the git cockpit work over a remote gateway |
-| `4e9439cc3b33` | #20 | fix(desktop): route composer context picking through remote-aware fs |
-| `453f134b3bc2` | #26 | refactor(desktop): centralize remote git REST routing |
 | `b31b0b9d95d1` | #22 | docs: reconcile docs with code across last 3 releases (#54254) |
 | `9a0010fd469f` | #20 | fix(windows): cover remaining console-flash spawn legs (#54417) |
 | `e5d22ab80d97` | #20 | fix(daytona): quote single-upload mkdir parent path (#54440) |


### PR DESCRIPTION
## Summary
- Port Rust MCP background-discovery OAuth prompt suppression for parallel stdio discovery.
- Port Matrix invite auto-join as detached/deduped timeout-bound work, preventing stale invite joins from blocking sync readiness.
- Persist Matrix direct invite joins into `m.direct` account data after successful auto-join.
- Evidence-classify absent/superseded desktop and Telegram Python/PTB-only deltas, then regenerate parity artifacts.

## Parity Delta
- Before this branch: `pending=60` at branch start.
- After regeneration: `pending=48`, `ported=514`, `superseded=6985`, `mirrored=97`.
- Closed 12 upstream delta rows in this batch: 3 ported Rust runtime rows and 9 superseded by Rust-first product/runtime evidence.

## Verification
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo fmt --all --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `jq empty docs/parity/queue-overrides.json docs/parity/upstream-missing-queue.json docs/parity/global-parity-proof.json`
- `git diff --check`
- `test ! -d target`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-gateway --features matrix --lib platforms::matrix -- --nocapture` -> `30 passed; 0 failed`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-mcp stdio_transport_marks_background_discovery_noninteractive -- --nocapture` -> `1 passed; 0 failed`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-gateway --features telegram --lib platforms::telegram -- --nocapture` -> `92 passed; 0 failed`

## Notes
- Full clippy warning gate was not rerun in this branch because the repo script is workspace/all-targets only and the current change is covered by focused Rust tests plus formatting/static guards. No repo-local `target` directory was created.
