### PR TITLE
parity(feishu): guard shutdown lifecycle

### DIFF
--- a/crates/hermes-gateway/src/platforms/feishu.rs
+++ b/crates/hermes-gateway/src/platforms/feishu.rs
@@ -7,7 +7,10 @@
 //! - Event subscription verification and incoming message parsing
 //! - Mention detection and stripping
 
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
@@ -226,6 +229,7 @@ pub struct FeishuAdapter {
     client: Client,
     tenant_token: RwLock<Option<CachedToken>>,
     stop_signal: Arc<Notify>,
+    closing: AtomicBool,
 }
 
 impl FeishuAdapter {
@@ -239,11 +243,29 @@ impl FeishuAdapter {
             client,
             tenant_token: RwLock::new(None),
             stop_signal: Arc::new(Notify::new()),
+            closing: AtomicBool::new(false),
         })
     }
 
     pub fn config(&self) -> &FeishuConfig {
         &self.config
+    }
+
+    fn rearm_runtime(&self) {
+        self.closing.store(false, Ordering::SeqCst);
+    }
+
+    fn begin_shutdown(&self) {
+        self.closing.store(true, Ordering::SeqCst);
+    }
+
+    fn ensure_runtime_available(&self, operation: &str) -> Result<(), GatewayError> {
+        if self.closing.load(Ordering::SeqCst) {
+            return Err(GatewayError::Platform(format!(
+                "Feishu adapter is shutting down; {operation} unavailable"
+            )));
+        }
+        Ok(())
     }
 
     // -----------------------------------------------------------------------
