### PR TITLE
parity(browser): improve CDP diagnostics

### DIFF
--- a/crates/hermes-tools/src/backends/browser.rs
+++ b/crates/hermes-tools/src/backends/browser.rs
@@ -12,8 +12,12 @@ use regex::Regex;
 use serde_json::{json, Value};
 use std::net::IpAddr;
 use std::path::Path;
-use std::sync::Arc;
 use std::sync::OnceLock;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use std::time::Duration;
 use tokio::sync::Mutex;
 use url::Url;
 use uuid::Uuid;
@@ -28,6 +32,9 @@ const BROWSER_USE_MANAGED_TIMEOUT_MINUTES: u64 = 5;
 const BROWSER_USE_MANAGED_PROXY_COUNTRY_CODE: &str = "us";
 const FIRECRAWL_BROWSER_BASE_URL_DEFAULT: &str = "https://api.firecrawl.dev";
 const FIRECRAWL_BROWSER_DEFAULT_TTL_SECS: u64 = 300;
+const DEFAULT_CDP_COMMAND_TIMEOUT_SECS: u64 = 30;
+const MIN_CDP_OPEN_TIMEOUT_SECS: u64 = 60;
+const MIN_FIRST_CDP_OPEN_TIMEOUT_SECS: u64 = 120;
 #[cfg(test)]
 const CAMOFOX_STATE_DIR_NAME: &str = "browser_auth";
 #[cfg(test)]
@@ -201,6 +208,87 @@ fn env_bool(name: &str, default: bool) -> bool {
             )
         })
         .unwrap_or(default)
+}
+
+fn env_duration_seconds(name: &str) -> Option<Duration> {
+    let seconds = env_optional_nonempty(name)?.parse::<f64>().ok()?;
+    if seconds.is_finite() && seconds > 0.0 {
+        Some(Duration::from_secs_f64(seconds))
+    } else {
+        None
+    }
+}
+
+fn cdp_command_timeout() -> Duration {
+    env_duration_seconds("HERMES_BROWSER_COMMAND_TIMEOUT_SECONDS")
+        .or_else(|| env_duration_seconds("BROWSER_COMMAND_TIMEOUT"))
+        .unwrap_or_else(|| Duration::from_secs(DEFAULT_CDP_COMMAND_TIMEOUT_SECS))
+}
+
+fn cdp_open_timeout(first_open: bool) -> Duration {
+    let floor_secs = if first_open {
+        MIN_FIRST_CDP_OPEN_TIMEOUT_SECS
+    } else {
+        MIN_CDP_OPEN_TIMEOUT_SECS
+    };
+    cdp_command_timeout().max(Duration::from_secs(floor_secs))
+}
+
+fn duration_label(duration: Duration) -> String {
+    let seconds = duration.as_secs_f64();
+    if (seconds.fract()).abs() < f64::EPSILON {
+        format!("{} seconds", seconds as u64)
+    } else {
+        format!("{seconds:.3} seconds")
+    }
+}
+
+fn browser_cdp_hint(method: &str, detail: &str) -> Vec<&'static str> {
+    let combined = detail.to_ascii_lowercase();
+    let mut hints = vec![
+        "Start Chrome/Chromium with --remote-debugging-port=9222 or set CHROME_CDP_URL/BROWSER_CDP_URL.",
+    ];
+    if method == "Page.navigate" {
+        hints.push("If this was the first browser open, Chrome may still be cold-starting; retry after the daemon is ready.");
+    }
+    if combined.contains("sandbox") || combined.contains("no usable sandbox") {
+        hints.push(
+            "For Docker/root/AppArmor launches, start Chromium with --no-sandbox,--disable-dev-shm-usage.",
+        );
+    }
+    hints
+}
+
+fn format_cdp_timeout_error(method: &str, endpoint: &str, timeout_duration: Duration) -> String {
+    let mut parts = vec![format!(
+        "Browser CDP command '{method}' timed out after {} while contacting {endpoint}.",
+        duration_label(timeout_duration)
+    )];
+    parts.extend(browser_cdp_hint(method, "").into_iter().map(str::to_string));
+    parts.join("\n")
+}
+
+fn tool_error_message(err: ToolError) -> String {
+    match err {
+        ToolError::ExecutionFailed(message)
+        | ToolError::InvalidParams(message)
+        | ToolError::NotFound(message)
+        | ToolError::Timeout(message)
+        | ToolError::SchemaViolation(message) => message,
+    }
+}
+
+fn format_cdp_command_error(method: &str, endpoint: &str, err: ToolError) -> ToolError {
+    let detail = tool_error_message(err);
+    let mut parts = vec![format!(
+        "Browser CDP command '{method}' failed while contacting {endpoint}: {detail}"
+    )];
+    parts.extend(
+        browser_cdp_hint(method, &detail)
+            .into_iter()
+            .map(str::to_string),
+    );
+    ToolError::ExecutionFailed(parts.join("\n"))
 }
 
 fn cdp_override_from_env() -> bool {
@@ -485,6 +573,7 @@ pub struct CdpBrowserBackend {
     /// CDP WebSocket endpoint URL (e.g., ws://localhost:9222/devtools/page/...)
     endpoint: String,
     client: reqwest::Client,
+    first_navigation: AtomicBool,
 }
 
 /// CamoFox anti-detection browser backend (compat layer).

--- a/crates/hermes-tools/src/backends/browser/local_backends.rs
+++ b/crates/hermes-tools/src/backends/browser/local_backends.rs
@@ -21,6 +21,7 @@ impl CdpBrowserBackend {
         Self {
             endpoint,
             client: reqwest::Client::new(),
+            first_navigation: AtomicBool::new(true),
         }
     }
 
@@ -33,7 +34,7 @@ impl CdpBrowserBackend {
     }
 
     /// Send a CDP command via HTTP (simplified - real impl would use WebSocket).
-    async fn cdp_command(&self, method: &str, params: Value) -> Result<Value, ToolError> {
+    async fn cdp_command_http(&self, method: &str, params: Value) -> Result<Value, ToolError> {
         // Get the first available page target
         let targets_resp = self
             .client
@@ -66,15 +67,48 @@ impl CdpBrowserBackend {
             "status": "sent",
         }))
     }
