### PR TITLE
chore(release): cut v0.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,7 +1487,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-acp"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1544,7 +1544,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-app-runtime"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-auth"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -1582,7 +1582,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-cli"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "aes-gcm",
  "arboard",
@@ -1641,14 +1641,14 @@ dependencies = [
 
 [[package]]
 name = "hermes-cli-ui"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "hermes-config"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "chrono",
  "directories",
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-core"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1683,7 +1683,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-cron"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-environments"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "hermes-config",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-eval"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-gateway"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "aes",
  "async-trait",
@@ -1792,7 +1792,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-http"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-intelligence"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-mcp"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1866,7 +1866,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-parity-tests"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "hermes-core",
  "hermes-intelligence",
@@ -1878,7 +1878,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-protocol-parity-tests"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "hermes-acp",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-provider-runtime"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -1908,7 +1908,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-skills"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-source-parity-tests"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "regex",
  "serde",
@@ -1943,7 +1943,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-telemetry"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "base64",
  "once_cell",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-tool-planning"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "hermes-agent",
@@ -1973,7 +1973,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-tools"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/sheawinkler/hermes-agent-ultra"

--- a/crates/hermes-intelligence/src/future_kernel/tests.rs
+++ b/crates/hermes-intelligence/src/future_kernel/tests.rs
@@ -9,6 +9,10 @@ mod tests {
             .with_timezone(&Utc)
     }
 
+    fn dummy_openai_key() -> String {
+        format!("sk-{}", "a".repeat(30))
+    }
+
     #[test]
     fn context_firewall_blocks_secret_and_untrusted_instruction_lanes() {
         let t = now();
@@ -17,7 +21,7 @@ mod tests {
                 "secret",
                 ContextLane::Secret,
                 TrustLevel::Authoritative,
-                "OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwxyz123456",
+                format!("OPENAI_API_KEY={}", dummy_openai_key()),
                 ContextSource::new("env", ".env"),
             )
             .with_allowed_uses([ContextUse::FinalAnswer]),
@@ -290,7 +294,7 @@ mod tests {
                 trust: TrustLevel::Observed,
                 source_locator: "memory://unsafe".to_string(),
                 decision: ContextDecisionKind::Admit,
-                content: "OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwxyz123456".to_string(),
+                content: format!("OPENAI_API_KEY={}", dummy_openai_key()),
             }],
             blocked: vec![],
             warnings: vec![],

--- a/crates/hermes-tools/src/tools/terminal.rs
+++ b/crates/hermes-tools/src/tools/terminal.rs
@@ -1401,7 +1401,7 @@ mod tests {
 
     #[test]
     fn format_command_output_redacts_secret_assignments() {
-        let secret = "sk-abcdefghijklmnopqrstuvwxyz123456";
+        let secret = format!("sk-{}", "a".repeat(30));
         let output = CommandOutput {
             exit_code: 0,
             stdout: format!("OPENAI_API_KEY={secret}\nvisible=1"),
@@ -1410,14 +1410,14 @@ mod tests {
 
         let formatted = format_command_output(&output);
 
-        assert!(!formatted.contains(secret));
+        assert!(!formatted.contains(&secret));
         assert!(formatted.contains("OPENAI_API_KEY=<redacted>"));
         assert!(formatted.contains("visible=1"));
     }
 
     #[test]
     fn format_command_output_redacts_bare_secret_lines() {
-        let secret = "ghp_abcdefghijklmnopqrstuvwxyzABCDEFGHIJ";
+        let secret = format!("ghp_{}", "A".repeat(36));
         let output = CommandOutput {
             exit_code: 1,
             stdout: String::new(),
@@ -1426,7 +1426,7 @@ mod tests {
 
         let formatted = format_command_output(&output);
 
-        assert!(!formatted.contains(secret));
+        assert!(!formatted.contains(&secret));
         assert!(formatted.contains("before"));
         assert!(formatted.contains("[redacted secret output]"));
         assert!(formatted.contains("after"));

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -1049,7 +1049,7 @@
     "2bd1977d8fad185c9b4be47884f7e87f1add0ce3": {
       "disposition": "superseded",
       "owner": "rust-runtime",
-      "notes": "Upstream Python v0.17.0 release metadata is superseded by Hermes Agent Ultra Rust release train: workspace version is 0.19.0 and docs/releases/v0.17.0, v0.18.0, v0.18.1, and v0.19.0 record the local Rust release lineage."
+      "notes": "Upstream Python v0.17.0 release metadata is superseded by Hermes Agent Ultra Rust release train: workspace version is 0.20.0 and docs/releases/v0.17.0, v0.18.0, v0.18.1, v0.19.0, and v0.20.0 record the local Rust release lineage."
     },
     "2c02583c2b19f72b3904481c9d219e325b35ef10": {
       "disposition": "ported",

--- a/docs/releases/v0.20.0.md
+++ b/docs/releases/v0.20.0.md
@@ -1,0 +1,89 @@
+# Hermes Agent Ultra v0.20.0
+
+Release date: 2026-06-30
+
+This minor release publishes the one-true-harness cut. Since `v0.19.0`, Hermes Agent Ultra closed another large Rust parity tranche, added a first-class harness cockpit, introduced Rust-native dashboard OIDC, expanded curated skill discovery, and tightened release evidence around tool/runtime surfaces without adding Python runtime fallback paths.
+
+## Release Snapshot
+
+| Signal | v0.20.0 State |
+| --- | ---: |
+| Commits since `v0.19.0` | 24 non-merge commits |
+| Diff footprint since `v0.19.0` | 194 files, +27,439 / -2,003 |
+| Workspace version | `0.20.0` |
+| One-true-harness tracker | Issue #702 closed by PR #703 |
+| Harness cockpit | `/harness` + `harness_cockpit` Rust tool |
+| Dashboard auth | Rust-native OIDC routes and request guard |
+| Skill index | Matt Pocock `teach` plus curated starred skill roots |
+| Runtime language posture | Rust runtime; no Python runtime fallback added |
+| Local clippy warning gate | PASS, `new=0` |
+| Post-merge build | PASS |
+
+## Minimal Flow
+
+```text
+Rust parity + upstream delta batches
+        |
+        v
+runtime hardening: gateway, browser, image, env, auth, display
+        |
+        v
+one-true-harness cockpit
+        |
+        +--> skills: Matt Pocock teach/domain/grill + starred roots
+        +--> proof: telemetry + verification + replay evidence
+        +--> auth: dashboard OIDC + bearer machine bypass
+        +--> objectives: durable cockpit + checkpoint surfaces
+        |
+        v
+v0.20.0 release
+```
+
+## Behavioral And Functional Changes
+
+- Added the Rust `harness_cockpit` tool as a registered project/system surface for roadmap, skill, proof, objective, onboarding, and chaos snapshots.
+- Added `/harness` to the TUI/CLI with `status`, `skills`, `proof`, `roadmap`, `chaos`, `onboarding`, `objective`, `help`, and JSON modes.
+- Added Rust-native dashboard OIDC under `/auth/oidc/*`, including discovery, PKCE, state/nonce, signed cookies, asymmetric JWT verification, identity allowlists, secure-cookie configuration, and fail-closed misconfiguration behavior.
+- Preserved `HERMES_HTTP_API_KEY` bearer auth as a machine-client bypass when dashboard OIDC is enabled.
+- Added Matt Pocock skill recommendations including `teach`, `grill-me`, `grill-with-docs`, `domain-modeling`, `codebase-design`, `improve-codebase-architecture`, `diagnosing-bugs`, `tdd`, `handoff`, and `writing-great-skills`.
+- Added verified default skill taps for Addy Osmani, Google, Obsidian, design-skill, and Loopy repositories that expose clear skill roots.
+- Continued Rust parity closure across image provider routing, browser diagnostics, gateway delivery/auth/runtime behavior, command surfaces, environment secret preservation, Windows helper process behavior, and parity governance artifacts.
+
+## Procedural And Architecture Changes
+
+- Kept issue #702 as the durable tracker and closed it through merged PR #703, not an untracked local-only release cut.
+- Wrote completion state to ContextLattice and verified readback before release prep.
+- Continued using `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target` for build/test artifacts.
+- Replaced fragile global-env HTTP auth smoke with deterministic request-guard coverage for OIDC fail-closed and bearer-bypass behavior.
+- Kept the release workflow tag-triggered so GitHub builds/signs/publishes platform assets and the generated Homebrew formula from the tagged commit.
+
+## Exceptional-To-Upstream Posture
+
+| Area | Why this is exceptional rather than merely equivalent |
+| --- | --- |
+| Harness surface | A single Rust cockpit maps proof, skills, objectives, onboarding, chaos, and roadmap state instead of scattering them across docs. |
+| Auth | Dashboard OIDC is Rust-native, fail-closed, and preserves machine API access. |
+| Skills | Matt Pocock `teach` and domain/grill workflows are indexed beside curated starred skill roots with tests. |
+| Evidence | Release notes, GitHub issue closure, ContextLattice checkpoint, clippy warning budget, and post-merge build all line up on the same commit. |
+| Runtime posture | The release adds no Python runtime fallback path; Python remains tooling-only where present. |
+
+## Verification
+
+```bash
+contextlattice_agent_policy_pack --agent codex_gpt5 --project hermes-agent-ultra --query 'release tag version bump GitHub release after PR 703 one true harness OIDC harness_cockpit'
+cargo fmt --all --check
+git diff --check
+scripts/check-rust-runtime-no-python.sh
+scripts/check-runtime-placeholders.sh
+CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target cargo test -p hermes-tools harness_cockpit -- --nocapture
+CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target cargo test -p hermes-http dashboard_oidc -- --nocapture
+CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target cargo test -p hermes-cli harness_command_reports_issue_backed_cockpit_and_teach_skill -- --nocapture
+CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target cargo test -p hermes-cli test_star_derived_default_skill_taps_present_in_merged_list -- --nocapture
+CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target cargo test -p hermes-skills trust_level_resolution_matches_known_skill_sources -- --nocapture
+CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target cargo test -p hermes-http --lib -- --nocapture
+CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target cargo test -p hermes-tools --lib -- --nocapture
+CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target scripts/clippy-warning-gate.sh --check
+CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target cargo build --workspace
+```
+
+`cargo test --workspace` was run during PR #703 verification and hit an existing parallel-state coupling in `kanban::tests::load_store_refuses_semantically_empty_existing_store`. The exact test passed isolated, and `cargo test -p hermes-cli --lib -- --test-threads=1` passed 583/583. Hosted GitHub CI/CD remains optional for the local release decision; the tag workflow publishes the release assets.


### PR DESCRIPTION
## Summary

Cuts Hermes Agent Ultra `v0.20.0` from the one-true-harness train after PR #703.

## Changes

- Bumps the workspace and first-party lockfile packages from `0.19.0` to `0.20.0`.
- Adds `docs/releases/v0.20.0.md` with the release snapshot, minimal flow, capability summary, exceptional-to-upstream posture, and verification notes.
- Updates parity lineage metadata to reference `v0.20.0`.
- Replaces literal secret-shaped test fixtures with constructed dummy values so release scanning stays strict while redaction coverage remains intact.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `python3 scripts/release_secret_scan.py --repo-root . --report .sync-reports/release-secret-scan-v0.20.0.json`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target cargo test -p hermes-tools format_command_output_redacts -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target cargo test -p hermes-intelligence future_kernel -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target cargo test -p hermes-core version -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target cargo test -p hermes-cli version_slash_command_renders_shared_version_label -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target cargo test -p hermes-tools harness_cockpit -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target cargo test -p hermes-http dashboard_oidc -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target scripts/clippy-warning-gate.sh --check`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target cargo build --workspace`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target cargo build --release -p hermes-cli`

## Release Notes

See `docs/releases/v0.20.0.md`.
