### PR TITLE
parity(gateway): close upstream runtime deltas

### DIFF
--- a/crates/hermes-auth/src/lib.rs
+++ b/crates/hermes-auth/src/lib.rs
@@ -488,6 +488,20 @@ mod tests {
         assert!(url.contains("scope=openid"));
     }
 
+    #[test]
+    fn authorization_url_allows_http_redirect_with_arbitrary_host() {
+        let endpoints = OAuth2Endpoints {
+            authorize_url: "https://example.com/oauth/authorize".to_string(),
+            token_url: "https://example.com/oauth/token".to_string(),
+            client_id: "cid".to_string(),
+            redirect_uri: "http://hermes.internal:9119/auth/callback".to_string(),
+            scopes: vec!["openid".to_string()],
+        };
+        let pkce = generate_pkce_pair();
+        let url = build_authorization_url(&endpoints, &pkce, "state-xyz").unwrap();
+        assert!(url.contains("redirect_uri=http%3A%2F%2Fhermes.internal%3A9119%2Fauth%2Fcallback"));
+    }
+
     fn sample_credential(provider: &str, access_token: &str) -> OAuthCredential {
         OAuthCredential {
             provider: provider.to_string(),

--- a/crates/hermes-core/src/lib.rs
+++ b/crates/hermes-core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod credits;
 pub mod errors;
 pub mod providers;
 pub mod schema_sanitizer;
+pub mod subprocess_env;
 pub mod tool_call_parser;
 pub mod tool_schema;
 pub mod traits;

--- a/crates/hermes-core/src/subprocess_env.rs
+++ b/crates/hermes-core/src/subprocess_env.rs
@@ -1,0 +1,264 @@
+//! Credential-safe environment construction for spawned subprocesses.
+//!
+//! Terminal execution paths may opt specific keys through a configured
+//! passthrough. Non-terminal helper processes should use this module so they do
+//! not blindly inherit high-value operator credentials.
+
+use std::collections::BTreeMap;
+
+pub const SUBPROCESS_ENV_FORCE_PREFIX: &str = "_HERMES_FORCE_";
+pub const SUBPROCESS_ENV_PASSTHROUGH_VAR: &str = "HERMES_SUBPROCESS_ENV_PASSTHROUGH";
+
+/// Tier-1 secrets stripped from every managed subprocess, even when provider
+/// credentials are intentionally inherited for a model-driving child.
+pub const SUBPROCESS_ALWAYS_STRIP_KEYS: &[&str] = &[
+    "DAYTONA_API_KEY",
+    "DISCORD_BOT_TOKEN",
+    "EMAIL_PASSWORD",
+    "GATEWAY_ALLOW_ALL_USERS",
+    "GATEWAY_ALLOWED_USERS",
+    "GH_TOKEN",
+    "GITHUB_APP_ID",
+    "GITHUB_APP_INSTALLATION_ID",
+    "GITHUB_APP_PRIVATE_KEY_PATH",
+    "GITHUB_TOKEN",
+    "HASS_TOKEN",
+    "HERMES_DASHBOARD_SESSION_TOKEN",
+    "HERMES_POLICY_ADMIN_TOKEN",
+    "MODAL_TOKEN_ID",
+    "MODAL_TOKEN_SECRET",
+    "SLACK_APP_TOKEN",
+    "SLACK_BOT_TOKEN",
+    "SLACK_SIGNING_SECRET",
+    "TELEGRAM_BOT_TOKEN",
+];
+
+/// Credential-like env vars stripped by default. Callers that legitimately
+/// spawn a model-driving child can opt into retaining these while Tier-1 keys
+/// remain stripped.
+pub const SUBPROCESS_ENV_BLOCKLIST_EXACT: &[&str] = &[
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_TOKEN",
+    "AWS_BEARER_TOKEN_BEDROCK",
+    "BROWSERBASE_PROJECT_ID",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "COHERE_API_KEY",
+    "DAYTONA_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "DISCORD_BOT_TOKEN",
+    "DISCORD_FREE_RESPONSE_CHANNELS",
+    "DISCORD_HOME_CHANNEL",
+    "DISCORD_HOME_CHANNEL_NAME",
+    "DISCORD_REQUIRE_MENTION",
+    "EMAIL_ADDRESS",
+    "EMAIL_HOME_ADDRESS",
+    "EMAIL_HOME_ADDRESS_NAME",
+    "EMAIL_IMAP_HOST",
+    "EMAIL_PASSWORD",
+    "EMAIL_SMTP_HOST",
+    "ELEVENLABS_API_KEY",
+    "FIRECRAWL_API_KEY",
+    "FIREWORKS_API_KEY",
+    "GATEWAY_ALLOW_ALL_USERS",
+    "GATEWAY_ALLOWED_USERS",
+    "GH_TOKEN",
+    "GITHUB_APP_ID",
+    "GITHUB_APP_INSTALLATION_ID",
+    "GITHUB_APP_PRIVATE_KEY_PATH",
+    "GITHUB_TOKEN",
+    "GLM_API_KEY",
+    "GOOGLE_API_KEY",
+    "GROQ_API_KEY",
+    "HASS_TOKEN",
+    "HASS_URL",
+    "HELICONE_API_KEY",
+    "HERMES_DASHBOARD_SESSION_TOKEN",
+    "HERMES_ENABLE_NOUS_MANAGED_TOOLS",
+    "HERMES_OPENAI_API_KEY",
+    "HERMES_POLICY_ADMIN_TOKEN",
+    "KIMI_API_KEY",
+    "LLM_MODEL",
+    "MINIMAX_API_KEY",
+    "MINIMAX_CN_API_KEY",
+    "MISTRAL_API_KEY",
+    "MODAL_TOKEN_ID",
+    "MODAL_TOKEN_SECRET",
+    "NVIDIA_API_KEY",
+    "OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
+    "OPENROUTER_API_KEY",
+    "PERPLEXITY_API_KEY",
+    "SIGNAL_ACCOUNT",
+    "SIGNAL_ALLOWED_USERS",
+    "SIGNAL_GROUP_ALLOWED_USERS",
+    "SIGNAL_HOME_CHANNEL",
+    "SIGNAL_HOME_CHANNEL_NAME",
+    "SIGNAL_HTTP_URL",
+    "SIGNAL_IGNORE_STORIES",
+    "SLACK_ALLOWED_USERS",
+    "SLACK_APP_TOKEN",
+    "SLACK_BOT_TOKEN",
+    "SLACK_HOME_CHANNEL",
+    "SLACK_HOME_CHANNEL_NAME",
+    "SLACK_SIGNING_SECRET",
+    "TELEGRAM_BOT_TOKEN",
+    "TELEGRAM_HOME_CHANNEL",
+    "TELEGRAM_HOME_CHANNEL_NAME",
+    "TOGETHER_API_KEY",
+    "WHATSAPP_ALLOWED_USERS",
+    "WHATSAPP_ENABLED",
+    "WHATSAPP_MODE",
+    "XAI_API_KEY",
+    "ZAI_API_KEY",
+    "Z_AI_API_KEY",
+];
+
+pub const SUBPROCESS_ENV_BLOCKLIST_PREFIXES: &[&str] = &[
+    "TOOL_GATEWAY_",
+    "HERMES_MANAGED_TOOL_GATEWAY_",
+    "HERMES_GATEWAY_",
+    "HERMES_HTTP_",
+];
+
+const SANE_PATH_ENTRIES: &[&str] = &[
+    "/usr/local/bin",
+    "/usr/bin",
+    "/bin",
+    "/usr/sbin",
+    "/sbin",
+    "/opt/homebrew/bin",
+    "/opt/homebrew/sbin",
+];
+
+pub fn should_strip_subprocess_env_key(key: &str, inherit_credentials: bool) -> bool {
+    SUBPROCESS_ALWAYS_STRIP_KEYS.contains(&key)
+        || SUBPROCESS_ENV_BLOCKLIST_PREFIXES
+            .iter()
+            .any(|prefix| key.starts_with(prefix))
+        || (!inherit_credentials && SUBPROCESS_ENV_BLOCKLIST_EXACT.contains(&key))
+        || key.starts_with(SUBPROCESS_ENV_FORCE_PREFIX)
+        || key == SUBPROCESS_ENV_PASSTHROUGH_VAR
+}
+
+pub fn normalize_subprocess_path(path: Option<&str>) -> String {
+    let Some(path) = path.filter(|value| !value.trim().is_empty()) else {
+        return SANE_PATH_ENTRIES.join(":");
+    };
+    if std::env::split_paths(path).any(|entry| entry == std::path::Path::new("/usr/bin")) {
+        return path.to_string();
+    }
+
+    let mut entries: Vec<String> = std::env::split_paths(path)
+        .map(|entry| entry.to_string_lossy().to_string())
+        .filter(|entry| !entry.is_empty())
+        .collect();
+    for sane in SANE_PATH_ENTRIES {
+        if !entries.iter().any(|entry| entry == sane) {
+            entries.push((*sane).to_string());
+        }
+    }
+    entries.join(":")
+}
+
+pub fn hermes_subprocess_env(inherit_credentials: bool) -> BTreeMap<String, String> {
+    hermes_subprocess_env_from(std::env::vars(), inherit_credentials)
+}
+
+pub fn hermes_subprocess_env_from<I, K, V>(
+    vars: I,
+    inherit_credentials: bool,
+) -> BTreeMap<String, String>
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: Into<String>,
+    V: Into<String>,
+{
+    let mut env = BTreeMap::new();
+    let mut path = None;
+    for (key, value) in vars {
+        let key = key.into();
+        let value = value.into();
+        if key == "PATH" {
+            path = Some(value.clone());
+        }
+        if should_strip_subprocess_env_key(&key, inherit_credentials) {
+            continue;
+        }
+        env.insert(key, value);
+    }
+    env.insert(
+        "PATH".to_string(),
+        normalize_subprocess_path(path.as_deref()),
+    );
+    env
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build(vars: &[(&str, &str)], inherit_credentials: bool) -> BTreeMap<String, String> {
+        hermes_subprocess_env_from(
+            vars.iter()
+                .map(|(key, value)| ((*key).to_string(), (*value).to_string())),
+            inherit_credentials,
+        )
+    }
+
+    #[test]
+    fn provider_keys_are_stripped_by_default() {
+        let env = build(
+            &[
+                ("PATH", "/custom/bin"),
+                ("HOME", "/home/user"),
+                ("OPENAI_API_KEY", "sk-test"),
+                ("HERMES_OPENAI_API_KEY", "sk-hermes"),
+                ("ANTHROPIC_API_KEY", "ant-test"),
+                ("SAFE_VAR", "keep"),
+            ],
+            false,
+        );
+        assert_eq!(env.get("SAFE_VAR").map(String::as_str), Some("keep"));
+        assert!(!env.contains_key("OPENAI_API_KEY"));
+        assert!(!env.contains_key("HERMES_OPENAI_API_KEY"));
+        assert!(!env.contains_key("ANTHROPIC_API_KEY"));
+    }
+
+    #[test]
+    fn provider_keys_can_be_inherited_but_tier1_stays_stripped() {
+        let env = build(
+            &[
+                ("OPENAI_API_KEY", "sk-test"),
+                ("ANTHROPIC_API_KEY", "ant-test"),
+                ("GH_TOKEN", "ghp-secret"),
+                ("TELEGRAM_BOT_TOKEN", "bot-secret"),
+                ("HERMES_GATEWAY_TOKEN", "gateway-secret"),
+            ],
+            true,
+        );
+        assert_eq!(
+            env.get("OPENAI_API_KEY").map(String::as_str),
+            Some("sk-test")
+        );
+        assert_eq!(
+            env.get("ANTHROPIC_API_KEY").map(String::as_str),
+            Some("ant-test")
+        );
+        assert!(!env.contains_key("GH_TOKEN"));
+        assert!(!env.contains_key("TELEGRAM_BOT_TOKEN"));
+        assert!(!env.contains_key("HERMES_GATEWAY_TOKEN"));
+    }
+
+    #[test]
+    fn force_and_passthrough_control_vars_never_leak() {
+        let env = build(
+            &[
+                ("_HERMES_FORCE_OPENAI_API_KEY", "sk-force"),
+                ("HERMES_SUBPROCESS_ENV_PASSTHROUGH", "OPENAI_API_KEY"),
+            ],
+            true,
+        );
+        assert!(!env.contains_key("_HERMES_FORCE_OPENAI_API_KEY"));
+        assert!(!env.contains_key("HERMES_SUBPROCESS_ENV_PASSTHROUGH"));
+    }
+}

--- a/crates/hermes-environments/src/local/env_shell.rs
+++ b/crates/hermes-environments/src/local/env_shell.rs
@@ -241,87 +241,11 @@ fn resolve_path(input: &str) -> Result<PathBuf, AgentError> {
     Ok(PathBuf::from(input))
 }
 
-const SUBPROCESS_ENV_BLOCKLIST_EXACT: &[&str] = &[
-    "ANTHROPIC_API_KEY",
-    "ANTHROPIC_TOKEN",
-    "AWS_BEARER_TOKEN_BEDROCK",
-    "BROWSERBASE_PROJECT_ID",
-    "CLAUDE_CODE_OAUTH_TOKEN",
-    "COHERE_API_KEY",
-    "DAYTONA_API_KEY",
-    "DEEPSEEK_API_KEY",
-    "DISCORD_FREE_RESPONSE_CHANNELS",
-    "DISCORD_HOME_CHANNEL",
-    "DISCORD_HOME_CHANNEL_NAME",
-    "DISCORD_REQUIRE_MENTION",
-    "EMAIL_ADDRESS",
-    "EMAIL_HOME_ADDRESS",
-    "EMAIL_HOME_ADDRESS_NAME",
-    "EMAIL_IMAP_HOST",
-    "EMAIL_PASSWORD",
-    "EMAIL_SMTP_HOST",
-    "ELEVENLABS_API_KEY",
-    "FIRECRAWL_API_KEY",
-    "FIREWORKS_API_KEY",
-    "GATEWAY_ALLOW_ALL_USERS",
-    "GATEWAY_ALLOWED_USERS",
-    "GH_TOKEN",
-    "GITHUB_APP_ID",
-    "GITHUB_APP_INSTALLATION_ID",
-    "GITHUB_APP_PRIVATE_KEY_PATH",
-    "GITHUB_TOKEN",
-    "GLM_API_KEY",
-    "GOOGLE_API_KEY",
-    "GROQ_API_KEY",
-    "HASS_TOKEN",
-    "HASS_URL",
-    "HELICONE_API_KEY",
-    "HERMES_ENABLE_NOUS_MANAGED_TOOLS",
-    "HERMES_POLICY_ADMIN_TOKEN",
-    "KIMI_API_KEY",
-    "LLM_MODEL",
-    "MINIMAX_API_KEY",
-    "MINIMAX_CN_API_KEY",
-    "MISTRAL_API_KEY",
-    "MODAL_TOKEN_ID",
-    "MODAL_TOKEN_SECRET",
-    "NVIDIA_API_KEY",
-    "OPENAI_API_KEY",
-    "OPENAI_BASE_URL",
-    "OPENROUTER_API_KEY",
-    "PERPLEXITY_API_KEY",
-    "SIGNAL_ACCOUNT",
-    "SIGNAL_ALLOWED_USERS",
-    "SIGNAL_GROUP_ALLOWED_USERS",
-    "SIGNAL_HOME_CHANNEL",
-    "SIGNAL_HOME_CHANNEL_NAME",
-    "SIGNAL_HTTP_URL",
-    "SIGNAL_IGNORE_STORIES",
-    "SLACK_ALLOWED_USERS",
-    "SLACK_APP_TOKEN",
-    "SLACK_HOME_CHANNEL",
-    "SLACK_HOME_CHANNEL_NAME",
-    "TELEGRAM_BOT_TOKEN",
-    "TELEGRAM_HOME_CHANNEL",
-    "TELEGRAM_HOME_CHANNEL_NAME",
-    "TOGETHER_API_KEY",
-    "WHATSAPP_ALLOWED_USERS",
-    "WHATSAPP_ENABLED",
-    "WHATSAPP_MODE",
-    "XAI_API_KEY",
-    "ZAI_API_KEY",
-    "Z_AI_API_KEY",
-];
-
-const SUBPROCESS_ENV_BLOCKLIST_PREFIXES: &[&str] = &[
-    "TOOL_GATEWAY_",
-    "HERMES_MANAGED_TOOL_GATEWAY_",
-    "HERMES_GATEWAY_",
-    "HERMES_HTTP_",
-];
-
-const SUBPROCESS_ENV_FORCE_PREFIX: &str = "_HERMES_FORCE_";
-const SUBPROCESS_ENV_PASSTHROUGH_VAR: &str = "HERMES_SUBPROCESS_ENV_PASSTHROUGH";
+use hermes_core::subprocess_env::{
+    should_strip_subprocess_env_key, SUBPROCESS_ENV_BLOCKLIST_EXACT,
+    SUBPROCESS_ENV_BLOCKLIST_PREFIXES, SUBPROCESS_ENV_FORCE_PREFIX,
+    SUBPROCESS_ENV_PASSTHROUGH_VAR,
+};
 
 const SANE_PATH_ENTRIES: &[&str] = &[
     "/usr/local/bin",
@@ -334,10 +258,7 @@ const SANE_PATH_ENTRIES: &[&str] = &[
 ];
 
 fn should_strip_subprocess_env(key: &str) -> bool {
-    SUBPROCESS_ENV_BLOCKLIST_EXACT.contains(&key)
-        || SUBPROCESS_ENV_BLOCKLIST_PREFIXES
-            .iter()
-            .any(|prefix| key.starts_with(prefix))
+    should_strip_subprocess_env_key(key, false)
 }
 
 fn normalize_env_passthrough_name(value: &str) -> Option<String> {
@@ -853,4 +774,3 @@ fn last_top_level_chain_operator(line: &str, stop: usize) -> Option<ChainOperato
     }
     last
 }
-

--- a/crates/hermes-gateway/src/gateway/routing_methods.rs
+++ b/crates/hermes-gateway/src/gateway/routing_methods.rs
@@ -312,8 +312,61 @@ impl Gateway {
             )
             .map(Self::busy_event_to_incoming)
         };
+        if let Err(error) = &processing_result {
+            self.send_processing_error_notification(incoming, error).await;
+        }
         processing_result?;
         Ok(pending)
+    }
+
+    async fn send_processing_error_notification(
+        &self,
+        incoming: &IncomingMessage,
+        original_error: &GatewayError,
+    ) -> bool {
+        let mut detail: String = original_error.to_string().chars().take(300).collect();
+        if detail.trim().is_empty() {
+            detail = "no details available".to_string();
+        }
+        let notice = format!(
+            "Sorry, I encountered an error ({}).\n{}\nTry again or use /reset to start a fresh session.",
+            Self::gateway_error_variant_name(original_error),
+            detail
+        );
+
+        match self
+            .send_message_threaded(
+                &incoming.platform,
+                &incoming.chat_id,
+                &notice,
+                Some(ParseMode::Plain),
+                Self::reply_thread_id(incoming),
+            )
+            .await
+        {
+            Ok(()) => true,
+            Err(notify_error) => {
+                error!(
+                    platform = %incoming.platform,
+                    chat_id = %incoming.chat_id,
+                    original_error = %original_error,
+                    notify_error = %notify_error,
+                    "failed to send gateway error notification"
+                );
+                false
+            }
+        }
+    }
+
+    fn gateway_error_variant_name(error: &GatewayError) -> &'static str {
+        match error {
+            GatewayError::ConnectionFailed(_) => "ConnectionFailed",
+            GatewayError::SendFailed(_) => "SendFailed",
+            GatewayError::Platform(_) => "Platform",
+            GatewayError::Auth(_) => "Auth",
+            GatewayError::RateLimited { .. } => "RateLimited",
+            GatewayError::SessionExpired(_) => "SessionExpired",
+        }
     }
 
     fn quick_command_key(raw: &str) -> String {
@@ -362,6 +415,8 @@ impl Gateway {
         timeout_secs: u64,
     ) -> Result<String, GatewayError> {
         let child = tokio::process::Command::new("sh")
+            .env_clear()
+            .envs(hermes_core::subprocess_env::hermes_subprocess_env(false))
             .arg("-c")
             .arg(command)
             .kill_on_drop(true)

--- a/crates/hermes-gateway/src/gateway/tests.rs
+++ b/crates/hermes-gateway/src/gateway/tests.rs
@@ -9,6 +9,11 @@ struct TestAdapter {
     messages: Arc<Mutex<Vec<(String, String)>>>,
 }
 
+struct FailingSendAdapter {
+    messages: Arc<Mutex<Vec<(String, String)>>>,
+    error: &'static str,
+}
+
 struct StatusUpdateAdapter {
     updates: Arc<Mutex<Vec<(String, String, String)>>>,
 }
@@ -80,6 +85,42 @@ impl Drop for HermesHomeEnvGuard {
         match &self.prev_ultra_home {
             Some(value) => std::env::set_var("HERMES_AGENT_ULTRA_HOME", value),
             None => std::env::remove_var("HERMES_AGENT_ULTRA_HOME"),
+        }
+    }
+}
+
+struct EnvVarsGuard {
+    previous: Vec<(String, Option<String>)>,
+    _guard: MutexGuard<'static, ()>,
+}
+
+impl EnvVarsGuard {
+    fn set(vars: &[(&str, &str)]) -> Self {
+        let guard = ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("env lock poisoned");
+        let previous = vars
+            .iter()
+            .map(|(key, _)| ((*key).to_string(), std::env::var(key).ok()))
+            .collect::<Vec<_>>();
+        for (key, value) in vars {
+            std::env::set_var(key, value);
+        }
+        Self {
+            previous,
+            _guard: guard,
+        }
+    }
+}
+
+impl Drop for EnvVarsGuard {
+    fn drop(&mut self) {
+        for (key, value) in &self.previous {
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
         }
     }
 }
@@ -188,6 +229,56 @@ impl PlatformAdapter for TestAdapter {
             .lock()
             .unwrap()
             .push((chat_id.to_string(), marker));
+        Ok(())
+    }
+
+    fn is_running(&self) -> bool {
+        true
+    }
+
+    fn platform_name(&self) -> &str {
+        "test"
+    }
+}
+
+#[async_trait]
+impl PlatformAdapter for FailingSendAdapter {
+    async fn start(&self) -> Result<(), GatewayError> {
+        Ok(())
+    }
+
+    async fn stop(&self) -> Result<(), GatewayError> {
+        Ok(())
+    }
+
+    async fn send_message(
+        &self,
+        chat_id: &str,
+        text: &str,
+        _parse_mode: Option<ParseMode>,
+    ) -> Result<(), GatewayError> {
+        self.messages
+            .lock()
+            .unwrap()
+            .push((chat_id.to_string(), text.to_string()));
+        Err(GatewayError::SendFailed(self.error.to_string()))
+    }
+
+    async fn edit_message(
+        &self,
+        _chat_id: &str,
+        _message_id: &str,
+        _text: &str,
+    ) -> Result<(), GatewayError> {
+        Ok(())
+    }
+
+    async fn send_file(
+        &self,
+        _chat_id: &str,
+        _file_path: &str,
+        _caption: Option<&str>,
+    ) -> Result<(), GatewayError> {
         Ok(())
     }
 
@@ -411,6 +502,38 @@ async fn gateway_quick_exec_returns_stdout_from_config() {
         .expect("reply");
 
     assert_eq!(reply, "ok");
+}
+
+#[tokio::test]
+async fn gateway_quick_exec_sanitizes_credential_environment() {
+    let _env = EnvVarsGuard::set(&[
+        ("OPENAI_API_KEY", "sk-should-not-leak"),
+        ("GH_TOKEN", "ghp-should-not-leak"),
+        ("SAFE_QUICK_ENV", "keep-me"),
+    ]);
+    let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+    let dm_manager = DmManager::with_pair_behavior();
+    let mut cfg = GatewayConfig::default();
+    cfg.quick_commands.insert(
+        "envcheck".to_string(),
+        QuickCommandConfig {
+            kind: "exec".to_string(),
+            command: Some(
+                "printf '%s|%s|%s' \"${OPENAI_API_KEY:-}\" \"${GH_TOKEN:-}\" \"${SAFE_QUICK_ENV:-}\""
+                    .to_string(),
+            ),
+            ..Default::default()
+        },
+    );
+    let gw = Gateway::new(session_mgr, dm_manager, cfg);
+
+    let reply = gw
+        .resolve_quick_command("/envcheck")
+        .await
+        .expect("quick command")
+        .expect("reply");
+
+    assert_eq!(reply, "||keep-me");
 }
 
 #[tokio::test]
@@ -809,6 +932,66 @@ async fn gateway_register_and_list_adapters() {
     let gw = Gateway::with_defaults(session_mgr, GatewayConfig::default());
 
     assert!(gw.adapter_names().await.is_empty());
+}
+
+#[tokio::test]
+async fn gateway_agent_error_sends_user_notification() {
+    let sent = Arc::new(Mutex::new(Vec::new()));
+    let adapter = Arc::new(TestAdapter {
+        messages: sent.clone(),
+    });
+    let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+    let mut dm_manager = DmManager::with_pair_behavior();
+    dm_manager.authorize_user("user1");
+    let gw = Gateway::new(session_mgr, dm_manager, GatewayConfig::default());
+    gw.register_adapter("test", adapter).await;
+    gw.set_message_handler(Arc::new(|_messages| {
+        Box::pin(async { Err(GatewayError::Platform("agent boom".to_string())) })
+    }))
+    .await;
+
+    let err = gw
+        .route_message(&test_incoming("explode"))
+        .await
+        .expect_err("handler failure should still propagate");
+
+    assert_eq!(err.to_string(), "Platform error: agent boom");
+    let sent = sent.lock().expect("sent lock");
+    assert_eq!(sent.len(), 1);
+    assert_eq!(sent[0].0, "chat1");
+    assert!(sent[0]
+        .1
+        .contains("Sorry, I encountered an error (Platform)."));
+    assert!(sent[0].1.contains("Platform error: agent boom"));
+    assert!(sent[0].1.contains("Try again or use /reset"));
+}
+
+#[tokio::test]
+async fn gateway_error_notification_failure_preserves_original_error() {
+    let attempts = Arc::new(Mutex::new(Vec::new()));
+    let adapter = Arc::new(FailingSendAdapter {
+        messages: attempts.clone(),
+        error: "notify transport down",
+    });
+    let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+    let mut dm_manager = DmManager::with_pair_behavior();
+    dm_manager.authorize_user("user1");
+    let gw = Gateway::new(session_mgr, dm_manager, GatewayConfig::default());
+    gw.register_adapter("test", adapter).await;
+    gw.set_message_handler(Arc::new(|_messages| {
+        Box::pin(async { Err(GatewayError::Platform("agent boom".to_string())) })
+    }))
+    .await;
+
+    let err = gw
+        .route_message(&test_incoming("explode"))
+        .await
+        .expect_err("original handler failure should still propagate");
+
+    assert_eq!(err.to_string(), "Platform error: agent boom");
+    let attempts = attempts.lock().expect("attempts lock");
+    assert_eq!(attempts.len(), 1);
+    assert!(attempts[0].1.contains("Platform error: agent boom"));
 }
 
 #[tokio::test]

--- a/crates/hermes-gateway/src/hooks.rs
+++ b/crates/hermes-gateway/src/hooks.rs
@@ -440,7 +440,9 @@ impl HookHandler for CommandHookHandler {
         .to_string();
 
         let mut cmd = tokio::process::Command::new(&self.argv[0]);
-        cmd.args(&self.argv[1..])
+        cmd.env_clear()
+            .envs(hermes_core::subprocess_env::hermes_subprocess_env(false))
+            .args(&self.argv[1..])
             .current_dir(&self.cwd)
             .env("HERMES_HOOK_EVENT", &event.event_type)
             .stdin(Stdio::piped())
@@ -582,7 +584,7 @@ impl HookHandler for BootMdHook {
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::Mutex;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
     use tempfile::TempDir;
 
     /// In-process handler that records every event it sees (for
@@ -660,6 +662,44 @@ mod tests {
 
         fn name(&self) -> &str {
             &self.name
+        }
+    }
+
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    struct EnvVarGuard {
+        previous: Vec<(String, Option<String>)>,
+        _guard: MutexGuard<'static, ()>,
+    }
+
+    impl EnvVarGuard {
+        fn set(vars: &[(&str, &str)]) -> Self {
+            let guard = ENV_LOCK
+                .get_or_init(|| Mutex::new(()))
+                .lock()
+                .expect("env lock poisoned");
+            let previous = vars
+                .iter()
+                .map(|(key, _)| ((*key).to_string(), std::env::var(key).ok()))
+                .collect::<Vec<_>>();
+            for (key, value) in vars {
+                std::env::set_var(key, value);
+            }
+            Self {
+                previous,
+                _guard: guard,
+            }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            for (key, value) in &self.previous {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
         }
     }
 
@@ -1178,6 +1218,34 @@ mod tests {
             .unwrap();
         let written = std::fs::read_to_string(&out).unwrap();
         assert_eq!(written, "agent:step");
+    }
+
+    #[tokio::test]
+    async fn command_hook_sanitizes_credential_environment() {
+        let _env = EnvVarGuard::set(&[
+            ("OPENAI_API_KEY", "sk-should-not-leak"),
+            ("GH_TOKEN", "ghp-should-not-leak"),
+            ("SAFE_HOOK_VAR", "keep-me"),
+        ]);
+        let tmp = TempDir::new().unwrap();
+        let out = tmp.path().join("env_out.txt");
+        let h = CommandHookHandler::new(
+            "env-sanitized-hook",
+            vec![
+                "/bin/sh".into(),
+                "-c".into(),
+                "printf '%s|%s|%s' \"${OPENAI_API_KEY:-}\" \"${GH_TOKEN:-}\" \"${SAFE_HOOK_VAR:-}\" > \"$1\"".into(),
+                "hook-env".into(),
+                out.to_string_lossy().to_string(),
+            ],
+            std::env::temp_dir(),
+            5,
+        );
+        h.handle(&HookEvent::new("agent:step", json!({"i": 7})))
+            .await
+            .unwrap();
+        let written = std::fs::read_to_string(&out).unwrap();
+        assert_eq!(written, "||keep-me");
     }
 
     #[tokio::test]

--- a/crates/hermes-gateway/src/lib.rs
+++ b/crates/hermes-gateway/src/lib.rs
@@ -77,10 +77,11 @@ pub use dm::{DmDecision, DmManager};
 pub use mirror::MirrorManager;
 pub use pairing::{PairingManager, PairingState};
 pub use relay::{
-    relay_close_disposition, relay_going_idle_frame, relay_inbound_ack_frame,
-    relay_passthrough_forward_from_frame, relay_platform_state_for_close, relay_policy_url,
-    relay_relevance_policy, relay_wake_url_from_sources, RelayCloseDisposition,
-    RelayPassthroughForward, RelayRelevancePolicy, RELAY_UNAUTHORIZED_CLOSE_CODE,
+    relay_close_disposition, relay_dual_write_scope_id, relay_going_idle_frame,
+    relay_inbound_ack_frame, relay_passthrough_forward_from_frame, relay_platform_state_for_close,
+    relay_policy_url, relay_relevance_policy, relay_scope_id_from_source,
+    relay_wake_url_from_sources, RelayCloseDisposition, RelayPassthroughForward,
+    RelayRelevancePolicy, RELAY_UNAUTHORIZED_CLOSE_CODE,
 };
 pub use sticker_cache::{StickerCache, StickerMeta};
 

--- a/crates/hermes-gateway/src/platforms/slack.rs
+++ b/crates/hermes-gateway/src/platforms/slack.rs
@@ -9,8 +9,9 @@
 //! App Home tab publishing, interactive component handling, modals, user info,
 //! reactions, topic setting, and permalinks.
 
+use std::collections::BTreeSet;
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use regex::{Regex, RegexBuilder};

--- a/crates/hermes-gateway/src/platforms/slack/adapter_impl.rs
+++ b/crates/hermes-gateway/src/platforms/slack/adapter_impl.rs
@@ -8,6 +8,7 @@ pub struct SlackAdapter {
     config: SlackConfig,
     client: Client,
     stop_signal: Arc<Notify>,
+    group_dm_scope_warned: Mutex<BTreeSet<String>>,
 }
 
 impl SlackAdapter {
@@ -23,6 +24,7 @@ impl SlackAdapter {
             config,
             client,
             stop_signal: Arc::new(Notify::new()),
+            group_dm_scope_warned: Mutex::new(BTreeSet::new()),
         })
     }
 
@@ -233,6 +235,67 @@ impl SlackAdapter {
             .and_then(|v| v.as_str())
             .map(String::from)
             .ok_or_else(|| GatewayError::ConnectionFailed("No URL in Socket Mode response".into()))
+    }
+
+    pub(crate) async fn warn_if_missing_group_dm_scopes_from_auth_test(
+        &self,
+        base_url: &str,
+    ) -> Result<bool, GatewayError> {
+        let resp = self
+            .client
+            .post(&format!("{}/auth.test", base_url.trim_end_matches('/')))
+            .header("Authorization", format!("Bearer {}", self.config.token))
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .send()
+            .await
+            .map_err(|e| GatewayError::ConnectionFailed(format!("Slack auth.test failed: {e}")))?;
+        let scopes = resp
+            .headers()
+            .get("x-oauth-scopes")
+            .or_else(|| resp.headers().get("X-OAuth-Scopes"))
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+        let body: SlackAuthTestResponse = resp.json().await.map_err(|e| {
+            GatewayError::ConnectionFailed(format!("Failed to parse Slack auth.test response: {e}"))
+        })?;
+        if !body.ok {
+            return Err(GatewayError::Auth(format!(
+                "Slack auth.test error: {}",
+                body.error.unwrap_or_else(|| "unknown".into())
+            )));
+        }
+        Ok(self.warn_if_missing_group_dm_scopes(
+            &scopes,
+            body.team.as_deref().or(body.team_id.as_deref()),
+        ))
+    }
+
+    pub(crate) fn warn_if_missing_group_dm_scopes(
+        &self,
+        scopes_header: &str,
+        team_name: Option<&str>,
+    ) -> bool {
+        let granted = parse_slack_scope_header(scopes_header);
+        if !granted.contains("im:history") || granted.contains("mpim:history") {
+            return false;
+        }
+        let team_key = team_name
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("this workspace")
+            .to_string();
+        let Ok(mut warned) = self.group_dm_scope_warned.lock() else {
+            return false;
+        };
+        if !warned.insert(team_key.clone()) {
+            return false;
+        }
+        warn!(
+            workspace = %team_key,
+            "Slack Group DMs will not work: the app is missing `mpim:history` scope and `message.mpim` event subscription. Add `mpim:history` and `mpim:read` to bot scopes, add `message.mpim` to event subscriptions, then reinstall the app to the workspace."
+        );
+        true
     }
 
     /// Parse a Socket Mode envelope into an IncomingSlackMessage.
@@ -584,4 +647,3 @@ impl SlackAdapter {
         Ok(result)
     }
 }
-

--- a/crates/hermes-gateway/src/platforms/slack/config_media.rs
+++ b/crates/hermes-gateway/src/platforms/slack/config_media.rs
@@ -58,6 +58,17 @@ pub struct SlackResponse {
 }
 
 #[derive(Debug, Deserialize)]
+struct SlackAuthTestResponse {
+    pub ok: bool,
+    #[serde(default)]
+    pub error: Option<String>,
+    #[serde(default)]
+    pub team: Option<String>,
+    #[serde(default)]
+    pub team_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
 struct SlackConversationsResponse {
     pub ok: bool,
     #[serde(default)]
@@ -232,4 +243,3 @@ impl SlackMentionPolicy {
         }
     }
 }
-

--- a/crates/hermes-gateway/src/platforms/slack/helpers.rs
+++ b/crates/hermes-gateway/src/platforms/slack/helpers.rs
@@ -32,6 +32,14 @@ fn slack_value_string(value: &serde_json::Value, key: &str) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
+fn parse_slack_scope_header(raw: &str) -> BTreeSet<String> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|scope| !scope.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
 fn slack_mime_key(raw: &str) -> String {
     raw.split(';')
         .next()
@@ -299,4 +307,3 @@ fn slack_image_url_blocks(image_url: &str, caption: Option<&str>) -> (serde_json
     let fallback = caption.unwrap_or(image_url).to_string();
     (serde_json::Value::Array(blocks), fallback)
 }
-

--- a/crates/hermes-gateway/src/platforms/slack/tests.rs
+++ b/crates/hermes-gateway/src/platforms/slack/tests.rs
@@ -266,6 +266,78 @@ fn slack_mention_patterns_env_fallback_splits_mixed_csv_and_newlines() {
 }
 
 #[test]
+fn slack_group_dm_scope_warning_detects_stale_install_once() {
+    let adapter = SlackAdapter::new(slack_test_config()).expect("adapter");
+    assert!(adapter.warn_if_missing_group_dm_scopes(
+        "chat:write,im:history,im:read,channels:history",
+        Some("Acme")
+    ));
+    assert!(!adapter.warn_if_missing_group_dm_scopes(
+        "chat:write,im:history,im:read,channels:history",
+        Some("Acme")
+    ));
+}
+
+#[test]
+fn slack_group_dm_scope_warning_requires_im_without_mpim() {
+    let adapter = SlackAdapter::new(slack_test_config()).expect("adapter");
+    assert!(!adapter.warn_if_missing_group_dm_scopes(
+        "chat:write,im:history,mpim:history,mpim:read",
+        Some("Acme")
+    ));
+    assert!(!adapter.warn_if_missing_group_dm_scopes("chat:write,channels:history", Some("Acme")));
+    assert!(!adapter.warn_if_missing_group_dm_scopes("", Some("Acme")));
+}
+
+#[tokio::test]
+async fn slack_auth_test_scope_header_drives_group_dm_warning() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/auth.test"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("x-oauth-scopes", "chat:write,im:history,im:read")
+                .set_body_json(serde_json::json!({
+                    "ok": true,
+                    "team": "Acme"
+                })),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let adapter = SlackAdapter::new(slack_test_config()).expect("adapter");
+    assert!(adapter
+        .warn_if_missing_group_dm_scopes_from_auth_test(&server.uri())
+        .await
+        .expect("auth scope audit"));
+}
+
+#[tokio::test]
+async fn slack_auth_test_mpim_scope_present_does_not_warn() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/auth.test"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("x-oauth-scopes", "chat:write,im:history,mpim:history")
+                .set_body_json(serde_json::json!({
+                    "ok": true,
+                    "team": "Acme"
+                })),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let adapter = SlackAdapter::new(slack_test_config()).expect("adapter");
+    assert!(!adapter
+        .warn_if_missing_group_dm_scopes_from_auth_test(&server.uri())
+        .await
+        .expect("auth scope audit"));
+}
+
+#[test]
 fn parse_event_with_config_requires_mention_but_accepts_wake_word() {
     let mut cfg = slack_test_config();
     cfg.require_mention = true;

--- a/crates/hermes-gateway/src/platforms/slack/trait_impls.rs
+++ b/crates/hermes-gateway/src/platforms/slack/trait_impls.rs
@@ -16,6 +16,12 @@ impl PlatformAdapter for SlackAdapter {
             "Slack adapter starting (token: {})",
             describe_secret(&self.config.token)
         );
+        if let Err(err) = self
+            .warn_if_missing_group_dm_scopes_from_auth_test(SLACK_API_BASE)
+            .await
+        {
+            debug!(error = %err, "Slack auth scope check skipped");
+        }
         self.base.mark_running();
         Ok(())
     }
@@ -115,4 +121,3 @@ impl PlatformAdapter for SlackAdapter {
         "slack"
     }
 }
