### PR TITLE
parity(windows): suppress helper subprocess consoles

### DIFF
--- a/crates/hermes-agent/src/coding_context.rs
+++ b/crates/hermes-agent/src/coding_context.rs
@@ -9,6 +9,7 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use hermes_core::subprocess::CommandNoWindowExt;
 use serde::{Deserialize, Serialize};
 
 pub const CODING_TOOLSET: &str = "coding";
@@ -555,6 +556,7 @@ fn append_git_snapshot(root: &Path, lines: &mut Vec<String>) {
         .arg("-C")
         .arg(root)
         .args(["status", "--short", "--branch"])
+        .suppress_windows_console()
         .output();
     let Ok(output) = status else {
         return;
@@ -603,6 +605,7 @@ fn git_last_commit(root: &Path) -> Option<String> {
         .arg("-C")
         .arg(root)
         .args(["log", "-1", "--oneline"])
+        .suppress_windows_console()
         .output()
         .ok()?;
     if !output.status.success() {

--- a/crates/hermes-agent/src/context_references.rs
+++ b/crates/hermes-agent/src/context_references.rs
@@ -9,6 +9,7 @@
 use std::collections::VecDeque;
 use std::path::{Component, Path, PathBuf};
 
+use hermes_core::subprocess::CommandNoWindowExt;
 use hermes_intelligence::estimate_tokens_rough;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -349,6 +350,7 @@ async fn expand_git_reference(
     let output = match TokioCommand::new("git")
         .args(args)
         .current_dir(cwd)
+        .suppress_windows_console()
         .output()
         .await
     {

--- a/crates/hermes-agent/src/memory_plugins/byterover.rs
+++ b/crates/hermes-agent/src/memory_plugins/byterover.rs
@@ -16,6 +16,7 @@
 use std::process::Command;
 use std::sync::Mutex;
 
+use hermes_core::subprocess::CommandNoWindowExt;
 use serde_json::{json, Value};
 
 use crate::memory_manager::MemoryProviderPlugin;
@@ -134,7 +135,11 @@ fn run_brv(args: &[&str], _timeout_secs: u64, cwd: &str) -> (bool, String) {
 
     let _ = std::fs::create_dir_all(cwd);
 
-    let result = Command::new(&brv_path).args(args).current_dir(cwd).output();
+    let result = Command::new(&brv_path)
+        .args(args)
+        .current_dir(cwd)
+        .suppress_windows_console()
+        .output();
 
     match result {
         Ok(output) => {

--- a/crates/hermes-cli/src/commands/command_agentic_workflows/swarm_specpatch_studio.rs
+++ b/crates/hermes-cli/src/commands/command_agentic_workflows/swarm_specpatch_studio.rs
@@ -184,6 +184,7 @@ async fn run_shell_capture(command: &str) -> Result<(i32, String, String), Agent
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
+        .suppress_windows_console()
         .output()
         .await
         .map_err(|e| AgentError::Io(format!("shell command failed: {}", e)))?;
@@ -330,6 +331,7 @@ async fn count_git_tracked_files(repo_root: &Path) -> Result<usize, AgentError> 
         .arg("ls-files")
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
+        .suppress_windows_console()
         .output()
         .await
         .map_err(|e| AgentError::Io(format!("git ls-files failed: {}", e)))?;
@@ -578,4 +580,3 @@ async fn handle_studio_command(app: &mut App, args: &[&str]) -> Result<CommandRe
     }
     Ok(CommandResult::Handled)
 }
-

--- a/crates/hermes-cli/src/commands/command_background_browser.rs
+++ b/crates/hermes-cli/src/commands/command_background_browser.rs
@@ -1320,7 +1320,9 @@ fn try_launch_chrome_debug(port: u16, system: &str) -> bool {
         #[cfg(windows)]
         {
             use std::os::windows::process::CommandExt;
-            command.creation_flags(0x00000008 | 0x00000200);
+            command.creation_flags(hermes_core::subprocess::windows_no_window_creation_flags(
+                0x00000008 | 0x00000200,
+            ));
         }
         if command.spawn().is_ok() {
             return true;

--- a/crates/hermes-cli/src/commands/command_background_browser/triage_background.rs
+++ b/crates/hermes-cli/src/commands/command_background_browser/triage_background.rs
@@ -1168,6 +1168,7 @@ fn schedule_background_job_execution(status_path: PathBuf, log_path: PathBuf, ta
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+        cmd.suppress_windows_console();
         // Ensure detached children do not survive runtime/session teardown.
         cmd.kill_on_drop(true);
 

--- a/crates/hermes-cli/src/commands/command_catalog/skill_resolution/install_bootstrap.rs
+++ b/crates/hermes-cli/src/commands/command_catalog/skill_resolution/install_bootstrap.rs
@@ -400,6 +400,7 @@ async fn execute_bootstrap_command(
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    process.suppress_windows_console();
     let output = process.output().await.map_err(|e| {
         AgentError::Io(format!(
             "Failed to execute bootstrap command '{}': {}",
@@ -522,4 +523,3 @@ async fn maybe_run_skill_bootstrap(
 
     Ok(())
 }
-

--- a/crates/hermes-cli/src/commands/command_cli_plugins_memory_mcp.rs
+++ b/crates/hermes-cli/src/commands/command_cli_plugins_memory_mcp.rs
@@ -1,4 +1,5 @@
 include!("command_cli_plugins_memory_mcp/plugins.rs");
+
 pub async fn handle_cli_plugins(
     action: Option<String>,
     name: Option<String>,
@@ -124,6 +125,7 @@ pub async fn handle_cli_plugins(
                         &plugin_name,
                         &target.to_string_lossy(),
                     ])
+                    .suppress_windows_console()
                     .output()
                     .await
                     .map_err(|e| hermes_core::AgentError::Io(format!("git clone failed: {}", e)))?;
@@ -220,6 +222,7 @@ pub async fn handle_cli_plugins(
                 println!("  Cloning from GitHub: {}", git_url);
                 let output = tokio::process::Command::new("git")
                     .args(["clone", "--depth", "1", &git_url, &target.to_string_lossy()])
+                    .suppress_windows_console()
                     .output()
                     .await
                     .map_err(|e| hermes_core::AgentError::Io(format!("git clone failed: {}", e)))?;
@@ -328,6 +331,7 @@ pub async fn handle_cli_plugins(
 
                                 let output = tokio::process::Command::new("git")
                                     .args(["clone", "--depth", "1", url, &target.to_string_lossy()])
+                                    .suppress_windows_console()
                                     .output()
                                     .await
                                     .map_err(|e| {
@@ -440,6 +444,7 @@ pub async fn handle_cli_plugins(
                         let path_s = path.to_string_lossy().to_string();
                         let before = tokio::process::Command::new("git")
                             .args(["-C", &path_s, "rev-parse", "HEAD"])
+                            .suppress_windows_console()
                             .output()
                             .await
                             .map_err(|e| {
@@ -460,6 +465,7 @@ pub async fn handle_cli_plugins(
 
                         let pull = tokio::process::Command::new("git")
                             .args(["-C", &path_s, "pull", "--ff-only"])
+                            .suppress_windows_console()
                             .output()
                             .await
                             .map_err(|e| {
@@ -477,6 +483,7 @@ pub async fn handle_cli_plugins(
 
                         let after = tokio::process::Command::new("git")
                             .args(["-C", &path_s, "rev-parse", "HEAD"])
+                            .suppress_windows_console()
                             .output()
                             .await
                             .map_err(|e| {

--- a/crates/hermes-cli/src/commands/command_cli_plugins_memory_mcp/plugins.rs
+++ b/crates/hermes-cli/src/commands/command_cli_plugins_memory_mcp/plugins.rs
@@ -486,6 +486,7 @@ async fn git_checkout_ref(repo_dir: &std::path::Path, git_ref: &str) -> Result<(
     let dir = repo_dir.to_string_lossy().to_string();
     let fetch = tokio::process::Command::new("git")
         .args(["-C", &dir, "fetch", "--depth", "1", "origin", git_ref])
+        .suppress_windows_console()
         .output()
         .await
         .map_err(|e| e.to_string())?;
@@ -495,6 +496,7 @@ async fn git_checkout_ref(repo_dir: &std::path::Path, git_ref: &str) -> Result<(
     }
     let co = tokio::process::Command::new("git")
         .args(["-C", &dir, "checkout", git_ref])
+        .suppress_windows_console()
         .output()
         .await
         .map_err(|e| e.to_string())?;

--- a/crates/hermes-cli/src/commands/command_dispatch_model/codex_runtime_personality.rs
+++ b/crates/hermes-cli/src/commands/command_dispatch_model/codex_runtime_personality.rs
@@ -127,6 +127,7 @@ fn check_codex_binary_status() -> (bool, String) {
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
+        .suppress_windows_console()
         .output();
     match output {
         Ok(output) if output.status.success() => {

--- a/crates/hermes-cli/src/commands/command_dispatch_model/quick_dispatch.rs
+++ b/crates/hermes-cli/src/commands/command_dispatch_model/quick_dispatch.rs
@@ -36,6 +36,7 @@ async fn run_quick_exec(
         .kill_on_drop(true)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
+        .suppress_windows_console()
         .output();
     let output = match tokio::time::timeout(Duration::from_secs(timeout_secs), child).await {
         Ok(result) => result.map_err(|e| {
@@ -359,4 +360,3 @@ fn handle_toolcards_command(app: &mut App, args: &[&str]) -> Result<CommandResul
 // ---------------------------------------------------------------------------
 // Individual command handlers
 // ---------------------------------------------------------------------------
-

--- a/crates/hermes-cli/src/commands/command_dispatch_model/skills_config_compress/skills_tools_config.rs
+++ b/crates/hermes-cli/src/commands/command_dispatch_model/skills_config_compress/skills_tools_config.rs
@@ -118,6 +118,7 @@ async fn run_skills_subcommand_via_cli(
     cmd.stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    cmd.suppress_windows_console();
     let output = cmd
         .output()
         .await

--- a/crates/hermes-cli/src/commands/command_ops_eval/evolve_and_ops.rs
+++ b/crates/hermes-cli/src/commands/command_ops_eval/evolve_and_ops.rs
@@ -92,6 +92,7 @@ async fn run_current_hermes_cli_command(args: &[&str]) -> Result<String, AgentEr
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
+        .suppress_windows_console()
         .output()
         .await
         .map_err(|e| AgentError::Io(format!("run current hermes command failed: {e}")))?;

--- a/crates/hermes-cli/src/commands/command_ops_eval/performance_autopilot.rs
+++ b/crates/hermes-cli/src/commands/command_ops_eval/performance_autopilot.rs
@@ -31,6 +31,7 @@ async fn run_autopilot_probe_command_with_timeout(
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
+        .suppress_windows_console()
         .kill_on_drop(true);
     let output = tokio::time::timeout(timeout, child.output()).await;
     let finished = chrono::Utc::now();

--- a/crates/hermes-cli/src/commands/mod.rs
+++ b/crates/hermes-cli/src/commands/mod.rs
@@ -28,6 +28,7 @@ use hermes_core::auth_gate::{
     oauth_runtime_gate_for_provider as shared_oauth_runtime_gate_for_provider,
     oauth_runtime_gate_manifest_default, OAuthRuntimeGateManifest,
 };
+use hermes_core::subprocess::CommandNoWindowExt;
 use hermes_core::AgentError;
 use hermes_cron::{
     BlueprintCommandAction, CronJob, DeliverConfig, DeliverTarget, SuggestionJobSpec,

--- a/crates/hermes-cli/src/main/doctor_routes.rs
+++ b/crates/hermes-cli/src/main/doctor_routes.rs
@@ -1,4 +1,6 @@
 /// Handle `hermes doctor`.
+use hermes_core::subprocess::CommandNoWindowExt;
+
 fn build_elite_doctor_diagnostics(cli: &Cli) -> serde_json::Value {
     let provenance_path = provenance_key_path_for_cli(cli);
     let provenance_exists = provenance_path.exists();
@@ -238,6 +240,7 @@ async fn run_doctor(
         print!("  {}... ", name);
         let ok = match tokio::process::Command::new("which")
             .arg(cmd)
+            .suppress_windows_console()
             .output()
             .await
         {
@@ -1218,6 +1221,7 @@ async fn run_legacy_elite_check(cmdline: String, json: bool, strict: bool) -> Re
     }
     let output = tokio::process::Command::new("bash")
         .args(["-lc", &cmdline])
+        .suppress_windows_console()
         .output()
         .await
         .map_err(|e| AgentError::Io(format!("elite-check command failed to start: {}", e)))?;

--- a/crates/hermes-core/src/lib.rs
+++ b/crates/hermes-core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod credits;
 pub mod errors;
 pub mod providers;
 pub mod schema_sanitizer;
+pub mod subprocess;
 pub mod subprocess_env;
 pub mod tool_call_parser;
 pub mod tool_schema;

--- a/crates/hermes-core/src/subprocess.rs
+++ b/crates/hermes-core/src/subprocess.rs
@@ -1,0 +1,64 @@
+//! Cross-platform subprocess helpers.
+//!
+//! Windows launches console-subsystem children in their own console window when
+//! GUI hosts or background workers spawn helpers. Backend helper processes
+//! should opt into `CREATE_NO_WINDOW`; terminal UI processes still control
+//! stdin/stdout normally through their configured pipes.
+
+pub const WINDOWS_CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+pub fn windows_no_window_creation_flags(existing: u32) -> u32 {
+    existing | WINDOWS_CREATE_NO_WINDOW
+}
+
+pub trait CommandNoWindowExt {
+    fn suppress_windows_console(&mut self) -> &mut Self;
+}
+
+impl CommandNoWindowExt for std::process::Command {
+    fn suppress_windows_console(&mut self) -> &mut Self {
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            self.creation_flags(windows_no_window_creation_flags(0));
+        }
+        self
+    }
+}
+
+impl CommandNoWindowExt for tokio::process::Command {
+    fn suppress_windows_console(&mut self) -> &mut Self {
+        #[cfg(windows)]
+        {
+            self.creation_flags(windows_no_window_creation_flags(0));
+        }
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_window_flag_preserves_existing_creation_flags() {
+        assert_eq!(
+            windows_no_window_creation_flags(0x0000_0200),
+            WINDOWS_CREATE_NO_WINDOW | 0x0000_0200
+        );
+    }
+
+    #[test]
+    fn std_command_helper_is_chainable_on_all_platforms() {
+        let mut command = std::process::Command::new("hermes-noop");
+        let returned = command.suppress_windows_console() as *mut _;
+        assert_eq!(returned, &mut command as *mut _);
+    }
+
+    #[test]
+    fn tokio_command_helper_is_chainable_on_all_platforms() {
+        let mut command = tokio::process::Command::new("hermes-noop");
+        let returned = command.suppress_windows_console() as *mut _;
+        assert_eq!(returned, &mut command as *mut _);
+    }
+}

--- a/crates/hermes-cron/src/runner.rs
+++ b/crates/hermes-cron/src/runner.rs
@@ -19,7 +19,9 @@ use hermes_agent::agent_loop::ToolRegistry;
 use hermes_agent::skill_orchestrator::parse_frontmatter;
 use hermes_agent::{AgentConfig, AgentLoop};
 use hermes_config::{load_config, load_prefill_messages, GatewayConfig};
-use hermes_core::{AgentResult, LlmProvider, Message, Skill, ToolSchema};
+use hermes_core::{
+    subprocess::CommandNoWindowExt, AgentResult, LlmProvider, Message, Skill, ToolSchema,
+};
 use hermes_skills::SkillGuard;
 use hermes_tools::{ToolRegistry as ToolsetRegistry, ToolsetManager};
 use regex::Regex;
@@ -297,10 +299,12 @@ fn command_for_script_path(script_path: &Path) -> Command {
     if ext == "sh" || ext == "bash" {
         let mut command = Command::new("/bin/bash");
         command.arg(script_path);
+        command.suppress_windows_console();
         command
     } else {
         let mut command = Command::new(python_for_scripts());
         command.arg(script_path);
+        command.suppress_windows_console();
         command
     }
 }
@@ -639,6 +643,7 @@ impl CronRunner {
             let shell = shell_for_inline_script(job);
             let mut command = Command::new(shell);
             command.arg("-lc").arg(script);
+            command.suppress_windows_console();
             command
         };
 

--- a/crates/hermes-environments/src/docker.rs
+++ b/crates/hermes-environments/src/docker.rs
@@ -5,7 +5,7 @@ use std::sync::Mutex;
 use async_trait::async_trait;
 use tokio::process::Command as TokioCommand;
 
-use hermes_core::{AgentError, CommandOutput, TerminalBackend};
+use hermes_core::{subprocess::CommandNoWindowExt, AgentError, CommandOutput, TerminalBackend};
 
 /// A [`TerminalBackend`] that runs commands inside a Docker container.
 pub struct DockerBackend {
@@ -165,6 +165,7 @@ impl DockerBackend {
 
         let output = TokioCommand::new("docker")
             .args(&args)
+            .suppress_windows_console()
             .output()
             .await
             .map_err(|e| AgentError::Io(format!("Failed to create Docker container: {}", e)))?;
@@ -233,6 +234,7 @@ impl DockerBackend {
         let result = tokio::time::timeout(std::time::Duration::from_secs(timeout_secs), async {
             let output = TokioCommand::new("docker")
                 .args(&args)
+                .suppress_windows_console()
                 .output()
                 .await
                 .map_err(|e| AgentError::Io(format!("Failed to execute docker command: {}", e)))?;
@@ -343,6 +345,7 @@ impl TerminalBackend for DockerBackend {
 
         let output = TokioCommand::new("docker")
             .args(["exec", container_id.as_str(), "sh", "-c", &cat_cmd])
+            .suppress_windows_console()
             .output()
             .await
             .map_err(|e| AgentError::Io(format!("Failed to read file via docker: {}", e)))?;
@@ -372,6 +375,7 @@ impl TerminalBackend for DockerBackend {
             let mkdir_cmd = format!("mkdir -p {}", shlex_quote(&parent_dir));
             let mkdir_output = TokioCommand::new("docker")
                 .args(["exec", container_id.as_str(), "sh", "-c", &mkdir_cmd])
+                .suppress_windows_console()
                 .output()
                 .await
                 .map_err(|e| {
@@ -398,6 +402,7 @@ impl TerminalBackend for DockerBackend {
 
         let output = TokioCommand::new("docker")
             .args(["exec", container_id.as_str(), "sh", "-c", &write_cmd])
+            .suppress_windows_console()
             .output()
             .await
             .map_err(|e| AgentError::Io(format!("Failed to write file via docker: {}", e)))?;
@@ -418,6 +423,7 @@ impl TerminalBackend for DockerBackend {
 
         let output = TokioCommand::new("docker")
             .args(["exec", container_id.as_str(), "test", "-e", path])
+            .suppress_windows_console()
             .output()
             .await
             .map_err(|e| AgentError::Io(format!("Failed to check file via docker: {}", e)))?;

--- a/crates/hermes-environments/src/local.rs
+++ b/crates/hermes-environments/src/local.rs
@@ -16,7 +16,7 @@ use tokio::sync::Mutex as AsyncMutex;
 use tokio::task::JoinHandle;
 
 use hermes_config::{TerminalConfig, TerminalHomeMode};
-use hermes_core::{AgentError, CommandOutput, TerminalBackend};
+use hermes_core::{subprocess::CommandNoWindowExt, AgentError, CommandOutput, TerminalBackend};
 
 const PROCESS_OUTPUT_WINDOW_CHARS: usize = 200_000;
 const PROCESS_PREVIEW_CHARS: usize = 1_000;
@@ -367,6 +367,7 @@ impl LocalBackend {
             let status = std::process::Command::new("kill")
                 .arg("-TERM")
                 .arg(pid.to_string())
+                .suppress_windows_console()
                 .status()
                 .map_err(|e| AgentError::Io(format!("Failed to invoke kill for pid {pid}: {e}")))?;
             if status.success() {
@@ -381,6 +382,7 @@ impl LocalBackend {
         {
             let status = std::process::Command::new("taskkill")
                 .args(["/PID", &pid.to_string(), "/T", "/F"])
+                .suppress_windows_console()
                 .status()
                 .map_err(|e| {
                     AgentError::Io(format!("Failed to invoke taskkill for pid {pid}: {e}"))
@@ -446,6 +448,7 @@ impl TerminalBackend for LocalBackend {
                 if let Some(dir) = workdir {
                     pty_cmd.current_dir(resolve_path(dir)?);
                 }
+                pty_cmd.suppress_windows_console();
 
                 return self
                     .collect_foreground_child(
@@ -492,6 +495,7 @@ impl TerminalBackend for LocalBackend {
         cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
         scrub_subprocess_env(&mut cmd, &self.env_passthrough);
         apply_subprocess_home_policy(&mut cmd, subprocess_home.as_ref());
+        cmd.suppress_windows_console();
 
         if let Some(dir) = workdir {
             cmd.current_dir(resolve_path(dir)?);
@@ -652,6 +656,7 @@ impl TerminalBackend for LocalBackend {
                 if let Some(dir) = workdir {
                     pty_cmd.current_dir(resolve_path(dir)?);
                 }
+                pty_cmd.suppress_windows_console();
 
                 return self
                     .collect_foreground_child(
@@ -683,6 +688,7 @@ impl TerminalBackend for LocalBackend {
         if let Some(dir) = workdir {
             cmd.current_dir(resolve_path(dir)?);
         }
+        cmd.suppress_windows_console();
 
         self.collect_foreground_child(
             cmd,

--- a/crates/hermes-environments/src/singularity.rs
+++ b/crates/hermes-environments/src/singularity.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 use tokio::process::Command as TokioCommand;
 
-use hermes_core::{AgentError, CommandOutput, TerminalBackend};
+use hermes_core::{subprocess::CommandNoWindowExt, AgentError, CommandOutput, TerminalBackend};
 
 /// A [`TerminalBackend`] that runs commands inside a Singularity (Apptainer) container.
 ///
@@ -141,6 +141,7 @@ impl TerminalBackend for SingularityBackend {
             if background {
                 cmd.stdin(std::process::Stdio::null());
             }
+            cmd.suppress_windows_console();
 
             let output = cmd.output().await.map_err(|e| {
                 AgentError::Io(format!("Failed to execute singularity command: {}", e))
@@ -210,6 +211,7 @@ impl TerminalBackend for SingularityBackend {
         let result = tokio::time::timeout(std::time::Duration::from_secs(timeout_secs), async {
             let output = TokioCommand::new(&binary)
                 .args(&args)
+                .suppress_windows_console()
                 .output()
                 .await
                 .map_err(|e| {
@@ -262,6 +264,7 @@ impl TerminalBackend for SingularityBackend {
             let binary = self.binary().to_string();
             let mkdir_output = TokioCommand::new(&binary)
                 .args(&mkdir_args)
+                .suppress_windows_console()
                 .output()
                 .await
                 .map_err(|e| {
@@ -301,6 +304,7 @@ impl TerminalBackend for SingularityBackend {
         let binary = self.binary().to_string();
         let output = TokioCommand::new(&binary)
             .args(&args)
+            .suppress_windows_console()
             .output()
             .await
             .map_err(|e| AgentError::Io(format!("Failed to write file via singularity: {}", e)))?;
@@ -334,6 +338,7 @@ impl TerminalBackend for SingularityBackend {
         let binary = self.binary().to_string();
         let output = TokioCommand::new(&binary)
             .args(&args)
+            .suppress_windows_console()
             .output()
             .await
             .map_err(|e| AgentError::Io(format!("Failed to check file via singularity: {}", e)))?;

--- a/crates/hermes-environments/src/ssh.rs
+++ b/crates/hermes-environments/src/ssh.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use std::process::Stdio;
 use tokio::process::Command as TokioCommand;
 
-use hermes_core::{AgentError, CommandOutput, TerminalBackend};
+use hermes_core::{subprocess::CommandNoWindowExt, AgentError, CommandOutput, TerminalBackend};
 
 /// A [`TerminalBackend`] that runs commands on a remote machine via SSH.
 pub struct SshBackend {
@@ -85,6 +85,7 @@ impl SshBackend {
     fn ssh_command(&self, args: &[String]) -> TokioCommand {
         let mut command = TokioCommand::new("ssh");
         command.args(args).stdin(Stdio::null());
+        command.suppress_windows_console();
         command
     }
 }

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -24,6 +24,7 @@ use hermes_config::{
     QuickCommandConfig,
 };
 use hermes_core::errors::GatewayError;
+use hermes_core::subprocess::CommandNoWindowExt;
 use hermes_core::traits::{ParseMode, PlatformAdapter, SendMessageOptions};
 use hermes_core::types::{Message, MessageRole};
 use hermes_intelligence::{

--- a/crates/hermes-gateway/src/gateway/routing_methods.rs
+++ b/crates/hermes-gateway/src/gateway/routing_methods.rs
@@ -422,6 +422,7 @@ impl Gateway {
             .kill_on_drop(true)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
+            .suppress_windows_console()
             .output();
         let output = match tokio::time::timeout(Duration::from_secs(timeout_secs), child).await {
             Ok(result) => result.map_err(|e| {

--- a/crates/hermes-gateway/src/hooks.rs
+++ b/crates/hermes-gateway/src/hooks.rs
@@ -49,6 +49,7 @@ use std::process::Stdio;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use hermes_core::subprocess::CommandNoWindowExt;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
@@ -448,6 +449,7 @@ impl HookHandler for CommandHookHandler {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+        cmd.suppress_windows_console();
 
         let mut child = cmd
             .spawn()

--- a/crates/hermes-gateway/src/platforms/matrix.rs
+++ b/crates/hermes-gateway/src/platforms/matrix.rs
@@ -47,6 +47,7 @@ use tokio::sync::{Mutex as AsyncMutex, Notify};
 use tracing::{debug, error, info, warn};
 
 use hermes_core::errors::GatewayError;
+use hermes_core::subprocess::CommandNoWindowExt;
 use hermes_core::traits::{ParseMode, PlatformAdapter};
 
 use crate::adapter::{AdapterProxyConfig, BasePlatformAdapter};

--- a/crates/hermes-gateway/src/platforms/matrix/adapter_impl/sync_parsing.rs
+++ b/crates/hermes-gateway/src/platforms/matrix/adapter_impl/sync_parsing.rs
@@ -178,6 +178,7 @@ impl MatrixAdapter {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
+            .suppress_windows_console()
             .spawn()
             .map_err(|e| format!("spawn failed for '{}': {e}", cfg.command))?;
 

--- a/crates/hermes-mcp/src/transport.rs
+++ b/crates/hermes-mcp/src/transport.rs
@@ -24,6 +24,8 @@ use tokio::process::{Child, Command};
 use tokio::task::JoinHandle;
 use tracing::{error, info, trace};
 
+use hermes_core::subprocess::CommandNoWindowExt;
+
 use crate::McpError;
 
 const MCP_PROTOCOL_VERSION_HEADER_VALUE: &str = "2025-03-26";
@@ -395,6 +397,7 @@ impl McpTransport for StdioTransport {
         for (key, value) in &sanitized_env {
             cmd.env(key, value);
         }
+        cmd.suppress_windows_console();
 
         let child = cmd.spawn().map_err(|e| {
             McpError::ConnectionError(format!("Failed to spawn process '{}': {}", self.command, e))

--- a/crates/hermes-source-parity-tests/tests/windows_subprocess_no_window_contract.rs
+++ b/crates/hermes-source-parity-tests/tests/windows_subprocess_no_window_contract.rs
@@ -1,0 +1,127 @@
+use std::fs;
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn read_repo_file(path: &str) -> String {
+    let full_path = repo_root().join(path);
+    fs::read_to_string(&full_path)
+        .unwrap_or_else(|err| panic!("failed reading {}: {err}", full_path.display()))
+}
+
+#[test]
+fn subprocess_no_window_helper_exposes_std_and_tokio_chokepoints() {
+    let helper = read_repo_file("crates/hermes-core/src/subprocess.rs");
+    assert!(helper.contains("WINDOWS_CREATE_NO_WINDOW"));
+    assert!(helper.contains("windows_no_window_creation_flags(existing: u32)"));
+    assert!(helper.contains("impl CommandNoWindowExt for std::process::Command"));
+    assert!(helper.contains("impl CommandNoWindowExt for tokio::process::Command"));
+    assert!(helper.contains("self.creation_flags(windows_no_window_creation_flags(0));"));
+}
+
+#[test]
+fn backend_helper_subprocesses_opt_into_windows_no_window_launch() {
+    let required = [
+        (
+            "crates/hermes-environments/src/local.rs",
+            "cmd.suppress_windows_console();",
+        ),
+        (
+            "crates/hermes-environments/src/docker.rs",
+            ".suppress_windows_console()",
+        ),
+        (
+            "crates/hermes-environments/src/singularity.rs",
+            ".suppress_windows_console()",
+        ),
+        (
+            "crates/hermes-environments/src/ssh.rs",
+            "command.suppress_windows_console();",
+        ),
+        (
+            "crates/hermes-mcp/src/transport.rs",
+            "cmd.suppress_windows_console();",
+        ),
+        (
+            "crates/hermes-gateway/src/hooks.rs",
+            "cmd.suppress_windows_console();",
+        ),
+        (
+            "crates/hermes-gateway/src/gateway/routing_methods.rs",
+            ".suppress_windows_console()",
+        ),
+        (
+            "crates/hermes-gateway/src/platforms/matrix/adapter_impl/sync_parsing.rs",
+            ".suppress_windows_console()",
+        ),
+        (
+            "crates/hermes-tools/src/backends/computer_use.rs",
+            ".suppress_windows_console()",
+        ),
+        (
+            "crates/hermes-tools/src/backends/code_execution.rs",
+            "cmd.suppress_windows_console();",
+        ),
+        (
+            "crates/hermes-tools/src/backends/tts.rs",
+            "cmd.suppress_windows_console();",
+        ),
+        (
+            "crates/hermes-tools/src/backends/video.rs",
+            ".suppress_windows_console()",
+        ),
+        (
+            "crates/hermes-tools/src/terminal_requirements.rs",
+            ".suppress_windows_console()",
+        ),
+        (
+            "crates/hermes-tools/src/teams_pipeline.rs",
+            ".suppress_windows_console()",
+        ),
+        (
+            "crates/hermes-agent/src/coding_context.rs",
+            ".suppress_windows_console()",
+        ),
+        (
+            "crates/hermes-agent/src/context_references.rs",
+            ".suppress_windows_console()",
+        ),
+        (
+            "crates/hermes-agent/src/memory_plugins/byterover.rs",
+            ".suppress_windows_console()",
+        ),
+        (
+            "crates/hermes-cli/src/commands/command_cli_plugins_memory_mcp.rs",
+            ".suppress_windows_console()",
+        ),
+        (
+            "crates/hermes-cli/src/commands/command_background_browser/triage_background.rs",
+            "cmd.suppress_windows_console();",
+        ),
+        (
+            "crates/hermes-cli/src/main/doctor_routes.rs",
+            ".suppress_windows_console()",
+        ),
+        (
+            "crates/hermes-cron/src/runner.rs",
+            "command.suppress_windows_console();",
+        ),
+    ];
+
+    for (path, needle) in required {
+        let text = read_repo_file(path);
+        assert!(
+            text.contains(needle),
+            "{path} must keep backend helper subprocesses routed through Windows no-window launch"
+        );
+    }
+}
+
+#[test]
+fn detached_chrome_debug_launch_preserves_existing_flags_and_adds_no_window() {
+    let text = read_repo_file("crates/hermes-cli/src/commands/command_background_browser.rs");
+    assert!(text.contains("windows_no_window_creation_flags("));
+    assert!(text.contains("0x00000008 | 0x00000200"));
+}

--- a/crates/hermes-tools/src/backends/code_execution.rs
+++ b/crates/hermes-tools/src/backends/code_execution.rs
@@ -6,7 +6,7 @@ use std::process::Stdio;
 use tokio::process::Command as TokioCommand;
 
 use crate::tools::code_execution::CodeExecutionBackend;
-use hermes_core::ToolError;
+use hermes_core::{subprocess::CommandNoWindowExt, ToolError};
 
 /// Code execution backend using local non-Python interpreters.
 pub struct LocalCodeExecutionBackend {
@@ -115,6 +115,7 @@ impl CodeExecutionBackend for LocalCodeExecutionBackend {
 
         apply_code_subprocess_home(&mut cmd);
         cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+        cmd.suppress_windows_console();
 
         let result = tokio::time::timeout(std::time::Duration::from_secs(timeout_secs), async {
             let child = cmd.spawn().map_err(|e| {

--- a/crates/hermes-tools/src/backends/computer_use.rs
+++ b/crates/hermes-tools/src/backends/computer_use.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
 
-use hermes_core::ToolError;
+use hermes_core::{subprocess::CommandNoWindowExt, ToolError};
 
 use crate::tools::computer_use::ComputerUseBackend;
 
@@ -62,6 +62,7 @@ impl CuaDriverBackend {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
+            .suppress_windows_console()
             .spawn()
             .map_err(|err| {
                 ToolError::ExecutionFailed(format!(
@@ -209,6 +210,7 @@ pub async fn resolve_mcp_invocation(driver_cmd: &str) -> (String, Vec<String>) {
         Command::new(driver_cmd)
             .arg("manifest")
             .stdin(Stdio::null())
+            .suppress_windows_console()
             .output(),
     )
     .await

--- a/crates/hermes-tools/src/backends/tts.rs
+++ b/crates/hermes-tools/src/backends/tts.rs
@@ -22,7 +22,7 @@ use hermes_config::managed_gateway::{
     resolve_managed_tool_gateway, resolve_openai_audio_api_key, ManagedToolGatewayConfig,
     ResolveOptions,
 };
-use hermes_core::ToolError;
+use hermes_core::{subprocess::CommandNoWindowExt, ToolError};
 
 pub const FALLBACK_MAX_TEXT_LENGTH: usize = 4_000;
 pub const DEFAULT_COMMAND_TTS_MAX_TEXT_LENGTH: usize = 15_000;
@@ -691,6 +691,7 @@ impl MultiTtsBackend {
                 cmd.arg("--noise_w").arg(v);
             }
         }
+        cmd.suppress_windows_console();
 
         let mut child = cmd.spawn().map_err(|e| {
             ToolError::ExecutionFailed(format!("Failed to start piper binary '{}': {}", binary, e))
@@ -797,6 +798,7 @@ impl MultiTtsBackend {
         };
         cmd.stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::piped());
+        cmd.suppress_windows_console();
 
         let duration = command_tts_timeout(&provider.config);
         let output = match timeout(duration, cmd.output()).await {

--- a/crates/hermes-tools/src/backends/video.rs
+++ b/crates/hermes-tools/src/backends/video.rs
@@ -10,7 +10,7 @@ use tokio::process::Command;
 
 use crate::tools::video::VideoBackend;
 use crate::tools::vision::VisionBackend;
-use hermes_core::ToolError;
+use hermes_core::{subprocess::CommandNoWindowExt, ToolError};
 
 /// Video backend that samples frames via ffmpeg and calls a vision backend.
 pub struct VisionFrameSamplingVideoBackend {
@@ -82,6 +82,7 @@ impl VisionFrameSamplingVideoBackend {
             .arg("-frames:v")
             .arg(max_frames.to_string())
             .arg(pattern.to_string_lossy().to_string())
+            .suppress_windows_console()
             .status()
             .await
             .map_err(|e| {

--- a/crates/hermes-tools/src/teams_pipeline.rs
+++ b/crates/hermes-tools/src/teams_pipeline.rs
@@ -19,7 +19,7 @@ use tokio::process::Command;
 use uuid::Uuid;
 
 use hermes_config::hermes_home;
-use hermes_core::{ToolError, ToolHandler};
+use hermes_core::{subprocess::CommandNoWindowExt, ToolError, ToolHandler};
 
 pub const DEFAULT_TEAMS_PIPELINE_STORE_FILENAME: &str = "teams_pipeline_store.json";
 
@@ -901,6 +901,7 @@ async fn prepare_audio_path(
         .arg("-i")
         .arg(recording_path)
         .arg(&audio_path)
+        .suppress_windows_console()
         .output()
         .await
         .map_err(|e| {

--- a/crates/hermes-tools/src/terminal_requirements.rs
+++ b/crates/hermes-tools/src/terminal_requirements.rs
@@ -14,6 +14,7 @@ use hermes_config::managed_gateway::{
     has_direct_modal_credentials, is_managed_tool_gateway_ready, managed_nous_tools_enabled,
     resolve_modal_backend_state, ModalMode, ResolveOptions, SelectedBackend,
 };
+use hermes_core::subprocess::CommandNoWindowExt;
 
 const REQUIREMENT_COMMAND_TIMEOUT: Duration = Duration::from_secs(5);
 const REQUIREMENT_CACHE_TTL: Duration = Duration::from_secs(5);
@@ -287,6 +288,7 @@ fn command_success_with_timeout(executable: &Path, args: &[&str], timeout: Durat
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
+        .suppress_windows_console()
         .spawn()
     {
         Ok(child) => child,

--- a/crates/hermes-tools/src/tools/project_workspace.rs
+++ b/crates/hermes-tools/src/tools/project_workspace.rs
@@ -5,7 +5,9 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use async_trait::async_trait;
-use hermes_core::{tool_schema, JsonSchema, ToolError, ToolHandler, ToolSchema};
+use hermes_core::{
+    subprocess::CommandNoWindowExt, tool_schema, JsonSchema, ToolError, ToolHandler, ToolSchema,
+};
 use indexmap::IndexMap;
 use serde_json::{json, Value};
 
@@ -433,6 +435,7 @@ fn git_output(root: &Path, args: &[&str]) -> Option<String> {
         .arg("-C")
         .arg(root)
         .args(args)
+        .suppress_windows_console()
         .output()
         .ok()?;
     if !output.status.success() {

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -196,7 +196,7 @@
         "status": "pass"
       },
       {
-        "actual": 29.0,
+        "actual": 20.0,
         "limit": 100,
         "metric": "max_queue_pending_commits",
         "status": "pass"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-06-30T07:33:14.036823+00:00",
+  "generated_at_utc": "2026-06-30T08:36:56.840611+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -274,7 +274,7 @@
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
     "max_files_only_upstream": 2309.0,
-    "max_queue_pending_commits": 29.0,
+    "max_queue_pending_commits": 20.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
     "max_test_coverage_audit_critical_gaps": 0.0,
@@ -299,9 +299,9 @@
   "queue_summary": {
     "by_disposition": {
       "mirrored": 97,
-      "pending": 29,
-      "ported": 533,
-      "superseded": 7013
+      "pending": 20,
+      "ported": 540,
+      "superseded": 7015
     },
     "by_target_ticket": {
       "20": 3505,
@@ -451,7 +451,7 @@
         "status": "pass"
       },
       {
-        "actual": 29.0,
+        "actual": 20.0,
         "limit": 0,
         "metric": "max_queue_pending_commits",
         "status": "fail"

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-06-30T07:33:14.036823+00:00`
+Generated: `2026-06-30T08:36:56.840611+00:00`
 
 ## Gate Status
 
@@ -38,7 +38,7 @@ Generated: `2026-06-30T07:33:14.036823+00:00`
 | `max_deep_problem_solving_gaps` | 0.0 |
 | `max_deep_problem_solving_unverified_cases` | 0.0 |
 | `max_deep_problem_solving_missing_rust_refs` | 0.0 |
-| `max_queue_pending_commits` | 29.0 |
+| `max_queue_pending_commits` | 20.0 |
 
 ## GPAR Ticket Completion
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -6638,6 +6638,51 @@
       "disposition": "ported",
       "owner": "rust-runtime",
       "notes": "Ported/superseded by Rust binary image handling: xAI/OpenRouter-compatible image references use std::fs::read/tokio::fs::read byte reads before base64 data-URL encoding, never text decoding. Existing Rust image/video generation tests cover local image paths encoded as data URLs, so the Python windows-footgun suppression is not needed."
+    },
+    "ef17cd204d7583c31fe1ace9255077f8c736b47e": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported as a Rust-native Windows subprocess no-window chokepoint: hermes-core exposes CommandNoWindowExt for std and tokio commands, backend helper spawns opt into CREATE_NO_WINDOW on Windows, and hermes-source-parity-tests covers the helper plus key runtime surfaces. The Python CI footgun script is superseded by compiled Rust source-contract coverage."
+    },
+    "5db1430af9ecd7ecc1e5eba93e7e1e965af59927": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust by routing background/helper spawns through CommandNoWindowExt across local/Docker/Singularity/SSH environments, MCP stdio, gateway hooks, cron, CLI probes, plugin git operations, computer-use, code execution, TTS, video/ffmpeg, Teams ffmpeg, and project/context git probes. Foreground terminal semantics stay unchanged while Windows background console flashes are suppressed."
+    },
+    "2ecca1e7d3e7c387b4d350f99dc699e2f43f73c5": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported as a real Rust chokepoint rather than relying on stdout/stderr capture: helper processes explicitly call suppress_windows_console before spawn/output/status, and source parity tests require the no-window helper on the primary backend subprocess surfaces."
+    },
+    "d3d621f7c38bb801d9d734cb2898bd4f9b134709": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream reverted earlier Python no-window wrappers. Hermes Agent Ultra does not inherit those reverted Python helper layers; the Rust runtime now implements the final behavior directly through hermes-core CommandNoWindowExt and explicit source-contract tests."
+    },
+    "cb982ad997c5e04c6b647c4cbb3d1b020ec383fb": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported in Rust for backend git/bash/helper spawns: coding context, context references, project workspace facts, plugin clone/update, specpatch git probes, doctor bash probes, background triage self-invocation, and quick exec all route through the no-window helper where applicable."
+    },
+    "1ffa01f35fb8bc0bf8825117788092ff0e08421f": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported with Rust source-contract coverage in crates/hermes-source-parity-tests/tests/windows_subprocess_no_window_contract.rs, proving the std/tokio helper chokepoints exist and key backend subprocess surfaces opt into them."
+    },
+    "eeca59f489194a4ce288b31de12b46c20d05cd48": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported/superseded by Rust helper coverage for the analogous remaining backend legs: TTS command/Piper, video and Teams ffmpeg, computer-use/cua-driver, MCP stdio, gateway Matrix decrypt FFI, and WhatsApp/Discord Python adapter legs are absent from the Rust runtime."
+    },
+    "9a0010fd469f0de6c7e2146f955ed9980d02b397": {
+      "disposition": "ported",
+      "owner": "rust-runtime",
+      "notes": "Ported for remaining Rust backend spawn legs, including environment backends, gateway hooks/routing, cron, CLI probes, plugin git operations, source-contract tests, and Chrome debug launch preserving detached/process-group flags while adding CREATE_NO_WINDOW through windows_no_window_creation_flags."
+    },
+    "ee22d853eb131ecdce3a8ba54a9a1c39ee5ca4a1": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream fix targets a Python/TUI pdftoppm subprocess. Hermes Agent Ultra has no Rust pdftoppm PDF attach subprocess surface; the broader Rust helper subprocess chokepoint now covers actual shipped helper spawns that can flash on Windows."
     }
   },
   "subject_patterns": [

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,8 +1,8 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-06-30T07:33:13.879112+00:00`
+Generated: `2026-06-30T08:36:56.665532+00:00`
 
-- Range: `origin/main..upstream/main`; total commits tracked: `7672`.
+- Range: `main..upstream/main`; total commits tracked: `7672`.
 
 | Ticket | Label | Commit Count |
 | ---: | --- | ---: |
@@ -17,9 +17,9 @@ Generated: `2026-06-30T07:33:13.879112+00:00`
 | Disposition | Commit Count |
 | --- | ---: |
 | mirrored | 97 |
-| pending | 29 |
-| ported | 533 |
-| superseded | 7013 |
+| pending | 20 |
+| ported | 540 |
+| superseded | 7015 |
 
 ## First 100 Pending Commits
 
@@ -28,10 +28,6 @@ Generated: `2026-06-30T07:33:13.879112+00:00`
 | `50f685521734` | #20 | feat(moa): make /moa one-shot only; route preset switching through the model picker |
 | `f67c0b3e60ba` | #21 | docs(hermes-agent skill): cover v0.13–v0.17 features, fix stale claims, tighten (#53566) |
 | `917f6bdb00b8` | #20 | fix(tools): let vision pick any provider+model, not just OpenRouter (#53606) |
-| `ef17cd204d75` | #20 | fix(windows): stop subprocess console-window popups + add CI guard (#53791) |
-| `5db1430af9ec` | #20 | fix(windows): stop terminal-window popups from background spawns (#53810) |
-| `2ecca1e7d3e7` | #23 | fix(windows): capture is not a no-window boundary; route flashing spawns through chokepoint (#53829) |
-| `d3d621f7c38b` | #20 | revert(windows): roll back terminal-popup PRs #53791 #53810 #53829 (#53853) |
 | `163cb24d45d8` | #22 | feat(moa): render reference-model blocks in TUI and desktop, not just CLI (#53855) |
 | `a94f657a5059` | #20 | fix(tui): route completion RPCs to the pool so they can't freeze the TUI (#53895) |
 | `d43e0cf304a1` | #20 | fix(agent): config-driven intent-ack continuation for all api_modes (#27881) (#53943) |
@@ -39,12 +35,7 @@ Generated: `2026-06-30T07:33:13.879112+00:00`
 | `fde1c8570ffe` | #20 | fix(tui_gateway): suppress WS peer-hangup teardown error flood (#50005) (#54126) |
 | `6d879d486b19` | #20 | fix(dashboard): close PTY WebSocket on child EOF to stop FD leak (#54028) (#54123) |
 | `5c2c85c5452f` | #20 | fix(tui): start MCP discovery for websocket sessions |
-| `cb982ad997c5` | #20 | fix(windows): hide console-window flash on backend git/gh/wmic/bash subprocess spawns |
-| `1ffa01f35fb8` | #20 | test(windows): cover no-window backend subprocess flags |
-| `eeca59f48919` | #20 | fix(windows): hide remaining backend console-flash legs missed on main |
 | `b31b0b9d95d1` | #22 | docs: reconcile docs with code across last 3 releases (#54254) |
-| `9a0010fd469f` | #20 | fix(windows): cover remaining console-flash spawn legs (#54417) |
-| `ee22d853eb13` | #26 | fix(windows): hide pdftoppm console flash on PDF attach |
 | `dff491a2b993` | #22 | feat(cli): add headless `hermes serve` backend; desktop no longer launches `dashboard` |
 | `476875acb9f0` | #22 | Add dashboard backup upload and download |
 | `fd324562d3ad` | #20 | feat(desktop): add context usage breakdown popover |


### PR DESCRIPTION
## What changed
- Added a Rust-native `hermes_core::subprocess::CommandNoWindowExt` helper for `std::process::Command` and `tokio::process::Command`.
- On Windows, helper/background subprocesses opt into `CREATE_NO_WINDOW`; on non-Windows this is a no-op.
- Applied the helper to backend/helper spawn surfaces across environment backends, MCP stdio, gateway hooks/routing/Matrix FFI, cron, CLI probes/plugin git operations/background triage/specpatch/quick exec/skill bootstrap, computer-use, code execution, TTS, video/ffmpeg, Teams ffmpeg, and project/context git probes.
- Preserved existing Chrome debug detached/process-group flags while adding `CREATE_NO_WINDOW` through `windows_no_window_creation_flags`.
- Added `hermes-source-parity-tests` source-contract coverage for the no-window helper and key backend subprocess surfaces.

## Queue delta
- Before this branch: `mirrored=97 pending=29 ported=533 superseded=7013`.
- After this branch: `mirrored=97 pending=20 ported=540 superseded=7015`.

## Validation
- `cargo fmt --all --check`
- `cargo test -p hermes-core subprocess -- --nocapture` -> `6 passed`
- `cargo test -p hermes-source-parity-tests --test windows_subprocess_no_window_contract -- --nocapture` -> `3 passed`
- `cargo check -p hermes-core -p hermes-environments -p hermes-agent -p hermes-tools -p hermes-gateway -p hermes-mcp -p hermes-cron -p hermes-cli --features gateway-adapters-all` -> finished in `8m 49s`
- `scripts/check-rust-runtime-no-python.sh` -> `No Rust runtime Python execution paths detected.`
- `scripts/check-runtime-placeholders.sh` -> `No runtime placeholder markers detected.`
- `jq empty docs/parity/queue-overrides.json docs/parity/upstream-missing-queue.json docs/parity/global-parity-proof.json`
- `git diff --check`
- `scripts/clippy-warning-gate.sh --check` -> `seen=183 allowlist=183 new=0 stale=0`, finished in `31m 47s`
- `test ! -d target` -> `no-local-target`

## Note
- Attempted `cargo check -p hermes-core --target x86_64-pc-windows-gnu`; it could not be used as validation because this machine's active cargo/rustc are Homebrew builds while `rustup target add` installs stdlibs for rustup toolchains. The Rust source-contract test and local clippy/check gates are the deterministic evidence in this PR.
