### PR TITLE
parity(display): add friendly tool labels

### DIFF
--- a/crates/hermes-cli-ui/src/tool_preview.rs
+++ b/crates/hermes-cli-ui/src/tool_preview.rs
@@ -314,6 +314,79 @@ fn read_file_preview(map: &Map<String, Value>) -> Option<String> {
     })
 }
 
+pub fn tool_friendly_verb(tool_name: &str) -> Option<&'static str> {
+    match tool_name {
+        "web_search" => Some("Searching the web"),
+        "web_extract" => Some("Reading"),
+        "web_crawl" => Some("Crawling"),
+        "browser_navigate" => Some("Browsing"),
+        "browser_click" => Some("Clicking"),
+        "browser_type" => Some("Typing"),
+        "browser_scroll" => Some("Scrolling"),
+        "browser_snapshot" => Some("Capturing"),
+        "read_file" => Some("Reading"),
+        "write_file" => Some("Writing"),
+        "patch" => Some("Editing"),
+        "search_files" => Some("Searching files"),
+        "terminal" => Some("Running"),
+        "execute_code" => Some("Running code"),
+        "image_generate" => Some("Generating image"),
+        "video_generate" => Some("Generating video"),
+        "text_to_speech" => Some("Generating speech"),
+        "vision_analyze" => Some("Looking at the image"),
+        "video_analyze" => Some("Looking at the video"),
+        "session_search" => Some("Searching past sessions"),
+        "skill_view" => Some("Reading skill"),
+        "skills_list" => Some("Listing skills"),
+        "skill_manage" => Some("Updating skill"),
+        "delegate_task" => Some("Delegating"),
+        "schedule_cronjob" | "cronjob" => Some("Scheduling"),
+        "list_cronjobs" => Some("Listing cron jobs"),
+        "remove_cronjob" => Some("Removing cron job"),
+        "clarify" => Some("Asking"),
+        "memory" => Some("Updating memory"),
+        "todo" => Some("Updating tasks"),
+        "send_message" => Some("Sending message"),
+        _ => None,
+    }
+}
+
+pub fn tool_friendly_connector(tool_name: &str) -> &'static str {
+    match tool_name {
+        "web_search" | "search_files" | "spotify_search" => " for ",
+        _ => " ",
+    }
+}
+
+pub fn tool_friendly_drops_preview(tool_name: &str) -> bool {
+    matches!(tool_name, "skills_list" | "session_search")
+}
+
+pub fn build_tool_label_from_preview(tool_name: &str, preview: Option<&str>) -> Option<String> {
+    let verb = tool_friendly_verb(tool_name)?;
+    if tool_friendly_drops_preview(tool_name) {
+        return Some(verb.to_string());
+    }
+    let preview = preview.map(str::trim).filter(|value| !value.is_empty());
+    Some(match preview {
+        Some(preview) => format!("{verb}{}{preview}", tool_friendly_connector(tool_name)),
+        None => verb.to_string(),
+    })
+}
+
+pub fn build_tool_label_from_value(
+    tool_name: &str,
+    args: &Value,
+    max_len: usize,
+    friendly_labels: bool,
+) -> Option<String> {
+    let preview = build_tool_preview_from_value(tool_name, args, max_len);
+    if !friendly_labels {
+        return preview;
+    }
+    build_tool_label_from_preview(tool_name, preview.as_deref()).or(preview)
+}
+
 fn value_to_scalar_string(value: &Value) -> Option<String> {
     match value {
         Value::String(s) => Some(s.clone()),
@@ -557,6 +630,17 @@ pub fn build_gateway_tool_progress_message(
     mode: &str,
     max_len: usize,
 ) -> Option<String> {
+    build_gateway_tool_progress_message_with_labels(platform, tool_name, args, mode, max_len, true)
+}
+
+pub fn build_gateway_tool_progress_message_with_labels(
+    platform: &str,
+    tool_name: &str,
+    args: &Value,
+    mode: &str,
+    max_len: usize,
+    friendly_labels: bool,
+) -> Option<String> {
     let mode = mode.trim().to_ascii_lowercase();
     if matches!(mode.as_str(), "" | "off" | "none" | "false" | "0") {
         return None;
@@ -591,10 +675,17 @@ pub fn build_gateway_tool_progress_message(
         ));
     }
 
-    match build_tool_preview_from_value(tool_name, args, max_len.max(40)) {
-        Some(preview) if !preview.trim().is_empty() => {
-            Some(format!("{emoji} {tool_name}: {preview}"))
-        }
+    if !friendly_labels {
+        return match build_tool_preview_from_value(tool_name, args, max_len.max(40)) {
+            Some(preview) if !preview.trim().is_empty() => {
+                Some(format!("{emoji} {tool_name}: {preview}"))
+            }
+            _ => Some(format!("{emoji} {tool_name}")),
+        };
+    }
+
+    match build_tool_label_from_value(tool_name, args, max_len.max(40), true) {
+        Some(label) if !label.trim().is_empty() => Some(format!("{emoji} {label}")),
         _ => Some(format!("{emoji} {tool_name}")),
     }
 }
@@ -665,6 +756,46 @@ mod tests {
             build_tool_preview_from_value("web_search", &json!({"query":"example search"}), 40)
                 .unwrap();
         assert_eq!(fallback, "example search");
+    }
+
+    #[test]
+    fn friendly_tool_labels_phrase_builtin_tools_and_preserve_custom_previews() {
+        let web =
+            build_tool_label_from_value("web_search", &json!({"query":"example search"}), 80, true)
+                .unwrap();
+        assert_eq!(web, "Searching the web for example search");
+
+        let terminal = build_tool_label_from_value(
+            "terminal",
+            &json!({"command":"cd /repo && cargo test --workspace --quiet 2>&1 | tail -20"}),
+            80,
+            true,
+        )
+        .unwrap();
+        assert_eq!(terminal, "Running cargo test --workspace --quiet");
+
+        let skills =
+            build_tool_label_from_value("skills_list", &json!({"category":"creative"}), 80, true)
+                .unwrap();
+        assert_eq!(skills, "Listing skills");
+
+        let disabled = build_tool_label_from_value(
+            "web_search",
+            &json!({"query":"example search"}),
+            80,
+            false,
+        )
+        .unwrap();
+        assert_eq!(disabled, "example search");
+
+        let custom = build_tool_label_from_value(
+            "custom_provider_search",
+            &json!({"query":"semantic index"}),
+            80,
+            true,
+        )
+        .unwrap();
+        assert_eq!(custom, "semantic index");
     }
 
     #[test]
@@ -765,10 +896,25 @@ mod tests {
         )
         .unwrap();
 
-        assert!(msg.starts_with("💻 terminal: "));
+        assert!(msg.starts_with("💻 Running "));
         assert!(!msg.contains("```bash"));
         assert!(msg.contains("cargo test --workspace"));
         assert!(!msg.contains("tail -20"));
+    }
+
+    #[test]
+    fn gateway_tool_progress_can_disable_friendly_labels_for_legacy_debug() {
+        let msg = build_gateway_tool_progress_message_with_labels(
+            "sms",
+            "web_search",
+            &json!({"query":"example search"}),
+            "all",
+            80,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(msg, "🔍 web_search: example search");
     }
 
     #[test]

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -51,7 +51,7 @@ use hermes_cli::runtime_tool_wiring::{
 use hermes_cli::terminal_backend::build_terminal_backend;
 use hermes_cli::App;
 use hermes_cli_ui::tool_preview::{
-    build_gateway_tool_progress_message, build_tool_preview_from_value, tool_emoji,
+    build_gateway_tool_progress_message_with_labels, build_tool_label_from_value, tool_emoji,
 };
 use hermes_config::{
     gateway_pid_path_in, hermes_home, load_config, load_user_config_file, save_config_yaml,

--- a/crates/hermes-cli/src/main/gateway_command.rs
+++ b/crates/hermes-cli/src/main/gateway_command.rs
@@ -319,14 +319,17 @@ async fn run_gateway(
                             &ctx.platform,
                             ctx.tool_progress.as_deref(),
                         );
+                        let friendly_tool_labels =
+                            config.display.friendly_tool_labels_enabled();
                         let tool_progress_seen = Arc::new(Mutex::new(HashSet::<String>::new()));
                         let gateway_for_tool_progress = gateway_for_review.clone();
                         let platform_for_tool_progress = ctx.platform.clone();
                         let chat_for_tool_progress = ctx.chat_id.clone();
                         let on_tool_start: Box<dyn Fn(&str, &serde_json::Value) + Send + Sync> =
                             Box::new(move |name: &str, args: &serde_json::Value| {
-                                let preview = build_tool_preview_from_value(name, args, 60)
-                                    .unwrap_or_default();
+                                let preview =
+                                    build_tool_label_from_value(name, args, 60, friendly_tool_labels)
+                                        .unwrap_or_default();
                                 let mut event = serde_json::json!({
                                     "phase": "start",
                                     "name": name,
@@ -343,12 +346,14 @@ async fn run_gateway(
                                     name,
                                     &tool_progress_seen,
                                 ) {
-                                    if let Some(message) = build_gateway_tool_progress_message(
+                                    if let Some(message) =
+                                        build_gateway_tool_progress_message_with_labels(
                                         &platform_for_tool_progress,
                                         name,
                                         args,
                                         &tool_progress_mode,
                                         60,
+                                        friendly_tool_labels,
                                     ) {
                                         let gw = gateway_for_tool_progress.clone();
                                         let platform = platform_for_tool_progress.clone();
@@ -602,14 +607,17 @@ async fn run_gateway(
                             &ctx.platform,
                             ctx.tool_progress.as_deref(),
                         );
+                        let friendly_tool_labels =
+                            config.display.friendly_tool_labels_enabled();
                         let tool_progress_seen = Arc::new(Mutex::new(HashSet::<String>::new()));
                         let gateway_for_tool_progress = gateway_for_review.clone();
                         let platform_for_tool_progress = ctx.platform.clone();
                         let chat_for_tool_progress = ctx.chat_id.clone();
                         let on_tool_start: Box<dyn Fn(&str, &serde_json::Value) + Send + Sync> =
                             Box::new(move |name: &str, args: &serde_json::Value| {
-                                let preview = build_tool_preview_from_value(name, args, 60)
-                                    .unwrap_or_default();
+                                let preview =
+                                    build_tool_label_from_value(name, args, 60, friendly_tool_labels)
+                                        .unwrap_or_default();
                                 let mut event = serde_json::json!({
                                     "phase": "start",
                                     "name": name,
@@ -626,12 +634,14 @@ async fn run_gateway(
                                     name,
                                     &tool_progress_seen,
                                 ) {
-                                    if let Some(message) = build_gateway_tool_progress_message(
+                                    if let Some(message) =
+                                        build_gateway_tool_progress_message_with_labels(
                                         &platform_for_tool_progress,
                                         name,
                                         args,
                                         &tool_progress_mode,
                                         60,
+                                        friendly_tool_labels,
                                     ) {
                                         let gw = gateway_for_tool_progress.clone();
                                         let platform = platform_for_tool_progress.clone();
@@ -1463,4 +1473,3 @@ async fn run_gateway_setup(cli: &Cli) -> Result<(), AgentError> {
     println!("Next step: `hermes gateway start`");
     Ok(())
 }
-

--- a/crates/hermes-cli/src/tool_preview.rs
+++ b/crates/hermes-cli/src/tool_preview.rs
@@ -1,6 +1,7 @@
 //! Compatibility re-export for CLI tool-preview presentation helpers.
 
 pub use hermes_cli_ui::tool_preview::{
-    build_gateway_tool_progress_message, build_tool_preview_from_value,
+    build_gateway_tool_progress_message, build_gateway_tool_progress_message_with_labels,
+    build_tool_label_from_value, build_tool_preview_from_value,
     platform_supports_markdown_code_blocks, tool_emoji,
 };

--- a/crates/hermes-config/src/config.rs
+++ b/crates/hermes-config/src/config.rs
@@ -330,7 +330,7 @@ impl ToolOutputConfig {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DisplayConfig {
     /// Enable `/verbose` as a runtime tool-progress cycling command.
     #[serde(
@@ -364,9 +364,31 @@ pub struct DisplayConfig {
     )]
     pub memory_notifications: Option<bool>,
 
+    /// Render built-in tool progress with human-phrased labels instead of raw tool ids.
+    #[serde(
+        default = "default_true",
+        deserialize_with = "deserialize_boolish",
+        skip_serializing_if = "is_true"
+    )]
+    pub friendly_tool_labels: bool,
+
     /// Per-platform display overrides keyed by normalized platform name.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub platforms: BTreeMap<String, PlatformDisplayConfig>,
+}
+
+impl Default for DisplayConfig {
+    fn default() -> Self {
+        Self {
+            tool_progress_command: false,
+            tool_progress: None,
+            busy_input_mode: None,
+            busy_ack_enabled: None,
+            memory_notifications: None,
+            friendly_tool_labels: true,
+            platforms: BTreeMap::new(),
+        }
+    }
 }
 
 impl DisplayConfig {
@@ -404,6 +426,10 @@ impl DisplayConfig {
 
     pub fn memory_notifications_enabled(&self) -> bool {
         self.memory_notifications.unwrap_or(true)
+    }
+
+    pub fn friendly_tool_labels_enabled(&self) -> bool {
+        self.friendly_tool_labels
     }
 }
 

--- a/crates/hermes-config/src/config/tests.rs
+++ b/crates/hermes-config/src/config/tests.rs
@@ -374,6 +374,7 @@ display:
   busy_input_mode: steer
   busy_ack_enabled: "false"
   memory_notifications: "false"
+  friendly_tool_labels: "false"
   platforms:
     telegram:
       tool_progress: off
@@ -390,6 +391,7 @@ agent:
         assert_eq!(cfg.display.normalized_busy_input_mode(), "steer");
         assert!(!cfg.display.busy_ack_enabled());
         assert!(!cfg.display.memory_notifications_enabled());
+        assert!(!cfg.display.friendly_tool_labels_enabled());
         assert_eq!(
             cfg.agent.normalized_service_tier().as_deref(),
             Some("priority")
@@ -404,6 +406,8 @@ display:
         )
         .expect("quoted false");
         assert!(!disabled.display.tool_progress_command_enabled());
+        assert!(disabled.display.friendly_tool_labels_enabled());
+        assert!(DisplayConfig::default().friendly_tool_labels_enabled());
     }
 
     #[test]

--- a/crates/hermes-config/src/loader/config_write.rs
+++ b/crates/hermes-config/src/loader/config_write.rs
@@ -199,6 +199,7 @@ pub fn display_config_env_bridge_pairs() -> &'static [(&'static str, &'static st
             "memory_notifications",
             "HERMES_MEMORY_NOTIFICATIONS_ENABLED",
         ),
+        ("friendly_tool_labels", "HERMES_FRIENDLY_TOOL_LABELS"),
     ]
 }
 

--- a/crates/hermes-config/src/loader/env_bridges.rs
+++ b/crates/hermes-config/src/loader/env_bridges.rs
@@ -229,6 +229,9 @@ fn bridge_display_config_to_env(display: &DisplayConfig) {
     if let Some(enabled) = display.memory_notifications {
         set_env_if_missing("HERMES_MEMORY_NOTIFICATIONS_ENABLED", enabled.to_string());
     }
+    if !display.friendly_tool_labels_enabled() {
+        set_env_if_missing("HERMES_FRIENDLY_TOOL_LABELS", "false".to_string());
+    }
 }
 
 fn apply_display_env_overrides(config: &mut DisplayConfig) {
@@ -243,6 +246,11 @@ fn apply_display_env_overrides(config: &mut DisplayConfig) {
     if let Some(v) = env_var_nonempty("HERMES_MEMORY_NOTIFICATIONS_ENABLED") {
         if let Some(parsed) = parse_bool_env("HERMES_MEMORY_NOTIFICATIONS_ENABLED", &v) {
             config.memory_notifications = Some(parsed);
+        }
+    }
+    if let Some(v) = env_var_nonempty("HERMES_FRIENDLY_TOOL_LABELS") {
+        if let Some(parsed) = parse_bool_env("HERMES_FRIENDLY_TOOL_LABELS", &v) {
+            config.friendly_tool_labels = parsed;
         }
     }
 }

--- a/crates/hermes-config/src/loader/tests/runtime_bridges.rs
+++ b/crates/hermes-config/src/loader/tests/runtime_bridges.rs
@@ -175,6 +175,7 @@ fn display_config_bridge_map_covers_busy_runtime_keys() {
         "busy_input_mode",
         "busy_ack_enabled",
         "memory_notifications",
+        "friendly_tool_labels",
     ] {
         assert!(keys.contains(key), "missing display bridge key: {key}");
         assert!(
@@ -207,6 +208,11 @@ fn set_user_config_value_bridges_display_runtime_keys() {
             "false",
             "HERMES_MEMORY_NOTIFICATIONS_ENABLED",
         ),
+        (
+            "display.friendly_tool_labels",
+            "false",
+            "HERMES_FRIENDLY_TOOL_LABELS",
+        ),
     ] {
         let result = set_user_config_value(dir.path(), key, value).unwrap();
         assert!(result.wrote_config(), "{key} should write config");
@@ -217,6 +223,7 @@ fn set_user_config_value_bridges_display_runtime_keys() {
     assert!(env_text.contains("HERMES_GATEWAY_BUSY_INPUT_MODE=steer"));
     assert!(env_text.contains("HERMES_GATEWAY_BUSY_ACK_ENABLED=false"));
     assert!(env_text.contains("HERMES_MEMORY_NOTIFICATIONS_ENABLED=false"));
+    assert!(env_text.contains("HERMES_FRIENDLY_TOOL_LABELS=false"));
     clear_display_env_bridge_vars();
 }
 
@@ -233,6 +240,7 @@ fn load_config_bridges_display_yaml_to_env_without_overriding_existing_env() {
 display:
   busy_input_mode: steer
   busy_ack_enabled: false
+  friendly_tool_labels: false
 "#,
     )
     .unwrap();
@@ -243,6 +251,7 @@ display:
 
     assert_eq!(cfg.display.normalized_busy_input_mode(), "queue");
     assert!(!cfg.display.busy_ack_enabled());
+    assert!(!cfg.display.friendly_tool_labels_enabled());
     assert_eq!(
         std::env::var("HERMES_GATEWAY_BUSY_INPUT_MODE")
             .ok()
@@ -251,6 +260,12 @@ display:
     );
     assert_eq!(
         std::env::var("HERMES_GATEWAY_BUSY_ACK_ENABLED")
+            .ok()
+            .as_deref(),
+        Some("false")
+    );
+    assert_eq!(
+        std::env::var("HERMES_FRIENDLY_TOOL_LABELS")
             .ok()
             .as_deref(),
         Some("false")
@@ -337,4 +352,3 @@ terminal:
     );
     clear_terminal_env_bridge_vars();
 }
-

--- a/crates/hermes-config/src/loader/user_config_patch.rs
+++ b/crates/hermes-config/src/loader/user_config_patch.rs
@@ -1,4 +1,4 @@
-const CONFIG_PATCH_HELP: &str = "model, personality, max_turns, system_prompt, prefill_messages_file, model_switch.persist_switch_by_default, budget.max_result_size_chars, budget.max_aggregate_chars, proxy.http, proxy.socks, security.allow_private_urls, web.backend|search_backend|extract_backend|crawl_backend, display.busy_input_mode|busy_ack_enabled|memory_notifications, sessions.auto_prune|retention_days|vacuum_after_prune|min_interval_hours, kanban.dispatch_in_gateway, agent.api_max_retries|preflight_context_compress, delegation.model|provider|base_url|api_key|max_spawn_depth, llm.<provider>.api_key|api_key_env|base_url|model|models|discover_models|api_mode|command|args|request_timeout_seconds|oauth_token_url|oauth_client_id, auxiliary.<task>.provider|model|base_url|api_key|timeout|download_timeout, smart_model_routing.enabled|max_simple_chars|max_simple_words|cheap_model.model|cheap_model.provider";
+const CONFIG_PATCH_HELP: &str = "model, personality, max_turns, system_prompt, prefill_messages_file, model_switch.persist_switch_by_default, budget.max_result_size_chars, budget.max_aggregate_chars, proxy.http, proxy.socks, security.allow_private_urls, web.backend|search_backend|extract_backend|crawl_backend, display.busy_input_mode|busy_ack_enabled|memory_notifications|friendly_tool_labels, sessions.auto_prune|retention_days|vacuum_after_prune|min_interval_hours, kanban.dispatch_in_gateway, agent.api_max_retries|preflight_context_compress, delegation.model|provider|base_url|api_key|max_spawn_depth, llm.<provider>.api_key|api_key_env|base_url|model|models|discover_models|api_mode|command|args|request_timeout_seconds|oauth_token_url|oauth_client_id, auxiliary.<task>.provider|model|base_url|api_key|timeout|download_timeout, smart_model_routing.enabled|max_simple_chars|max_simple_words|cheap_model.model|cheap_model.provider";
 
 fn mask_secret(s: &str) -> String {
     if s.is_empty() {
@@ -179,6 +179,10 @@ fn apply_user_config_patch_dotted(
         ["display", "memory_notifications"] => {
             config.display.memory_notifications =
                 Some(parse_config_bool("display.memory_notifications", value)?);
+        }
+        ["display", "friendly_tool_labels"] => {
+            config.display.friendly_tool_labels =
+                parse_config_bool("display.friendly_tool_labels", value)?;
         }
         ["sessions", "auto_prune"] => {
             let normalized = value.trim().to_ascii_lowercase();
@@ -495,6 +499,9 @@ pub fn user_config_field_display(config: &GatewayConfig, key: &str) -> Result<St
         ["display", "busy_ack_enabled"] => Ok(config.display.busy_ack_enabled().to_string()),
         ["display", "memory_notifications"] => {
             Ok(config.display.memory_notifications_enabled().to_string())
+        }
+        ["display", "friendly_tool_labels"] => {
+            Ok(config.display.friendly_tool_labels_enabled().to_string())
         }
         ["sessions", "auto_prune"] => Ok(config.sessions.auto_prune.to_string()),
         ["sessions", "retention_days"] => Ok(config.sessions.retention_days.to_string()),

--- a/crates/hermes-intelligence/src/display.rs
+++ b/crates/hermes-intelligence/src/display.rs
@@ -166,6 +166,83 @@ pub fn build_tool_preview(
     }
 }
 
+/// Friendly verb phrase for a built-in tool, when the Rust surface knows its semantics.
+pub fn tool_friendly_verb(tool_name: &str) -> Option<&'static str> {
+    match tool_name {
+        "web_search" => Some("Searching the web"),
+        "web_extract" => Some("Reading"),
+        "web_crawl" => Some("Crawling"),
+        "browser_navigate" => Some("Browsing"),
+        "browser_click" => Some("Clicking"),
+        "browser_type" => Some("Typing"),
+        "browser_scroll" => Some("Scrolling"),
+        "browser_snapshot" => Some("Capturing"),
+        "read_file" => Some("Reading"),
+        "write_file" => Some("Writing"),
+        "patch" => Some("Editing"),
+        "search_files" => Some("Searching files"),
+        "terminal" => Some("Running"),
+        "execute_code" => Some("Running code"),
+        "image_generate" => Some("Generating image"),
+        "video_generate" => Some("Generating video"),
+        "text_to_speech" => Some("Generating speech"),
+        "vision_analyze" => Some("Looking at the image"),
+        "video_analyze" => Some("Looking at the video"),
+        "session_search" => Some("Searching past sessions"),
+        "skill_view" => Some("Reading skill"),
+        "skills_list" => Some("Listing skills"),
+        "skill_manage" => Some("Updating skill"),
+        "delegate_task" => Some("Delegating"),
+        "schedule_cronjob" | "cronjob" => Some("Scheduling"),
+        "list_cronjobs" => Some("Listing cron jobs"),
+        "remove_cronjob" => Some("Removing cron job"),
+        "clarify" => Some("Asking"),
+        "memory" => Some("Updating memory"),
+        "todo" => Some("Updating tasks"),
+        "send_message" => Some("Sending message"),
+        _ => None,
+    }
+}
+
+pub fn tool_friendly_connector(tool_name: &str) -> &'static str {
+    match tool_name {
+        "web_search" | "search_files" | "spotify_search" => " for ",
+        _ => " ",
+    }
+}
+
+pub fn tool_friendly_drops_preview(tool_name: &str) -> bool {
+    matches!(tool_name, "skills_list" | "session_search")
+}
+
+/// Build a human-phrased status label while preserving raw previews for custom tools.
+pub fn build_tool_label(
+    tool_name: &str,
+    args: &serde_json::Value,
+    max_len: usize,
+    friendly_labels: bool,
+) -> Option<String> {
+    let preview = build_tool_preview(tool_name, args, max_len);
+    if !friendly_labels {
+        return preview;
+    }
+
+    let Some(verb) = tool_friendly_verb(tool_name) else {
+        return preview;
+    };
+    if tool_friendly_drops_preview(tool_name) {
+        return Some(verb.to_string());
+    }
+    let preview = preview
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    Some(match preview {
+        Some(preview) => format!("{verb}{}{preview}", tool_friendly_connector(tool_name)),
+        None => verb.to_string(),
+    })
+}
+
 /// Format a tool call for display.
 pub fn format_tool_call(name: &str, args: &serde_json::Value) -> String {
     let preview = build_tool_preview(name, args, 60);
@@ -1016,6 +1093,54 @@ mod tests {
         let args = serde_json::json!({"path":"./src/main.ts", "offset":25, "limit":10});
         let preview = build_tool_preview("read_file", &args, 0);
         assert_eq!(preview, Some("main.ts L25-34".to_string()));
+    }
+
+    #[test]
+    fn test_build_tool_label_phrases_builtins_and_preserves_fallbacks() {
+        let web = build_tool_label(
+            "web_search",
+            &serde_json::json!({"query": "rust crates"}),
+            80,
+            true,
+        );
+        assert_eq!(web, Some("Searching the web for rust crates".to_string()));
+
+        let terminal = build_tool_label(
+            "terminal",
+            &serde_json::json!({
+                "command": "cd /repo && cargo test --workspace --quiet 2>&1 | tail -20"
+            }),
+            80,
+            true,
+        );
+        assert_eq!(
+            terminal,
+            Some("Running cargo test --workspace --quiet".to_string())
+        );
+
+        let skills = build_tool_label(
+            "skills_list",
+            &serde_json::json!({"category": "creative"}),
+            80,
+            true,
+        );
+        assert_eq!(skills, Some("Listing skills".to_string()));
+
+        let disabled = build_tool_label(
+            "web_search",
+            &serde_json::json!({"query": "rust crates"}),
+            80,
+            false,
+        );
+        assert_eq!(disabled, Some("rust crates".to_string()));
+
+        let custom = build_tool_label(
+            "custom_provider_search",
+            &serde_json::json!({"query": "semantic index"}),
+            80,
+            true,
+        );
+        assert_eq!(custom, Some("semantic index".to_string()));
     }
 
     #[test]

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 39.0,
+        "actual": 38.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "pass"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-30T05:00:12.179729+00:00",
+  "generated_at_utc": "2026-06-30T06:11:48.660389+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 39.0,
+    "max_queue_pending_commits": 38.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,22 +299,22 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 97,
-      "pending": 39,
-      "ported": 530,
-      "superseded": 7002
+      "pending": 38,
+      "ported": 531,
+      "superseded": 7006
     },
     "by_target_ticket": {
-      "20": 3502,
+      "20": 3505,
       "21": 132,
       "22": 1003,
       "23": 503,
       "24": 25,
       "25": 165,
-      "26": 2338
+      "26": 2339
     },
     "overrides_path": "docs/parity/queue-overrides.json",
     "patch_equivalent_count": 6,
-    "total_commits": 7668
+    "total_commits": 7672
   },
   "release_gate": {
     "checks": [
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 39.0,
+        "actual": 38.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-30T05:00:12.179729+00:00`
+Generated: `2026-06-30T06:11:48.660389+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-30T05:00:12.179729+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 39.0 |
+| `max_queue_pending_commits` | 38.0 |
 
 ## GPAR Ticket Completion
 
@@ -93,13 +93,13 @@ Generated: `2026-06-30T05:00:12.179729+00:00`
 
 ## Queue Summary
 
-- Upstream missing commits tracked: `7668`.
+- Upstream missing commits tracked: `7672`.
 - By target ticket:
-  - `#20`: `3502`
+  - `#20`: `3505`
   - `#21`: `132`
   - `#22`: `1003`
   - `#23`: `503`
   - `#24`: `25`
   - `#25`: `165`
-  - `#26`: `2338`
+  - `#26`: `2339`
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -6583,6 +6583,16 @@
       "disposition": "ported",
       "owner": "rust-runtime",
       "notes": "Ported in Rust platform config: PlatformConfig exposes a first-class typing_indicator flag defaulting true, merge/deserialization preserve explicit false, Python-style root platform blocks lift the key under platforms, and tests cover default, explicit-disable, compatibility lift, and JSON/YAML roundtrip behavior. Rust has no generic Python-style keep-typing loop to spawn, so this is the applicable runtime gate contract."
+    },
+    "481caa66f23c75eede53867e99a68400012cf501": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust display/gateway surfaces: hermes-cli-ui and hermes-intelligence build friendly human-phrased labels for built-in tools, display.friendly_tool_labels defaults on with env/config-set opt-out, gateway tool-start events and progress messages use the label path, verbose mode remains raw/debug-oriented, and focused Rust tests cover default labels plus legacy-off behavior."
+    },
+    "04639adace67c7765eb14a32c78ae4fb62da7fe6": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream already-installed theme picker flags are confined to the absent Electron desktop app under apps/desktop. Hermes Agent Ultra does not ship that theme marketplace/install picker surface; Rust CLI/gateway/TUI UX is the shipped product boundary, so no Rust runtime port applies."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,25 +1,25 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-30T05:00:11.751235+00:00`
+Generated: `2026-06-30T06:11:48.456436+00:00`
 
-- Range: `origin/main..upstream/main`; total commits tracked: `7668`.
+- Range: `origin/main..upstream/main`; total commits tracked: `7672`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
-| #20 | GPAR-01 tests+CI parity | 3502 |
+| #20 | GPAR-01 tests+CI parity | 3505 |
 | #21 | GPAR-02 skills parity | 132 |
 | #22 | GPAR-03 UX parity | 1003 |
 | #23 | GPAR-04 gateway/plugin-memory parity | 503 |
 | #24 | GPAR-05 environments+parsers+benchmarks | 25 |
 | #25 | GPAR-06 packaging/docs/install parity | 165 |
-| #26 | GPAR-07 upstream queue backfill | 2338 |
+| #26 | GPAR-07 upstream queue backfill | 2339 |
 
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 97 |
-| pending | 39 |
-| ported | 530 |
-| superseded | 7002 |
+| pending | 38 |
+| ported | 531 |
+| superseded | 7006 |
 
 ## First 100 Pending Commits
 
@@ -60,7 +60,6 @@ Generated: `2026-06-30T05:00:11.751235+00:00`
 | `66ba9e06d925` | #25 | change(ci): remove lint PR comment |
 | `cca8b4ef4e3f` | #25 | fix(ci): unify amd64/arm64 docker pipelines |
 | `41c85fb9469b` | #26 | fix(agents.md): fix documentation on subprocess isolation in tests |
-| `481caa66f23c` | #20 | feat(display): friendly human-phrased tool labels for built-in tools (#55166) |
 | `9ce79cd64212` | #20 | feat(xai): Imagine public-URL storage, chaining & video edit/extend |
 | `5a3d7fb99d1f` | #26 | fix(xai): suppress false-positive windows-footgun on binary image read |
 | `d4c14011ebbc` | #21 | feat(claude-design): add surface-first conditioning + slop diagnostic (#55399) |


### PR DESCRIPTION
## Summary
- add Rust-native friendly tool labels for built-in tool progress surfaces
- wire `display.friendly_tool_labels` as a default-on config flag with env/config-set opt-out
- route gateway tool-start events and progress messages through the friendly label path while keeping verbose mode raw/debug-oriented
- mark the upstream friendly-labels commit ported and the desktop theme-picker commit superseded in the parity ledger

## Validation
- `cargo fmt --all --check`
- `cargo test -p hermes-cli-ui tool_preview -- --nocapture` -> 15 passed
- `cargo test -p hermes-intelligence display -- --nocapture` -> 13 passed
- `cargo test -p hermes-config display -- --nocapture` -> 4 passed
- `cargo check -p hermes-cli --features gateway-slack`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `jq empty docs/parity/queue-overrides.json docs/parity/upstream-missing-queue.json docs/parity/global-parity-proof.json`
- `git diff --check`
- `scripts/clippy-warning-gate.sh --check` -> seen=183 allowlist=183 new=0 stale=0
- `test ! -d target` -> no-local-target

## Parity Delta
- regenerated queue summary: pending=38, ported=531, superseded=7006, mirrored=97