+
+    async fn cdp_command_with_timeout(
+        &self,
+        method: &str,
+        params: Value,
+        timeout_duration: Duration,
+    ) -> Result<Value, ToolError> {
+        match tokio::time::timeout(timeout_duration, self.cdp_command_http(method, params)).await {
+            Ok(Ok(value)) => Ok(value),
+            Ok(Err(err)) => Err(format_cdp_command_error(method, &self.endpoint, err)),
+            Err(_) => Err(ToolError::ExecutionFailed(format_cdp_timeout_error(
+                method,
+                &self.endpoint,
+                timeout_duration,
+            ))),
+        }
+    }
+
+    async fn cdp_command(&self, method: &str, params: Value) -> Result<Value, ToolError> {
+        self.cdp_command_with_timeout(method, params, cdp_command_timeout())
+            .await
+    }
 }
 
 #[async_trait]
 impl BrowserBackend for CdpBrowserBackend {
     async fn navigate(&self, url: &str) -> Result<String, ToolError> {
         validate_url_does_not_exfiltrate_secret(url)?;
+        let first_open = self.first_navigation.swap(false, Ordering::SeqCst);
         let result = self
-            .cdp_command("Page.navigate", json!({"url": url}))
-            .await?;
+            .cdp_command_with_timeout(
+                "Page.navigate",
+                json!({"url": url}),
+                cdp_open_timeout(first_open),
+            )
+            .await
+            .map_err(|err| {
+                ToolError::ExecutionFailed(format!(
+                    "Failed to open {url}: {}",
+                    tool_error_message(err)
+                ))
+            })?;
         Ok(json!({"status": "navigated", "url": url, "cdp": result}).to_string())
     }
 
@@ -268,4 +302,3 @@ impl BrowserBackend for CamoFoxBrowserBackend {
         self.inner.console(action).await
     }
 }
-