-

--- a/crates/hermes-gateway/src/relay.rs
+++ b/crates/hermes-gateway/src/relay.rs
@@ -114,6 +114,34 @@ pub fn relay_inbound_ack_frame(buffer_id: &str) -> Option<Value> {
     (!buffer_id.is_empty()).then(|| json!({"type": "inbound_ack", "bufferId": buffer_id}))
 }
 
+/// Resolve the platform-neutral relay scope discriminator.
+///
+/// `scope_id` is canonical; `guild_id` is a deprecated compatibility alias
+/// retained during the cross-repo relay wire migration.
+pub fn relay_scope_id_from_source(source: &Value) -> Option<String> {
+    source
+        .get("scope_id")
+        .or_else(|| source.get("guild_id"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+/// Dual-write canonical `scope_id` and deprecated `guild_id` alias.
+pub fn relay_dual_write_scope_id(source: &mut Value, scope_id: &str) -> bool {
+    let scope_id = scope_id.trim();
+    if scope_id.is_empty() {
+        return false;
+    }
+    let Some(map) = source.as_object_mut() else {
+        return false;
+    };
+    map.insert("scope_id".to_string(), Value::String(scope_id.to_string()));
+    map.insert("guild_id".to_string(), Value::String(scope_id.to_string()));
+    true
+}
+
 /// Classify relay socket close events.
 ///
 /// A connector `4401` before the first successful descriptor/handshake remains
@@ -271,6 +299,30 @@ mod tests {
             json!({"type": "inbound_ack", "bufferId": "buf-9"})
         );
         assert!(relay_inbound_ack_frame("   ").is_none());
+    }
+
+    #[test]
+    fn relay_scope_id_prefers_canonical_and_falls_back_to_guild_alias() {
+        assert_eq!(
+            relay_scope_id_from_source(&json!({"scope_id": "S1", "guild_id": "G1"})).as_deref(),
+            Some("S1")
+        );
+        assert_eq!(
+            relay_scope_id_from_source(&json!({"guild_id": "G1"})).as_deref(),
+            Some("G1")
+        );
+        assert!(relay_scope_id_from_source(&json!({"scope_id": "  "})).is_none());
+    }
+
+    #[test]
+    fn relay_scope_id_dual_writes_canonical_and_legacy_keys() {
+        let mut source = json!({"platform": "discord", "chat_id": "C1"});
+        assert!(relay_dual_write_scope_id(&mut source, "S1"));
+        assert_eq!(source["scope_id"], "S1");
+        assert_eq!(source["guild_id"], "S1");
+        assert!(!relay_dual_write_scope_id(&mut source, " "));
+        let mut non_object = json!(null);
+        assert!(!relay_dual_write_scope_id(&mut non_object, "S1"));
     }
 
     #[test]

--- a/crates/hermes-gateway/src/session_control.rs
+++ b/crates/hermes-gateway/src/session_control.rs
@@ -18,6 +18,8 @@ pub struct SessionSource {
     pub chat_type: String,
     pub user_id: Option<String>,
     pub thread_id: Option<String>,
+    pub scope_id: Option<String>,
+    pub guild_id: Option<String>,
 }
 
 impl SessionSource {
@@ -32,6 +34,8 @@ impl SessionSource {
             chat_type: chat_type.into(),
             user_id: None,
             thread_id: None,
+            scope_id: None,
+            guild_id: None,
         }
     }
 
@@ -44,6 +48,25 @@ impl SessionSource {
         self.thread_id = Some(thread_id.into());
         self
     }
+
+    pub fn with_scope(mut self, scope_id: impl Into<String>) -> Self {
+        let scope_id = scope_id.into();
+        self.guild_id = Some(scope_id.clone());
+        self.scope_id = Some(scope_id);
+        self
+    }
+
+    pub fn with_guild_id(self, guild_id: impl Into<String>) -> Self {
+        self.with_scope(guild_id)
+    }
+
+    pub fn scope_id(&self) -> Option<&str> {
+        self.scope_id
+            .as_deref()
+            .or(self.guild_id.as_deref())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+    }
 }
 
 pub fn build_session_key(source: &SessionSource) -> String {
@@ -52,6 +75,9 @@ pub fn build_session_key(source: &SessionSource) -> String {
         .filter(|part| !part.is_empty())
         .map(str::to_string)
         .collect::<Vec<_>>();
+    if let Some(scope_id) = source.scope_id() {
+        parts.insert(1, scope_id.to_string());
+    }
     if let Some(thread_id) = source
         .thread_id
         .as_deref()
@@ -466,6 +492,20 @@ mod tests {
             build_session_key(&source("10")),
             build_session_key(&source("11"))
         );
+    }
+
+    #[test]
+    fn session_source_scope_id_is_canonical_and_guild_id_is_alias() {
+        let scoped = SessionSource::new("relay", "C1", "channel").with_scope("T1");
+        assert_eq!(scoped.scope_id.as_deref(), Some("T1"));
+        assert_eq!(scoped.guild_id.as_deref(), Some("T1"));
+        assert_eq!(scoped.scope_id(), Some("T1"));
+        assert_eq!(build_session_key(&scoped), "relay:T1:C1");
+
+        let legacy = SessionSource::new("relay", "C1", "channel").with_guild_id("G1");
+        assert_eq!(legacy.scope_id.as_deref(), Some("G1"));
+        assert_eq!(legacy.guild_id.as_deref(), Some("G1"));
+        assert_eq!(build_session_key(&legacy), "relay:G1:C1");
     }
 
     #[test]

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-30T01:23:08.904982+00:00",
+  "generated_at_utc": "2026-06-30T03:26:00.619065+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -300,8 +300,8 @@
     "by_disposition": {
       "mirrored": 97,
       "pending": 35,
-      "ported": 523,
-      "superseded": 6996
+      "ported": 527,
+      "superseded": 6997
     },
     "by_target_ticket": {
       "20": 3494,
@@ -309,12 +309,12 @@
       "22": 1003,
       "23": 503,
       "24": 25,
-      "25": 162,
-      "26": 2333
+      "25": 165,
+      "26": 2335
     },
     "overrides_path": "docs/parity/queue-overrides.json",
     "patch_equivalent_count": 6,
-    "total_commits": 7651
+    "total_commits": 7656
   },
   "release_gate": {
     "checks": [

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-30T01:23:08.904982+00:00`
+Generated: `2026-06-30T03:26:00.619065+00:00`
 
 ## Gate Status
 
@@ -93,13 +93,13 @@ Generated: `2026-06-30T01:23:08.904982+00:00`
 
 ## Queue Summary
 
-- Upstream missing commits tracked: `7651`.
+- Upstream missing commits tracked: `7656`.
 - By target ticket:
   - `#20`: `3494`
   - `#21`: `131`
   - `#22`: `1003`
   - `#23`: `503`
   - `#24`: `25`
-  - `#25`: `162`
-  - `#26`: `2333`
+  - `#25`: `165`
+  - `#26`: `2335`
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -6533,6 +6533,31 @@
       "disposition": "superseded",
       "owner": "rust-runtime",
       "notes": "Superseded by Rust model-switch architecture: CLI/TUI and gateway model switches update runtime config/defaults without appending a model-switch marker into model-facing history, so strict providers never see a mid-conversation system message. Added gateway_model_switch_does_not_inject_mid_history_system_marker regression coverage."
+    },
+    "9c6229ce249e4bbd86a22463be73ac2986db6324": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported with shared Rust subprocess environment policy: hermes_core::subprocess_env strips provider credentials by default, always strips tier-1 live tokens/gateway secrets, preserves safe env vars, normalizes PATH, and is used by gateway command hooks and quick exec. Focused tests cover helper policy plus hook and quick-exec child environments."
+    },
+    "34e616e778d065acea1477ddc6933c30378def89": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust SlackAdapter: startup performs a best-effort auth.test scope audit, warns once per workspace when direct-message scopes exist but mpim:history/message.mpim coverage is missing, and continues startup if the audit fails. Unit and wiremock tests cover stale installs, once-only warnings, auth.test header parsing, and mpim-present suppression."
+    },
+    "3a55f66602898b53524a232e3dbadea3ed9b0cf8": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported with Rust relay/session scope_id migration support: scope_id is canonical, guild_id remains a deprecated alias, relay helpers dual-read and dual-write both keys, SessionSource exposes with_scope/with_guild_id compatibility, and docs/tests cover the wire-contract behavior."
+    },
+    "f3d2dfbec670cd520bf23fe6ec1f4ce918d286bd": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Superseded by Rust OAuth URL construction: hermes-auth does not impose the upstream self-hosted localhost-only http redirect_uri restriction, and the regression test proves arbitrary http:// host callback URLs are preserved in authorization URLs."
+    },
+    "f1cbe4308f54215cec248eba94444a6fb8f1caef": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust Gateway route handling: agent processing errors now trigger a best-effort user error notification, notification-send failures are logged with the original error preserved, and focused tests cover user notice delivery plus send-failure preservation."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,8 +1,8 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-30T01:23:08.771275+00:00`
+Generated: `2026-06-30T03:26:00.450945+00:00`
 
