### PR TITLE
parity(gateway): close WhatsApp media deltas

### DIFF
--- a/crates/hermes-cli/src/main/gateway_adapters.rs
+++ b/crates/hermes-cli/src/main/gateway_adapters.rs
@@ -353,6 +353,7 @@ async fn register_gateway_adapters(
                     token,
                     phone_number_id: extra_string(platform_cfg, "phone_number_id"),
                     business_account_id: extra_string(platform_cfg, "business_account_id"),
+                    api_base_url: extra_string(platform_cfg, "api_base_url"),
                     verify_token: extra_string(platform_cfg, "verify_token"),
                     reply_prefix: platform_cfg
                         .extra

--- a/crates/hermes-gateway/src/platforms/whatsapp.rs
+++ b/crates/hermes-gateway/src/platforms/whatsapp.rs
@@ -17,7 +17,7 @@ use hermes_core::traits::{ParseMode, PlatformAdapter};
 
 use crate::adapter::{AdapterProxyConfig, BasePlatformAdapter};
 
-const WHATSAPP_API_BASE: &str = "https://graph.facebook.com/v18.0";
+const DEFAULT_WHATSAPP_API_BASE: &str = "https://graph.facebook.com/v18.0";
 const MAX_WHATSAPP_MESSAGE_LENGTH: usize = 4096;
 
 // ---------------------------------------------------------------------------
@@ -51,6 +51,10 @@ pub struct WhatsAppConfig {
     /// WhatsApp Business Account ID.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub business_account_id: Option<String>,
+
+    /// Optional WhatsApp Cloud API base URL override for tests/private gateways.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_base_url: Option<String>,
 
     /// Webhook verify token for incoming events.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -126,6 +130,16 @@ impl WhatsAppAdapter {
 
     pub fn config(&self) -> &WhatsAppConfig {
         &self.config
+    }
+
+    fn phone_endpoint(&self, phone_id: &str, endpoint: &str) -> String {
+        let base = self
+            .config
+            .api_base_url
+            .as_deref()
+            .unwrap_or(DEFAULT_WHATSAPP_API_BASE)
+            .trim_end_matches('/');
+        format!("{}/{}/{}", base, phone_id, endpoint.trim_start_matches('/'))
     }
 
     /// Convert common Markdown shapes to WhatsApp's lightweight formatting.
@@ -248,7 +262,7 @@ impl WhatsAppAdapter {
             .as_deref()
             .ok_or_else(|| GatewayError::SendFailed("phone_number_id not configured".into()))?;
 
-        let url = format!("{}/{}/messages", WHATSAPP_API_BASE, phone_id);
+        let url = self.phone_endpoint(phone_id, "messages");
         let body = build_text_body(to, text);
 
         let resp = self
@@ -415,7 +429,7 @@ impl WhatsAppAdapter {
             .as_deref()
             .ok_or_else(|| GatewayError::SendFailed("phone_number_id not configured".into()))?;
 
-        let url = format!("{}/{}/messages", WHATSAPP_API_BASE, phone_id);
+        let url = self.phone_endpoint(phone_id, "messages");
         let body = serde_json::json!({
             "messaging_product": "whatsapp",
             "status": "read",
@@ -456,7 +470,7 @@ impl WhatsAppAdapter {
             .as_deref()
             .ok_or_else(|| GatewayError::SendFailed("phone_number_id not configured".into()))?;
 
-        let url = format!("{}/{}/messages", WHATSAPP_API_BASE, phone_id);
+        let url = self.phone_endpoint(phone_id, "messages");
         let body = build_reaction_body(to, message_id, emoji);
 
         let resp = self
@@ -494,7 +508,7 @@ impl WhatsAppAdapter {
             .as_deref()
             .ok_or_else(|| GatewayError::SendFailed("phone_number_id not configured".into()))?;
 
-        let url = format!("{}/{}/messages", WHATSAPP_API_BASE, phone_id);
+        let url = self.phone_endpoint(phone_id, "messages");
         let body = build_link_media_body(to, media_type, media_url, caption);
 
         let resp = self
@@ -573,12 +587,15 @@ fn build_uploaded_media_body(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use wiremock::matchers::{body_json, header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn config() -> WhatsAppConfig {
         WhatsAppConfig {
             token: "token".to_string(),
             phone_number_id: Some("phone-1".to_string()),
             business_account_id: None,
+            api_base_url: None,
             verify_token: None,
             reply_prefix: None,
             require_mention: false,
@@ -756,6 +773,59 @@ mod tests {
         );
         assert_eq!(cleaned, "what is the weather?");
     }
+
+    #[tokio::test]
+    async fn send_file_uploads_then_sends_native_image_payload() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/phone-1/media"))
+            .and(header("authorization", "Bearer token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "media-123"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/phone-1/messages"))
+            .and(header("authorization", "Bearer token"))
+            .and(body_json(serde_json::json!({
+                "messaging_product": "whatsapp",
+                "to": "15551234567",
+                "type": "image",
+                "image": {
+                    "id": "media-123",
+                    "caption": "native caption"
+                }
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "messages": [{"id": "wamid.1"}]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let image_path = dir.path().join("photo.png");
+        tokio::fs::write(&image_path, b"fake-png")
+            .await
+            .expect("write image");
+        let adapter = WhatsAppAdapter::new(WhatsAppConfig {
+            api_base_url: Some(server.uri()),
+            ..config()
+        })
+        .expect("adapter");
+
+        adapter
+            .send_file(
+                "+1 (555) 123-4567",
+                image_path.to_str().expect("utf8 path"),
+                Some("native caption"),
+            )
+            .await
+            .expect("send native image");
+        server.verify().await;
+    }
 }
 
 #[async_trait]
@@ -820,7 +890,7 @@ impl PlatformAdapter for WhatsAppAdapter {
         let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("file");
 
         // Step 1: Upload media to WhatsApp Cloud API
-        let upload_url = format!("{}/{}/media", WHATSAPP_API_BASE, phone_id);
+        let upload_url = self.phone_endpoint(phone_id, "media");
         let part = reqwest::multipart::Part::bytes(file_bytes)
             .file_name(file_name.to_string())
             .mime_str(mime)
@@ -859,7 +929,7 @@ impl PlatformAdapter for WhatsAppAdapter {
             _ => "document",
         };
 
-        let send_url = format!("{}/{}/messages", WHATSAPP_API_BASE, phone_id);
+        let send_url = self.phone_endpoint(phone_id, "messages");
         let mut media_obj = serde_json::json!({ "id": media_id });
         if let Some(cap) = caption {
             media_obj["caption"] = serde_json::Value::String(cap.to_string());

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 38.0,
+        "actual": 29.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "pass"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-30T06:11:48.660389+00:00",
+  "generated_at_utc": "2026-06-30T07:33:14.036823+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 38.0,
+    "max_queue_pending_commits": 29.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,9 +299,9 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 97,
-      "pending": 38,
-      "ported": 531,
-      "superseded": 7006
+      "pending": 29,
+      "ported": 533,
+      "superseded": 7013
     },
     "by_target_ticket": {
       "20": 3505,
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 38.0,
+        "actual": 29.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-30T06:11:48.660389+00:00`
+Generated: `2026-06-30T07:33:14.036823+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-30T06:11:48.660389+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 38.0 |
+| `max_queue_pending_commits` | 29.0 |
 
 ## GPAR Ticket Completion
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -6593,6 +6593,51 @@
       "disposition": "superseded",
       "owner": "rust-runtime",
       "notes": "Upstream already-installed theme picker flags are confined to the absent Electron desktop app under apps/desktop. Hermes Agent Ultra does not ship that theme marketplace/install picker surface; Rust CLI/gateway/TUI UX is the shipped product boundary, so no Rust runtime port applies."
+    },
+    "5636c22828b0be1eadaf8968c7033efb27f705fa": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Photon Spectrum TS sidecar upgrade is confined to the Python/Node Photon plugin bridge. Hermes Agent Ultra does not ship the Photon sidecar in the Rust runtime; shipped Rust gateway adapters cover first-class platform integrations without vendoring this JS bridge."
+    },
+    "4345b3e767c73405e143b2f03a1e4e7773c2b472": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Photon Spectrum TS v8 sidecar upgrade only changes the absent Python/Node Photon bridge. There is no Rust Photon sidecar/package-lock surface to update, so the Rust product boundary supersedes this dependency churn."
+    },
+    "882730026739c51e6ae5c7cbe47e9b64a920a065": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Photon tapback correlation targets the absent Photon adapter and Spectrum TS sidecar. Hermes Agent Ultra does not ship that bridge; Rust gateway reaction/media behavior is owned by the compiled platform adapters instead."
+    },
+    "cd592c105cbbc0bbf927b30ee9d061b1dd7b0b1b": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported/superseded in Rust WhatsApp gateway: PlatformAdapter::send_file uploads local media to WhatsApp Cloud API, maps extension categories to native image/video/audio/document payloads, then sends the uploaded media id. This batch adds api_base_url configurability and a wiremock test proving upload-then-native-image send with caption through the Rust adapter and gateway media path."
+    },
+    "520212cc593dd8bc0472002877e31d7310bd295b": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream live agent terminal streaming changes are Electron desktop right-sidebar UI code. Hermes Agent Ultra does not ship the Electron desktop terminal tab surface; Rust CLI/gateway/TUI terminal execution and streaming surfaces are the product boundary."
+    },
+    "e117cfdff08b7e43b7d0b7f7e661be7b710e7a4f": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream live agent terminals and agent-driven tab close are Electron desktop UI changes. The Rust runtime has no apps/desktop tab lifecycle to port; CLI/gateway session lifecycle is implemented in compiled Rust."
+    },
+    "adacb16d624336f18380a0a40b4b704c699c3f10": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream readable agent terminal tab fixes are limited to the absent Electron desktop terminal UI. Hermes Agent Ultra's shipped runtime uses Rust CLI/gateway/TUI surfaces, so no Rust port applies."
+    },
+    "e5d22ab80d979d38d8062e666af418ed847618a9": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream Daytona fix quotes a Python SDK shell mkdir in the single-upload path. Hermes Agent Ultra's Rust DaytonaBackend does not run mkdir for writes; it sends PUT /workspace/{id}/file with the remote path URL-encoded, so the shell-metacharacter injection class is absent."
+    },
+    "5a3d7fb99d1f23d3156e17575cabc664fc7fe593": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported/superseded by Rust binary image handling: xAI/OpenRouter-compatible image references use std::fs::read/tokio::fs::read byte reads before base64 data-URL encoding, never text decoding. Existing Rust image/video generation tests cover local image paths encoded as data URLs, so the Python windows-footgun suppression is not needed."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-30T06:11:48.456436+00:00`
+Generated: `2026-06-30T07:33:13.879112+00:00`
 
 - Range: `origin/main..upstream/main`; total commits tracked: `7672`.
 
@@ -17,20 +17,16 @@ Generated: `2026-06-30T06:11:48.456436+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 97 |
-| pending | 38 |
-| ported | 531 |
-| superseded | 7006 |
+| pending | 29 |
+| ported | 533 |
+| superseded | 7013 |
 
 ## First 100 Pending Commits
 
 | SHA | Ticket | Subject |
 | --- | ---: | --- |
-| `5636c22828b0` | #20 | feat(photon): upgrade spectrum-ts sidecar to v7.0.0 |
-| `4345b3e767c7` | #20 | fix(photon): upgrade spectrum-ts sidecar to v8.0.0 |
-| `882730026739` | #20 | fix(photon): correlate tapbacks to bot message context |
 | `50f685521734` | #20 | feat(moa): make /moa one-shot only; route preset switching through the model picker |
 | `f67c0b3e60ba` | #21 | docs(hermes-agent skill): cover v0.13–v0.17 features, fix stale claims, tighten (#53566) |
-| `cd592c105cbb` | #20 | feat(send_message): native WhatsApp media delivery via Baileys bridge (#53598) |
 | `917f6bdb00b8` | #20 | fix(tools): let vision pick any provider+model, not just OpenRouter (#53606) |
 | `ef17cd204d75` | #20 | fix(windows): stop subprocess console-window popups + add CI guard (#53791) |
 | `5db1430af9ec` | #20 | fix(windows): stop terminal-window popups from background spawns (#53810) |
@@ -48,11 +44,7 @@ Generated: `2026-06-30T06:11:48.456436+00:00`
 | `eeca59f48919` | #20 | fix(windows): hide remaining backend console-flash legs missed on main |
 | `b31b0b9d95d1` | #22 | docs: reconcile docs with code across last 3 releases (#54254) |
 | `9a0010fd469f` | #20 | fix(windows): cover remaining console-flash spawn legs (#54417) |
-| `e5d22ab80d97` | #20 | fix(daytona): quote single-upload mkdir parent path (#54440) |
 | `ee22d853eb13` | #26 | fix(windows): hide pdftoppm console flash on PDF attach |
-| `520212cc593d` | #26 | feat(desktop): stream agent terminal output live instead of polling |
-| `e117cfdff08b` | #20 | feat(desktop): live agent terminals + agent-driven tab close |
-| `adacb16d6243` | #26 | fix(desktop): make agent terminal tabs fully readable |
 | `dff491a2b993` | #22 | feat(cli): add headless `hermes serve` backend; desktop no longer launches `dashboard` |
 | `476875acb9f0` | #22 | Add dashboard backup upload and download |
 | `fd324562d3ad` | #20 | feat(desktop): add context usage breakdown popover |
@@ -61,5 +53,4 @@ Generated: `2026-06-30T06:11:48.456436+00:00`
 | `cca8b4ef4e3f` | #25 | fix(ci): unify amd64/arm64 docker pipelines |
 | `41c85fb9469b` | #26 | fix(agents.md): fix documentation on subprocess isolation in tests |
 | `9ce79cd64212` | #20 | feat(xai): Imagine public-URL storage, chaining & video edit/extend |
-| `5a3d7fb99d1f` | #26 | fix(xai): suppress false-positive windows-footgun on binary image read |
 | `d4c14011ebbc` | #21 | feat(claude-design): add surface-first conditioning + slop diagnostic (#55399) |


### PR DESCRIPTION
## What changed
- Added `WhatsAppConfig::api_base_url` and gateway adapter wiring so the Rust WhatsApp Cloud API client can target deterministic test/private gateway endpoints instead of only the production Graph API base.
- Added a Rust `wiremock` async test proving `PlatformAdapter::send_file` uploads local image bytes to `/media`, consumes the returned media id, and sends a native WhatsApp image payload with caption to `/messages`.
- Closed the current upstream parity queue slice by porting/superseding WhatsApp media delivery, Photon sidecar-only changes, Electron desktop terminal-only changes, Daytona Python shell-upload quoting, and binary image reference handling.

## Queue delta
- Before this branch: `pending=38` after PR #697.
- After this branch: `mirrored=97 pending=29 ported=533 superseded=7013`.

## Validation
- `cargo fmt --all --check`
- `cargo test -p hermes-gateway --features whatsapp whatsapp -- --nocapture` -> `13 passed`
- `cargo check -p hermes-cli --features gateway-whatsapp`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `jq empty docs/parity/queue-overrides.json docs/parity/upstream-missing-queue.json docs/parity/global-parity-proof.json`
- `git diff --check`
- `scripts/clippy-warning-gate.sh --check` -> `seen=183 allowlist=183 new=0 stale=0`
- `test ! -d target` -> `no-local-target`