--- a/crates/hermes-tools/src/backends/browser/tests.rs
+++ b/crates/hermes-tools/src/backends/browser/tests.rs
@@ -39,6 +39,8 @@ impl EnvScope {
             "BROWSER_CDP_URL",
             "CAMOFOX_REWRITE_LOOPBACK_URLS",
             "CAMOFOX_LOOPBACK_HOST_ALIAS",
+            "HERMES_BROWSER_COMMAND_TIMEOUT_SECONDS",
+            "BROWSER_COMMAND_TIMEOUT",
         ];
         let original = keys.iter().map(|k| (*k, std::env::var(k).ok())).collect();
         for k in &keys {
@@ -678,6 +680,99 @@ fn browser_backend_choice_accepts_browser_cloud_provider() {
     let _scope = EnvScope::new();
     std::env::set_var("BROWSER_CLOUD_PROVIDER", "browserbase");
     assert_eq!(browser_backend_choice_from_env(), "browserbase");
+}
+
+#[test]
+fn browser_cdp_open_timeout_uses_first_open_floor_and_env_ceiling() {
+    let _scope = EnvScope::new();
+
+    std::env::set_var("HERMES_BROWSER_COMMAND_TIMEOUT_SECONDS", "30");
+    assert_eq!(
+        cdp_open_timeout(true),
+        std::time::Duration::from_secs(MIN_FIRST_CDP_OPEN_TIMEOUT_SECS)
+    );
+    assert_eq!(
+        cdp_open_timeout(false),
+        std::time::Duration::from_secs(MIN_CDP_OPEN_TIMEOUT_SECS)
+    );
+
+    std::env::set_var("HERMES_BROWSER_COMMAND_TIMEOUT_SECONDS", "180");
+    assert_eq!(cdp_open_timeout(true), std::time::Duration::from_secs(180));
+    assert_eq!(cdp_open_timeout(false), std::time::Duration::from_secs(180));
+}
+
+#[test]
+fn browser_cdp_timeout_error_includes_actionable_hints() {
+    let rendered = format_cdp_timeout_error(
+        "Page.navigate",
+        "http://127.0.0.1:9222",
+        std::time::Duration::from_secs(120),
+    );
+
+    assert!(rendered.contains("timed out after 120 seconds"));
+    assert!(rendered.contains("http://127.0.0.1:9222"));
+    assert!(rendered.contains("--remote-debugging-port=9222"));
+    assert!(rendered.contains("first browser open"));
+}
+
+#[test]
+fn browser_cdp_command_error_includes_sandbox_hint_when_relevant() {
+    let err = format_cdp_command_error(
+        "Page.navigate",
+        "http://127.0.0.1:9222",
+        ToolError::ExecutionFailed("No usable sandbox!".to_string()),
+    );
+    let rendered = err.to_string();
+
+    assert!(rendered.contains("No usable sandbox"));
+    assert!(rendered.contains("--no-sandbox,--disable-dev-shm-usage"));
+}
+
+#[tokio::test]
+async fn browser_cdp_timeout_path_surfaces_endpoint_and_hints() {
+    use tokio::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    tokio::spawn(async move {
+        let (_stream, _) = listener.accept().await.expect("accept");
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    });
+
+    let backend = CdpBrowserBackend::new(format!("http://{addr}"));
+    let err = backend
+        .cdp_command_with_timeout(
+            "Page.navigate",
+            json!({"url": "https://example.com"}),
+            std::time::Duration::from_millis(25),
+        )
+        .await
+        .expect_err("timeout");
+    let rendered = err.to_string();
+
+    assert!(rendered.contains("timed out after 0.025 seconds"));
+    assert!(rendered.contains(&addr.to_string()));
+    assert!(rendered.contains("--remote-debugging-port=9222"));
+}
+
+#[tokio::test]
+async fn browser_navigate_failure_is_labeled_failed_to_open() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    drop(listener);
+
+    let backend = CdpBrowserBackend::new(format!("http://{addr}"));
+    let err = backend
+        .navigate("https://example.com")
+        .await
+        .expect_err("closed CDP endpoint");
+    let rendered = err.to_string();
+
+    assert!(rendered.contains("Failed to open https://example.com"));
+    assert!(rendered.contains("--remote-debugging-port=9222"));
+    assert!(!backend.first_navigation.load(Ordering::SeqCst));
 }
 
 #[tokio::test]

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 40.0,
+        "actual": 38.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "pass"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-30T00:48:32.769059+00:00",
+  "generated_at_utc": "2026-06-30T00:53:29.633259+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 40.0,
+    "max_queue_pending_commits": 38.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,8 +299,8 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 97,
-      "pending": 40,
-      "ported": 519,
+      "pending": 38,
+      "ported": 521,
       "superseded": 6988
     },
     "by_target_ticket": {
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 40.0,
+        "actual": 38.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-30T00:48:32.769059+00:00`
+Generated: `2026-06-30T00:53:29.633259+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-30T00:48:32.769059+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 40.0 |
+| `max_queue_pending_commits` | 38.0 |
 
 ## GPAR Ticket Completion
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -6499,6 +6499,16 @@
       "owner": "rust-runtime",
       "notes": "Ported in Rust Feishu shutdown semantics: real stop() sets a closing guard so post-shutdown calls cannot resurrect outbound work, while start() clears the guard before reconnect token refresh. Focused async tests cover refusal and re-arm state."
     },