-- Range: `origin/main..upstream/main`; total commits tracked: `7651`.
+- Range: `origin/main..upstream/main`; total commits tracked: `7656`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
@@ -11,15 +11,15 @@ Generated: `2026-06-30T01:23:08.771275+00:00`
 | #22 | GPAR-03 UX parity | 1003 |
 | #23 | GPAR-04 gateway/plugin-memory parity | 503 |
 | #24 | GPAR-05 environments+parsers+benchmarks | 25 |
-| #25 | GPAR-06 packaging/docs/install parity | 162 |
-| #26 | GPAR-07 upstream queue backfill | 2333 |
+| #25 | GPAR-06 packaging/docs/install parity | 165 |
+| #26 | GPAR-07 upstream queue backfill | 2335 |
 
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 97 |
 | pending | 35 |
-| ported | 523 |
-| superseded | 6996 |
+| ported | 527 |
+| superseded | 6997 |
 
 ## First 100 Pending Commits
 
@@ -38,7 +38,6 @@ Generated: `2026-06-30T01:23:08.771275+00:00`
 | `d3d621f7c38b` | #20 | revert(windows): roll back terminal-popup PRs #53791 #53810 #53829 (#53853) |
 | `163cb24d45d8` | #22 | feat(moa): render reference-model blocks in TUI and desktop, not just CLI (#53855) |
 | `a94f657a5059` | #20 | fix(tui): route completion RPCs to the pool so they can't freeze the TUI (#53895) |