@@ -252,6 +274,7 @@ impl FeishuAdapter {
 
     /// Get a valid tenant access token, refreshing automatically when expired.
     pub async fn get_tenant_token(&self) -> Result<String, GatewayError> {
+        self.ensure_runtime_available("tenant token refresh")?;
         {
             let guard = self.tenant_token.read().await;
             if let Some(ref cached) = *guard {
@@ -1282,6 +1305,7 @@ fn format_message(content: &str) -> String {
 impl PlatformAdapter for FeishuAdapter {
     async fn start(&self) -> Result<(), GatewayError> {
         info!("Feishu adapter starting (app_id: {})", self.config.app_id);
+        self.rearm_runtime();
         self.get_tenant_token().await?;
         self.base.mark_running();
         Ok(())
@@ -1289,6 +1313,7 @@ impl PlatformAdapter for FeishuAdapter {
 
     async fn stop(&self) -> Result<(), GatewayError> {
         info!("Feishu adapter stopping");
+        self.begin_shutdown();
         self.base.mark_stopped();
         self.stop_signal.notify_one();
         Ok(())
@@ -1319,6 +1344,7 @@ impl PlatformAdapter for FeishuAdapter {
         file_path: &str,
         caption: Option<&str>,
     ) -> Result<(), GatewayError> {
+        self.ensure_runtime_available("file send")?;
         use crate::platforms::helpers::{media_category, mime_from_extension};
 
         let path = std::path::Path::new(file_path);
@@ -1418,6 +1444,7 @@ impl PlatformAdapter for FeishuAdapter {
         image_url: &str,
         caption: Option<&str>,
     ) -> Result<(), GatewayError> {
+        self.ensure_runtime_available("image-url send")?;
         let downloaded = download_media_url(&self.client, image_url).await;
 
         let (image_bytes, content_type) = match downloaded {

--- a/crates/hermes-gateway/src/platforms/feishu/tests.rs
+++ b/crates/hermes-gateway/src/platforms/feishu/tests.rs
@@ -223,4 +223,51 @@ mod tests {
         assert_eq!(format_message("\n\nhello world\n"), "hello world");
         assert_eq!(format_message("  hello world  "), "hello world");
     }
+
+    #[tokio::test]
+    async fn stop_refuses_outbound_api_until_rearmed() {
+        let adapter = FeishuAdapter::new(FeishuConfig {
+            app_id: "cli_test_app".to_string(),
+            app_secret: "secret".to_string(),
+            verification_token: None,
+            encrypt_key: None,
+            proxy: AdapterProxyConfig::default(),
+        })
+        .expect("adapter");
+
+        adapter.stop().await.expect("stop");
+
+        let err = adapter
+            .send_text("oc_chat", "hello after shutdown")
+            .await
+            .expect_err("send is refused while shutting down");
+        let rendered = err.to_string();
+        assert!(rendered.contains("Feishu adapter is shutting down"));
+        assert!(rendered.contains("tenant token refresh"));
+
+        adapter.rearm_runtime();
+        assert!(!adapter.closing.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn stopped_feishu_file_paths_do_not_touch_local_inputs() {
+        let adapter = FeishuAdapter::new(FeishuConfig {
+            app_id: "cli_test_app".to_string(),
+            app_secret: "secret".to_string(),
+            verification_token: None,
+            encrypt_key: None,
+            proxy: AdapterProxyConfig::default(),
+        })
+        .expect("adapter");
+
+        adapter.stop().await.expect("stop");
+
+        let err = adapter
+            .send_file("oc_chat", "/definitely/missing/file.txt", None)
+            .await
+            .expect_err("shutdown guard wins before local file reads");
+        let rendered = err.to_string();
+        assert!(rendered.contains("Feishu adapter is shutting down"));
+        assert!(rendered.contains("file send"));
+    }
 }

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 42.0,
+        "actual": 40.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "pass"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-30T00:32:30.870918+00:00",
+  "generated_at_utc": "2026-06-30T00:48:32.769059+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 42.0,
+    "max_queue_pending_commits": 40.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,8 +299,8 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 97,
-      "pending": 42,
-      "ported": 517,
+      "pending": 40,
+      "ported": 519,
       "superseded": 6988
     },
     "by_target_ticket": {
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 42.0,
+        "actual": 40.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-30T00:32:30.870918+00:00`
+Generated: `2026-06-30T00:48:32.769059+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-30T00:32:30.870918+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 42.0 |
+| `max_queue_pending_commits` | 40.0 |
 
 ## GPAR Ticket Completion
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -6489,6 +6489,16 @@
       "owner": "rust-runtime",
       "notes": "Ported/already covered in Rust Holographic memory: shutdown deterministically drops the rusqlite Connection by clearing the guarded Option instead of relying on later process teardown. Added a focused regression test that initialized connections are gone after shutdown."
     },
+    "b296915c82c9da02bd6edacf52490e68f85e1f16": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported as a Rust-native Feishu lifecycle guard instead of Python executor plumbing: the adapter has no blocking SDK executor, but stop() now marks the runtime closing and outbound API/token/file/image-url paths refuse work before network or local file IO until start/reconnect re-arms the adapter."
+    },
+    "7ee0b689739e80c75d7c32f42cf2a79a2207c0a0": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust Feishu shutdown semantics: real stop() sets a closing guard so post-shutdown calls cannot resurrect outbound work, while start() clears the guard before reconnect token refresh. Focused async tests cover refusal and re-arm state."
+    },
     "1289f12812a9c6a3f3e6fbdf39e39ed7e1b7bd50": {
       "disposition": "superseded",
       "owner": "rust-runtime",

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-30T00:32:30.634245+00:00`
+Generated: `2026-06-30T00:48:32.546716+00:00`
 
 - Range: `main..upstream/main`; total commits tracked: `7644`.
 
@@ -17,8 +17,8 @@ Generated: `2026-06-30T00:32:30.634245+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 97 |
-| pending | 42 |
-| ported | 517 |
+| pending | 40 |
+| ported | 519 |
 | superseded | 6988 |
 
 ## First 100 Pending Commits
@@ -30,8 +30,6 @@ Generated: `2026-06-30T00:32:30.634245+00:00`
 | `882730026739` | #20 | fix(photon): correlate tapbacks to bot message context |
 | `50f685521734` | #20 | feat(moa): make /moa one-shot only; route preset switching through the model picker |
 | `f67c0b3e60ba` | #21 | docs(hermes-agent skill): cover v0.13–v0.17 features, fix stale claims, tighten (#53566) |
-| `b296915c82c9` | #20 | fix(feishu): route blocking SDK calls through an adapter-owned executor |
-| `7ee0b689739e` | #20 | fix(gateway,feishu): refuse executor resurrection during real shutdown |
 | `cd592c105cbb` | #20 | feat(send_message): native WhatsApp media delivery via Baileys bridge (#53598) |
 | `917f6bdb00b8` | #20 | fix(tools): let vision pick any provider+model, not just OpenRouter (#53606) |
 | `ef17cd204d75` | #20 | fix(windows): stop subprocess console-window popups + add CI guard (#53791) |


### PR DESCRIPTION
## Summary
- add a Rust-native Feishu shutdown guard so outbound API/token/file/image-url work refuses after `stop()` until start/reconnect re-arms the adapter
- cover post-stop refusal before network token refresh and before local file reads
- mark upstream Feishu executor/shutdown rows as ported and regenerate parity artifacts

## Upstream deltas closed
- `b296915c82c9` fix(feishu): route blocking SDK calls through an adapter-owned executor
- `7ee0b689739e` fix(gateway,feishu): refuse executor resurrection during real shutdown

## Verification
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-gateway --features feishu --lib feishu -- --nocapture` -> 19 passed; 0 failed
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo fmt --all --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `jq empty docs/parity/queue-overrides.json docs/parity/upstream-missing-queue.json docs/parity/global-parity-proof.json`
- `git diff --check`
- `test ! -d target`

## Queue delta
- pending: 42 -> 40
- ported: 517 -> 519