+    "a10727a555ad5e5c4155b3b74d19959c36c436db": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported as Rust CDP diagnostics rather than Python agent-browser daemon plumbing: local browser commands now have bounded CDP timeouts, first-navigation open timeout floors, endpoint/remote-debugging hints, sandbox hints, and browser_navigate failures labeled as Failed to open."
+    },
+    "7bb8aa3bd55d0d4b39bc9e026d780d92fe0b306a": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported with Rust tests for browser open-timeout floors, timeout diagnostics, sandbox hint formatting, bounded CDP timeout behavior, and failed-navigate labeling. The upstream desktop chip text is represented in the Rust tool error surface because this repo does not ship the Electron chip UI."
+    },
     "1289f12812a9c6a3f3e6fbdf39e39ed7e1b7bd50": {
       "disposition": "superseded",
       "owner": "rust-runtime",

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-30T00:48:32.546716+00:00`
+Generated: `2026-06-30T00:53:29.424303+00:00`
 
 - Range: `main..upstream/main`; total commits tracked: `7644`.
 
@@ -17,8 +17,8 @@ Generated: `2026-06-30T00:48:32.546716+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 97 |
-| pending | 40 |
-| ported | 519 |
+| pending | 38 |
+| ported | 521 |
 | superseded | 6988 |
 
 ## First 100 Pending Commits
@@ -50,8 +50,6 @@ Generated: `2026-06-30T00:48:32.546716+00:00`
 | `cb982ad997c5` | #20 | fix(windows): hide console-window flash on backend git/gh/wmic/bash subprocess spawns |
 | `1ffa01f35fb8` | #20 | test(windows): cover no-window backend subprocess flags |
 | `eeca59f48919` | #20 | fix(windows): hide remaining backend console-flash legs missed on main |
-| `a10727a555ad` | #26 | fix(browser): extend first-open timeout and surface daemon errors |
-| `7bb8aa3bd55d` | #20 | test(browser): cover open timeout diagnostics and failed navigate title |
 | `b31b0b9d95d1` | #22 | docs: reconcile docs with code across last 3 releases (#54254) |
 | `9a0010fd469f` | #20 | fix(windows): cover remaining console-flash spawn legs (#54417) |
 | `e5d22ab80d97` | #20 | fix(daytona): quote single-upload mkdir parent path (#54440) |


### PR DESCRIPTION
## Summary
- add bounded CDP command timeouts plus first-navigation open timeout floors
- surface actionable local-browser diagnostics for remote-debugging, cold first open, and sandbox failures
- label browser_navigate failures as `Failed to open <url>` in the Rust tool error surface
- add focused Rust tests for timeout floors, formatting, timeout behavior, and failed-open labeling
- mark the two upstream browser diagnostic rows as ported and regenerate parity artifacts

## Upstream deltas closed
- `a10727a555ad` fix(browser): extend first-open timeout and surface daemon errors
- `7bb8aa3bd55` test(browser): cover open timeout diagnostics and failed navigate title

## Verification
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-tools --lib backends::browser::tests::browser_cdp -- --nocapture` -> 5 passed; 0 failed
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo test -p hermes-tools --lib backends::browser::tests::browser_navigate_failure_is_labeled_failed_to_open -- --nocapture` -> 1 passed; 0 failed
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets CARGO_INCREMENTAL=0 cargo fmt --all --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `jq empty docs/parity/queue-overrides.json docs/parity/upstream-missing-queue.json docs/parity/global-parity-proof.json`
- `git diff --check`
- `test ! -d target`

## Queue delta
- pending: 40 -> 38
- ported: 519 -> 521