-| `9c6229ce249e` | #20 | fix(security): centralize credential-safe subprocess env (#29157) |
 | `d43e0cf304a1` | #20 | fix(agent): config-driven intent-ack continuation for all api_modes (#27881) (#53943) |
 | `a8c862900b9c` | #20 | fix(tui): sanitize replay history on WebUI/TUI session resume (#29086) (#53939) |
 | `fde1c8570ffe` | #20 | fix(tui_gateway): suppress WS peer-hangup teardown error flood (#50005) (#54126) |
@@ -52,11 +51,12 @@ Generated: `2026-06-30T01:23:08.771275+00:00`
 | `e5d22ab80d97` | #20 | fix(daytona): quote single-upload mkdir parent path (#54440) |
 | `ee22d853eb13` | #26 | fix(windows): hide pdftoppm console flash on PDF attach |
 | `520212cc593d` | #26 | feat(desktop): stream agent terminal output live instead of polling |
-| `f1cbe4308f54` | #23 | fix(gateway): log error-notification failures instead of silently swallowing (#54472) |
 | `e117cfdff08b` | #20 | feat(desktop): live agent terminals + agent-driven tab close |
 | `adacb16d6243` | #26 | fix(desktop): make agent terminal tabs fully readable |
 | `dff491a2b993` | #22 | feat(cli): add headless `hermes serve` backend; desktop no longer launches `dashboard` |
 | `476875acb9f0` | #22 | Add dashboard backup upload and download |
