### PR TITLE
parity(memory): close provider setup deltas

### DIFF
--- a/crates/hermes-agent/src/memory_plugins/byterover.rs
+++ b/crates/hermes-agent/src/memory_plugins/byterover.rs
@@ -9,6 +9,8 @@
 //! Configuration:
 //!   - `brv` CLI must be installed (npm install -g byterover-cli)
 //!   - `BRV_API_KEY` (optional, for cloud sync)
+//!   - `$HERMES_HOME/byterover.json` with `auto_extract: false` disables
+//!     background turn/memory/compression curation while keeping tools enabled.
 //!   - Working directory: `$HERMES_HOME/byterover/`
 
 use std::process::Command;
@@ -17,11 +19,43 @@ use std::sync::Mutex;
 use serde_json::{json, Value};
 
 use crate::memory_manager::MemoryProviderPlugin;
+use crate::memory_plugins::config_io;
 
 const QUERY_TIMEOUT_SECS: u64 = 10;
 const CURATE_TIMEOUT_SECS: u64 = 120;
 const MIN_QUERY_LEN: usize = 10;
 const MIN_OUTPUT_LEN: usize = 20;
+
+fn coerce_bool(value: Option<&Value>, default: bool) -> bool {
+    match value {
+        Some(Value::Bool(value)) => *value,
+        Some(Value::Number(value)) => value.as_i64().map(|n| n != 0).unwrap_or(default),
+        Some(Value::String(value)) => match value.trim().to_ascii_lowercase().as_str() {
+            "1" | "true" | "yes" | "on" => true,
+            "0" | "false" | "no" | "off" => false,
+            _ => default,
+        },
+        _ => default,
+    }
+}
+
+fn byterover_config_path_for_home(hermes_home: &str) -> std::path::PathBuf {
+    std::path::Path::new(hermes_home).join("byterover.json")
+}
+
+fn default_byterover_config_path() -> std::path::PathBuf {
+    config_io::default_hermes_home().join("byterover.json")
+}
+
+fn load_auto_extract(hermes_home: &str) -> bool {
+    for key in ["HERMES_BYTEROVER_AUTO_EXTRACT", "BYTEROVER_AUTO_EXTRACT"] {
+        if let Ok(value) = std::env::var(key) {
+            return coerce_bool(Some(&Value::String(value)), true);
+        }
+    }
+    let config = config_io::read_json_object(&byterover_config_path_for_home(hermes_home));
+    coerce_bool(config.get("auto_extract"), true)
+}
 
 // ---------------------------------------------------------------------------
 // Tool schemas
@@ -132,6 +166,7 @@ pub struct ByteRoverPlugin {
     cwd: Mutex<String>,
     session_id: Mutex<String>,
     turn_count: Mutex<u32>,
+    auto_extract: Mutex<bool>,
 }
 
 impl ByteRoverPlugin {
@@ -140,11 +175,16 @@ impl ByteRoverPlugin {
             cwd: Mutex::new(String::new()),
             session_id: Mutex::new(String::new()),
             turn_count: Mutex::new(0),
+            auto_extract: Mutex::new(true),
         }
     }
 
     fn working_dir(&self) -> String {
         self.cwd.lock().unwrap().clone()
+    }
+
+    fn auto_extract_enabled(&self) -> bool {
+        *self.auto_extract.lock().unwrap()
     }
 }
 