-| `34e616e778d0` | #22 | feat(slack): nudge stale installs to add mpim scopes; mark message.mpim required |
 | `fd324562d3ad` | #20 | feat(desktop): add context usage breakdown popover |
-| `f3d2dfbec670` | #20 | fix(dashboard_auth): allow any http:// host in self-hosted OIDC redirect_uri (#55099) |
+| `808ba82125e2` | #25 | feat(ci): add CI timing report |
+| `66ba9e06d925` | #25 | change(ci): remove lint PR comment |
+| `cca8b4ef4e3f` | #25 | fix(ci): unify amd64/arm64 docker pipelines |
+| `41c85fb9469b` | #26 | fix(agents.md): fix documentation on subprocess isolation in tests |

--- a/docs/relay-connector-contract.md
+++ b/docs/relay-connector-contract.md
@@ -19,6 +19,9 @@ upstream invariants:
 - The connector returns a capability descriptor before events flow.
 - Inbound events use the same session-key discriminators as native platform
   adapters.
+- Relay source metadata uses `scope_id` as the canonical platform-neutral
+  tenant discriminator; `guild_id` is a deprecated alias that Rust readers
+  dual-read and Rust writers dual-write during the migration overlap.
 - Platform signatures, encrypted payloads, and follow-up tokens are verified or
   vaulted by the connector, never leaked into the gateway.
 - Interrupts route by session key and cancel only the active turn for that