@@ -167,6 +207,7 @@ impl MemoryProviderPlugin for ByteRoverPlugin {
         *self.cwd.lock().unwrap() = cwd;
         *self.session_id.lock().unwrap() = session_id.to_string();
         *self.turn_count.lock().unwrap() = 0;
+        *self.auto_extract.lock().unwrap() = load_auto_extract(hermes_home);
 
         tracing::info!(
             "ByteRover memory plugin initialized for session {}",
@@ -210,6 +251,10 @@ impl MemoryProviderPlugin for ByteRoverPlugin {
     fn sync_turn(&self, user_content: &str, assistant_content: &str, _session_id: &str) {
         *self.turn_count.lock().unwrap() += 1;
 
+        if !self.auto_extract_enabled() {
+            tracing::debug!("ByteRover sync_turn skipped because auto_extract is disabled");
+            return;
+        }
         if user_content.trim().len() < MIN_QUERY_LEN {
             return;
         }
@@ -232,6 +277,10 @@ impl MemoryProviderPlugin for ByteRoverPlugin {
     }
 
     fn on_memory_write(&self, action: &str, target: &str, content: &str) {
+        if !self.auto_extract_enabled() {
+            tracing::debug!("ByteRover memory mirror skipped because auto_extract is disabled");
+            return;
+        }
         if !matches!(action, "add" | "replace") || content.is_empty() {
             return;
         }
@@ -254,6 +303,12 @@ impl MemoryProviderPlugin for ByteRoverPlugin {
     }
 
     fn on_pre_compress(&self, messages: &[Value]) -> String {
+        if !self.auto_extract_enabled() {
+            tracing::debug!(
+                "ByteRover pre-compression curation skipped because auto_extract is disabled"
+            );
+            return String::new();
+        }
         if messages.is_empty() {
             return String::new();
         }
@@ -341,18 +396,47 @@ impl MemoryProviderPlugin for ByteRoverPlugin {
 
     fn get_config_schema(&self) -> Option<Value> {
         Some(json!([
-            {"key": "api_key", "description": "ByteRover API key (optional, for cloud sync)", "secret": true, "env_var": "BRV_API_KEY", "url": "https://app.byterover.dev"}
+            {"key": "api_key", "description": "ByteRover API key (optional, for cloud sync)", "secret": true, "env_var": "BRV_API_KEY", "url": "https://app.byterover.dev"},
+            {"key": "auto_extract", "description": "Automatically curate completed turns, explicit memory writes, and pre-compression context", "default": true, "choices": ["true", "false"]}
         ]))
     }
 
-    fn save_config(&self, _config: &Value) -> Result<(), String> {
-        Ok(())
+    fn save_config(&self, config: &Value) -> Result<(), String> {
+        config_io::merge_and_write_owner_only(&default_byterover_config_path(), config)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
 
     #[test]
     fn test_byterover_plugin_name() {
@@ -394,5 +478,46 @@ mod tests {
         // Not initialized, should return error
         let result = plugin.handle_tool_call("brv_query", &json!({"query": "test"}));
         assert!(result.contains("error"));
+    }
+
+    #[test]
+    fn test_byterover_auto_extract_config_coerces_values() {
+        assert!(!coerce_bool(Some(&json!(false)), true));
+        assert!(!coerce_bool(Some(&json!("off")), true));
+        assert!(coerce_bool(Some(&json!("yes")), false));
+        assert!(coerce_bool(None, true));
+    }
+
+    #[test]
+    fn test_byterover_initialize_honors_auto_extract_config() {
+        let _guard = config_io::TEST_ENV_LOCK.lock().expect("env lock");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _home = EnvGuard::set("HERMES_HOME", tmp.path());
+        let _hermes_override = EnvGuard::remove("HERMES_BYTEROVER_AUTO_EXTRACT");
+        let _byterover_override = EnvGuard::remove("BYTEROVER_AUTO_EXTRACT");
+        std::fs::write(
+            tmp.path().join("byterover.json"),
+            r#"{"auto_extract": false}"#,
+        )
+        .expect("write config");
+
+        let plugin = ByteRoverPlugin::new();
+        plugin.initialize("session-1", tmp.path().to_str().expect("tmp"));
+
+        assert!(!plugin.auto_extract_enabled());
+    }
+
+    #[test]
+    fn test_byterover_config_schema_exposes_auto_extract() {
+        let plugin = ByteRoverPlugin::new();
+        let schema = plugin.get_config_schema().expect("schema");
+        let keys = schema
+            .as_array()
+            .expect("schema array")
+            .iter()
+            .filter_map(|entry| entry.get("key").and_then(Value::as_str))
+            .collect::<Vec<_>>();
+
+        assert!(keys.contains(&"auto_extract"));
     }
 }

--- a/crates/hermes-agent/src/memory_plugins/holographic.rs
+++ b/crates/hermes-agent/src/memory_plugins/holographic.rs
@@ -757,4 +757,17 @@ mod tests {
         assert_eq!(id1, id2);
         assert_eq!(plugin.fact_count(), 1);
     }
+
+    #[test]
+    fn test_shutdown_drops_sqlite_connection() {
+        let tmp = tempfile::tempdir().unwrap();
+        let plugin = HolographicMemoryPlugin::new();
+        plugin.initialize("test-session", tmp.path().to_str().unwrap());
+        assert!(plugin.with_conn(|conn| conn.is_autocommit()).is_some());
+
+        plugin.shutdown();
+
+        assert!(plugin.with_conn(|conn| conn.is_autocommit()).is_none());
+        assert_eq!(plugin.fact_count(), 0);
+    }
 }

--- a/crates/hermes-agent/src/memory_plugins/supermemory.rs
+++ b/crates/hermes-agent/src/memory_plugins/supermemory.rs
@@ -19,6 +19,7 @@ use crate::memory_plugins::config_io;
 const DEFAULT_CONTAINER_TAG: &str = "hermes";
 const DEFAULT_MAX_RECALL: usize = 10;
 const DEFAULT_BASE_URL: &str = "https://api.supermemory.ai";
+const SUPERMEMORY_API_KEY_URL: &str = "https://app.supermemory.ai/integrations?connect=hermes";
 const SUPERMEMORY_SOURCE: &str = "hermes";
 
 // ---------------------------------------------------------------------------
@@ -120,6 +121,11 @@ impl SupermemoryConfig {
         let config_path = std::path::Path::new(hermes_home).join("supermemory.json");
         if let Ok(content) = std::fs::read_to_string(&config_path) {
             if let Ok(raw) = serde_json::from_str::<Value>(&content) {
+                if let Some(api_key) = raw.get("api_key").and_then(|v| v.as_str()) {
+                    if !api_key.trim().is_empty() {
+                        config.api_key = api_key.trim().to_string();
+                    }
+                }
                 if let Some(tag) = raw.get("container_tag").and_then(|v| v.as_str()) {
                     if !tag.is_empty() {
                         config.container_tag = sanitize_tag(tag);
@@ -770,10 +776,12 @@ impl MemoryProviderPlugin for SupermemoryMemoryPlugin {
 
     fn get_config_schema(&self) -> Option<Value> {
         Some(json!([
-            {"key": "api_key", "description": "Supermemory API key", "secret": true, "required": true, "env_var": "SUPERMEMORY_API_KEY", "url": "https://supermemory.ai"},
+            {"key": "api_key", "description": "Supermemory API key", "secret": true, "required": true, "env_var": "SUPERMEMORY_API_KEY", "url": SUPERMEMORY_API_KEY_URL},
             {"key": "base_url", "description": "Supermemory API base URL", "default": DEFAULT_BASE_URL},
             {"key": "container_tag", "description": "Container tag", "default": DEFAULT_CONTAINER_TAG},
-            {"key": "search_mode", "description": "hybrid|memories|documents", "default": "hybrid"}
+            {"key": "search_mode", "description": "hybrid|memories|documents", "default": "hybrid"},
+            {"key": "auto_recall", "description": "Automatically inject relevant Supermemory context before turns", "default": true, "choices": ["true", "false"]},
+            {"key": "auto_capture", "description": "Automatically capture completed turns and explicit memory writes", "default": true, "choices": ["true", "false"]}
         ]))
     }
 
@@ -899,6 +907,46 @@ mod tests {
         .expect("write config");
 
         assert!(SupermemoryMemoryPlugin::new().is_available());
+    }
+
+    #[test]
+    fn test_supermemory_initialize_reads_api_key_from_config_file() {
+        let _guard = config_io::TEST_ENV_LOCK.lock().expect("env lock");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _home = EnvGuard::set("HERMES_HOME", tmp.path());
+        let _api = EnvGuard::remove("SUPERMEMORY_API_KEY");
+        std::fs::write(
+            tmp.path().join("supermemory.json"),
+            r#"{"api_key":"sm-file-secret","container_tag":"my-tag"}"#,
+        )
+        .expect("write config");
+
+        let plugin = SupermemoryMemoryPlugin::new();
+        plugin.initialize("session-1", tmp.path().to_str().expect("tmp"));
+
+        assert!(*plugin.active.lock().expect("active"));
+        let config = plugin.config_snapshot().expect("config");
+        assert_eq!(config.api_key, "sm-file-secret");
+        assert_eq!(config.container_tag, "my_tag");
+    }
+
+    #[test]
+    fn test_supermemory_config_schema_uses_integration_url_and_auto_flags() {
+        let schema = SupermemoryMemoryPlugin::new()
+            .get_config_schema()
+            .expect("schema");
+        let entries = schema.as_array().expect("schema array");
+        let api_key = entries
+            .iter()
+            .find(|entry| entry.get("key").and_then(Value::as_str) == Some("api_key"))
+            .expect("api key schema");
+        assert_eq!(api_key["url"], SUPERMEMORY_API_KEY_URL);
+        let keys = entries
+            .iter()
+            .filter_map(|entry| entry.get("key").and_then(Value::as_str))
+            .collect::<Vec<_>>();
+        assert!(keys.contains(&"auto_recall"));
+        assert!(keys.contains(&"auto_capture"));
     }
 
     #[test]

--- a/crates/hermes-cli/src/commands/command_cli_plugins_memory_mcp/memory_setup.rs
+++ b/crates/hermes-cli/src/commands/command_cli_plugins_memory_mcp/memory_setup.rs
@@ -40,6 +40,15 @@ fn memory_setup_label_is_secret(label: &str) -> bool {
         || lower.contains("secret")
 }
 
+fn memory_setup_bool_value(raw: &str, default: bool) -> bool {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => true,
+        "0" | "false" | "no" | "off" => false,
+        "" => default,
+        _ => default,
+    }
+}
+
 fn active_honcho_host_key_for_cli() -> String {
     if let Ok(explicit) = std::env::var("HERMES_HONCHO_HOST") {
         let explicit = explicit.trim();
@@ -268,6 +277,79 @@ fn setup_mem0_provider(yes: bool) -> Result<PathBuf, AgentError> {
         .save_config(&config)
         .map_err(AgentError::Config)?;
     Ok(hermes_config::hermes_home().join("mem0.json"))
+}
+
+fn setup_supermemory_provider(yes: bool) -> Result<PathBuf, AgentError> {
+    const API_KEY_URL: &str = "https://app.supermemory.ai/integrations?connect=hermes";
+
+    let api_key_default = std::env::var("SUPERMEMORY_API_KEY").unwrap_or_default();
+    let base_url_default = std::env::var("SUPERMEMORY_BASE_URL")
+        .unwrap_or_else(|_| "https://api.supermemory.ai".to_string());
+    let container_default =
+        std::env::var("SUPERMEMORY_CONTAINER_TAG").unwrap_or_else(|_| "hermes".to_string());
+
+    if !yes {
+        println!("Get your Supermemory API key at {API_KEY_URL}");
+    }
+    let api_key =
+        prompt_memory_setup_value("Supermemory API key", Some(&api_key_default), yes)?;
+    if api_key.trim().is_empty() {
+        return Err(AgentError::Config(format!(
+            "Supermemory setup requires SUPERMEMORY_API_KEY or an API key from {API_KEY_URL}."
+        )));
+    }
+    let base_url = prompt_memory_setup_value("Supermemory API base URL", Some(&base_url_default), yes)?;
+    let container_tag =
+        prompt_memory_setup_value("Supermemory container tag", Some(&container_default), yes)?;
+    let auto_recall = memory_setup_bool_value(
+        &prompt_memory_setup_value("Supermemory auto_recall (true|false)", Some("true"), yes)?,
+        true,
+    );
+    let auto_capture = memory_setup_bool_value(
+        &prompt_memory_setup_value("Supermemory auto_capture (true|false)", Some("true"), yes)?,
+        true,
+    );
+
+    let config = serde_json::json!({
+        "api_key": api_key,
+        "base_url": base_url,
+        "container_tag": container_tag,
+        "auto_recall": auto_recall,
+        "auto_capture": auto_capture,
+        "search_mode": "hybrid"
+    });
+    hermes_agent::memory_plugins::supermemory::SupermemoryMemoryPlugin::new()
+        .save_config(&config)
+        .map_err(AgentError::Config)?;
+
+    let container = config
+        .get("container_tag")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("hermes");
+    println!(
+        "Supermemory setup summary: container={container}, auto_recall={}, auto_capture={}",
+        if auto_recall { "on" } else { "off" },
+        if auto_capture { "on" } else { "off" }
+    );
+    Ok(hermes_config::hermes_home().join("supermemory.json"))
+}
+
+fn setup_byterover_provider(yes: bool) -> Result<PathBuf, AgentError> {
+    let api_key_default = std::env::var("BRV_API_KEY").unwrap_or_default();
+    let api_key = prompt_memory_setup_value("ByteRover API key", Some(&api_key_default), yes)?;
+    let auto_extract = memory_setup_bool_value(
+        &prompt_memory_setup_value("ByteRover auto_extract (true|false)", Some("true"), yes)?,
+        true,
+    );
+
+    let config = serde_json::json!({
+        "auto_extract": auto_extract,
+        "api_key": api_key
+    });
+    hermes_agent::memory_plugins::byterover::ByteRoverPlugin::new()
+        .save_config(&config)
+        .map_err(AgentError::Config)?;
+    Ok(hermes_config::hermes_home().join("byterover.json"))
 }
 
 fn setup_honcho_provider(yes: bool) -> Result<PathBuf, AgentError> {
@@ -513,12 +595,13 @@ fn setup_openviking_provider(yes: bool) -> Result<PathBuf, AgentError> {
 
 fn setup_memory_provider_target(provider: &str, yes: bool) -> Result<PathBuf, AgentError> {
     match provider.trim().to_ascii_lowercase().as_str() {
+        "byterover" | "brv" => setup_byterover_provider(yes),
         "mem0" => setup_mem0_provider(yes),
+        "supermemory" | "sm" => setup_supermemory_provider(yes),
         "honcho" => setup_honcho_provider(yes),
         "openviking" | "ov" => setup_openviking_provider(yes),
         other => Err(AgentError::Config(format!(
-            "Unsupported memory provider setup target '{other}'. Supported: honcho, mem0, openviking"
+            "Unsupported memory provider setup target '{other}'. Supported: byterover, honcho, mem0, openviking, supermemory"
         ))),
     }
 }
-

--- a/crates/hermes-cli/src/commands/command_tests.rs
+++ b/crates/hermes-cli/src/commands/command_tests.rs
@@ -500,6 +500,57 @@ mod tests {
     }
 
     #[test]
+    fn memory_supermemory_setup_target_writes_runtime_config() {
+        let _guard = env_test_lock();
+        let tmp = tempdir().expect("tempdir");
+        let _home = TempHomeGuard::new(tmp.path());
+        let _api_key = EnvVarGuard::set("SUPERMEMORY_API_KEY", "sm-test-key");
+        let _base_url = EnvVarGuard::set("SUPERMEMORY_BASE_URL", "https://api.supermemory.ai");
+        let _container = EnvVarGuard::set("SUPERMEMORY_CONTAINER_TAG", "hermes-tests");
+
+        let path = setup_memory_provider_target("supermemory", true).expect("setup supermemory");
+
+        assert_eq!(path, tmp.path().join("supermemory.json"));
+        let parsed: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).expect("read config"))
+                .expect("json");
+        assert_eq!(parsed["api_key"], "sm-test-key");
+        assert_eq!(parsed["container_tag"], "hermes-tests");
+        assert!(parsed["auto_recall"].as_bool().expect("auto_recall"));
+        assert!(parsed["auto_capture"].as_bool().expect("auto_capture"));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(&path)
+                    .expect("metadata")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
+    }
+
+    #[test]
+    fn memory_byterover_setup_target_writes_auto_extract_config() {
+        let _guard = env_test_lock();
+        let tmp = tempdir().expect("tempdir");
+        let _home = TempHomeGuard::new(tmp.path());
+        let _api_key = EnvVarGuard::set("BRV_API_KEY", "brv-test-key");
+
+        let path = setup_memory_provider_target("byterover", true).expect("setup byterover");
+
+        assert_eq!(path, tmp.path().join("byterover.json"));
+        let parsed: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).expect("read config"))
+                .expect("json");
+        assert_eq!(parsed["api_key"], "brv-test-key");
+        assert!(parsed["auto_extract"].as_bool().expect("auto_extract"));
+    }
+
+    #[test]
     fn memory_setup_prompt_classifies_secret_labels() {
         assert!(memory_setup_label_is_secret("Mem0 API key"));
         assert!(memory_setup_label_is_secret("Honcho local JWT/API key"));

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 48.0,
+        "actual": 42.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "pass"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-30T00:03:35.832910+00:00",
+  "generated_at_utc": "2026-06-30T00:32:30.870918+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 48.0,
+    "max_queue_pending_commits": 42.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,9 +299,9 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 97,
-      "pending": 48,
-      "ported": 514,
-      "superseded": 6985
+      "pending": 42,
+      "ported": 517,
+      "superseded": 6988
     },
     "by_target_ticket": {
       "20": 3489,
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 48.0,
+        "actual": 42.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-30T00:03:35.832910+00:00`
+Generated: `2026-06-30T00:32:30.870918+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-30T00:03:35.832910+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 48.0 |
+| `max_queue_pending_commits` | 42.0 |
 
 ## GPAR Ticket Completion
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -6463,6 +6463,36 @@
       "disposition": "superseded",
       "owner": "rust-runtime",
       "notes": "Superseded by Rust direct polling: there is no PTB updater.running=true/consumer-task-dead split. Rust owns the getUpdates request directly with a timeout bounded by TELEGRAM_POLL_STALL_GRACE_SECONDS, exponential backoff, consecutive-error health gates, and immediate 409 conflict fail-closed tests."
+    },
+    "dbe734beff0caf5e8ee2acbe4277db7f6cf84a21": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Superseded by Rust runtime scope: this upstream row patches Python dashboard_auth interactive login/provider registry behavior for the drain-secret plugin. Hermes Ultra does not expose a Rust dashboard-auth provider registry or /auth/login surface; token/service credential access is not presented as an interactive Rust login provider."
+    },
+    "fbf748b2824703f11a55bcf4b5ba7a5909c00865": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Superseded by Rust runtime scope: this upstream row patches Python dashboard_auth self-hosted OIDC discovery with httpx follow_redirects. The shipped Rust runtime has no first-class dashboard-auth OIDC discovery/login flow to patch; Python plugin trees remain tracked but outside the Rust runtime surface."
+    },
+    "1b75b3fd90d32e9111607c6331ace49fdc47287a": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported with a higher-quality Rust Supermemory setup surface: setup now supports hermes memory setup supermemory, persists owner-only supermemory.json, exposes the app.supermemory.ai integration URL plus auto_recall/auto_capture schema knobs, prints a deterministic setup summary, and initialize now actually loads api_key from supermemory.json instead of only env."
+    },
+    "52a09d8faf6b3a44da5f3eff3e17f85a4f5ea90c": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust ByteRover: byterover.json and HERMES_BYTEROVER_AUTO_EXTRACT/BYTEROVER_AUTO_EXTRACT now control auto_extract, disabling background turn, explicit memory, and pre-compression curation while leaving brv_curate/brv_query tools available. CLI setup persists owner-only ByteRover config and tests cover config coercion/schema/setup."
+    },
+    "7c0a5def58fbec985ace8c887ca3484f7b8cf584": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported/already covered in Rust Holographic memory: shutdown deterministically drops the rusqlite Connection by clearing the guarded Option instead of relying on later process teardown. Added a focused regression test that initialized connections are gone after shutdown."
+    },
+    "1289f12812a9c6a3f3e6fbdf39e39ed7e1b7bd50": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Superseded by Rust-native memory providers: Mem0 and Supermemory use direct reqwest HTTP clients and compiled Rust code, not optional Python SDK imports. There is no runtime SDK lazy-install step to add; Supermemory setup/config activation was strengthened separately in Rust."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-30T00:03:35.518867+00:00`
+Generated: `2026-06-30T00:32:30.634245+00:00`
 
 - Range: `main..upstream/main`; total commits tracked: `7644`.
 
@@ -17,23 +17,19 @@ Generated: `2026-06-30T00:03:35.518867+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 97 |
-| pending | 48 |
-| ported | 514 |
-| superseded | 6985 |
+| pending | 42 |
+| ported | 517 |
+| superseded | 6988 |
 
 ## First 100 Pending Commits
 
 | SHA | Ticket | Subject |
 | --- | ---: | --- |
-| `dbe734beff0c` | #20 | fix(dashboard-auth): exclude non-interactive providers from interactive login surfaces (#53239) |
-| `fbf748b28247` | #20 | fix(dashboard-auth): follow redirects on self-hosted OIDC discovery (#53399) |
 | `5636c22828b0` | #20 | feat(photon): upgrade spectrum-ts sidecar to v7.0.0 |
 | `4345b3e767c7` | #20 | fix(photon): upgrade spectrum-ts sidecar to v8.0.0 |
 | `882730026739` | #20 | fix(photon): correlate tapbacks to bot message context |
-| `1b75b3fd90d3` | #23 | feat(memory): add Supermemory setup connection summary |
 | `50f685521734` | #20 | feat(moa): make /moa one-shot only; route preset switching through the model picker |
 | `f67c0b3e60ba` | #21 | docs(hermes-agent skill): cover v0.13–v0.17 features, fix stale claims, tighten (#53566) |
-| `52a09d8faf6b` | #23 | fix(byterover): honor auto extract config |
 | `b296915c82c9` | #20 | fix(feishu): route blocking SDK calls through an adapter-owned executor |
 | `7ee0b689739e` | #20 | fix(gateway,feishu): refuse executor resurrection during real shutdown |
 | `cd592c105cbb` | #20 | feat(send_message): native WhatsApp media delivery via Baileys bridge (#53598) |
@@ -50,7 +46,6 @@ Generated: `2026-06-30T00:03:35.518867+00:00`
 | `a8c862900b9c` | #20 | fix(tui): sanitize replay history on WebUI/TUI session resume (#29086) (#53939) |
 | `c9df4bc094fb` | #20 | fix(gateway): default restart_drain_timeout to 0 to kill systemd crash loop (#54066) |
 | `fde1c8570ffe` | #20 | fix(tui_gateway): suppress WS peer-hangup teardown error flood (#50005) (#54126) |
-| `7c0a5def58fb` | #23 | fix(memory/holographic): close DB connection on shutdown instead of leaking to GC (#54133) |
 | `6d879d486b19` | #20 | fix(dashboard): close PTY WebSocket on child EOF to stop FD leak (#54028) (#54123) |
 | `5c2c85c5452f` | #20 | fix(tui): start MCP discovery for websocket sessions |
 | `61622bb56a7a` | #20 | fix(tui): use role=user for model switch marker to avoid HTTP 400 on strict providers (#48338) |
@@ -69,7 +64,6 @@ Generated: `2026-06-30T00:03:35.518867+00:00`
 | `adacb16d6243` | #26 | fix(desktop): make agent terminal tabs fully readable |
 | `dff491a2b993` | #22 | feat(cli): add headless `hermes serve` backend; desktop no longer launches `dashboard` |
 | `476875acb9f0` | #22 | Add dashboard backup upload and download |
-| `1289f12812a9` | #20 | fix(memory): lazy-install supermemory + mem0 SDKs like honcho/hindsight |
 | `34e616e778d0` | #22 | feat(slack): nudge stale installs to add mpim scopes; mark message.mpim required |
 | `fd324562d3ad` | #20 | feat(desktop): add context usage breakdown popover |
 | `290fa7fd2baa` | #20 | fix(gateway): skip confirmed-dead delivery targets (deleted groups, blocked bots) (#55115) |


### PR DESCRIPTION
## Summary
- Add Rust ByteRover `auto_extract` config support with owner-only `byterover.json` persistence and CLI setup target.
- Strengthen Rust Supermemory setup/config: `hermes memory setup supermemory`, integration URL schema, auto_recall/auto_capture schema knobs, owner-only config persistence, and config-file `api_key` activation during initialize.
- Pin Holographic memory shutdown behavior with a deterministic SQLite connection drop regression test.
- Evidence-classify Python-only dashboard-auth and SDK lazy-install rows, then regenerate parity artifacts.

## Parity Delta
- Before this branch: `pending=48`.
- After regeneration: `pending=42`, `ported=517`, `superseded=6988`, `mirrored=97`.
- Closed 6 upstream delta rows in this batch: 3 ported Rust runtime/setup rows and 3 superseded by Rust-native runtime scope.

## Verification
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo fmt --all --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `jq empty docs/parity/queue-overrides.json docs/parity/upstream-missing-queue.json docs/parity/global-parity-proof.json`
- `git diff --check`
- `test ! -d target`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-agent --lib memory_plugins:: -- --nocapture` -> `123 passed; 0 failed`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-cli --lib memory_ -- --nocapture` -> `13 passed; 0 failed`

## Notes
- Rust Mem0/Supermemory use direct HTTP clients and compiled Rust code, so Python SDK lazy-install rows are intentionally superseded, not reintroduced.
- Dashboard-auth rows target Python middleware/plugin OIDC login surfaces; no equivalent first-class Rust dashboard-auth provider registry is exposed in this runtime.
- No repo-local `target` directory was created.