### PR DESCRIPTION
## Summary
- Added shared Rust subprocess environment sanitization and applied it to gateway command hooks and quick exec.
- Added Slack startup auth.test scope audit for stale group-DM installs missing mpim coverage.
- Added relay/session `scope_id` canonical handling with `guild_id` compatibility dual-read/write.
- Added gateway fallback user error notifications with logged notification-send failures.
- Added OAuth redirect regression coverage for arbitrary self-hosted `http://` callback hosts.
- Updated parity queue/proof metadata for the closed upstream deltas.

## Verification
- `cargo test -p hermes-core subprocess_env -- --nocapture`
- `cargo test -p hermes-auth authorization_url_allows_http_redirect_with_arbitrary_host -- --nocapture`
- `cargo test -p hermes-gateway --features slack --lib gateway_agent_error -- --nocapture`
- `cargo test -p hermes-gateway --features slack --lib gateway_error_notification -- --nocapture`
- `cargo test -p hermes-gateway --features slack --lib slack_group_dm_scope_warning -- --nocapture`
- `cargo test -p hermes-gateway --features slack --lib slack_auth_test -- --nocapture`
- `cargo test -p hermes-gateway --features slack --lib command_hook_sanitizes_credential_environment -- --nocapture`
- `cargo test -p hermes-gateway --features slack --lib gateway_quick_exec_sanitizes_credential_environment -- --nocapture`
- `cargo test -p hermes-gateway --features slack --lib relay_scope_id -- --nocapture`
- `cargo test -p hermes-gateway --features slack --lib session_source_scope_id -- --nocapture`
- `cargo check -p hermes-cli --features gateway-slack`
- `cargo fmt --all --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `scripts/clippy-warning-gate.sh --check` -> `seen=183 allowlist=183 new=0 stale=0`
- `git diff --check`
- `jq empty docs/parity/queue-overrides.json docs/parity/upstream-missing-queue.json docs/parity/global-parity-proof.json`
- `test ! -d target`

## Parity Delta
- pending `40 -> 35`
- ported `523 -> 527`
- superseded `6996 -> 6997`
