### PR TITLE
release: v0.21.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,7 +1487,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-acp"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1544,7 +1544,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-app-runtime"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-auth"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -1582,7 +1582,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-cli"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "aes-gcm",
  "arboard",
@@ -1641,14 +1641,14 @@ dependencies = [
 
 [[package]]
 name = "hermes-cli-ui"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "hermes-config"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "chrono",
  "directories",
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-core"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1683,7 +1683,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-cron"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-environments"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "hermes-config",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-eval"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-gateway"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "aes",
  "async-trait",
@@ -1792,7 +1792,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-http"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-intelligence"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-mcp"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1866,7 +1866,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-parity-tests"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "hermes-core",
  "hermes-intelligence",
@@ -1878,7 +1878,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-protocol-parity-tests"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "hermes-acp",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-provider-runtime"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -1908,7 +1908,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-skills"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-source-parity-tests"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "regex",
  "serde",
@@ -1943,7 +1943,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-telemetry"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "base64",
  "once_cell",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-tool-planning"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "hermes-agent",
@@ -1973,7 +1973,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-tools"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/sheawinkler/hermes-agent-ultra"

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-07-02T18:24:05.741337+00:00",
+  "generated_at_utc": "2026-07-02T18:30:54.092535+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-07-02T18:24:05.741337+00:00`
+Generated: `2026-07-02T18:30:54.092535+00:00`
 
 ## Gate Status
 

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-07-02T18:02:58.637233+00:00",
+  "generated_at_utc": "2026-07-02T18:30:52.297342+00:00",
   "refs": {
     "local_ref": "main",
-    "local_sha": "74c52efb207a4607bcddf715432951022e1851dd",
+    "local_sha": "13085efc6e7264168d174136cf3aad00f9df6452",
     "upstream_ref": "upstream/main",
     "upstream_sha": "a9b5598909585b851b1ed65f05034033676d1a86",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 14223,
-    "commits_ahead": 1320,
+    "commits_ahead": 1321,
     "upstream_patch_missing": 13006,
     "upstream_patch_represented": 6,
-    "local_patch_unique": 1056,
+    "local_patch_unique": 1057,
     "files_only_upstream": 3228,
     "files_only_local": 1317,
     "files_shared_identical": 1471,
     "files_shared_different": 1267,
     "tree_files_changed": 5710,
     "tree_insertions": 1294373,
-    "tree_deletions": 762440
+    "tree_deletions": 777286
   },
   "top_upstream_only": [
     {
@@ -906,7 +906,7 @@
   "commit_mapping": {
     "upstream_patch_missing": 13006,
     "upstream_patch_represented": 6,
-    "local_patch_unique": 1056,
+    "local_patch_unique": 1057,
     "local_patch_equivalent_to_upstream": 1,
     "upstream_patch_missing_sample": [
       "21d80ca68346dfdb8d3556015a723a9217f8566f",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,10 +1,10 @@
 # Parity Matrix
 
-Generated: `2026-07-02T18:02:58.637233+00:00`
+Generated: `2026-07-02T18:30:52.297342+00:00`
 
 ## Scope
 
-- Local ref: `main` (`74c52efb207a4607bcddf715432951022e1851dd`)
+- Local ref: `main` (`13085efc6e7264168d174136cf3aad00f9df6452`)
 - Upstream ref: `upstream/main` (`a9b5598909585b851b1ed65f05034033676d1a86`)
 - Merge base: `none (history divergence)`
 
@@ -13,17 +13,17 @@ Generated: `2026-07-02T18:02:58.637233+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 14223 |
-| Commits ahead local (`local` ancestry only) | 1320 |
+| Commits ahead local (`local` ancestry only) | 1321 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 13006 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 6 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 1056 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 1057 |
 | Files only in upstream tree | 3228 |
 | Files only in local tree | 1317 |
 | Shared files identical content | 1471 |
 | Shared files different content | 1267 |
 | Total files changed (`local` vs `upstream`) | 5710 |
 | Insertions (`local` vs `upstream`) | 1294373 |
-| Deletions (`local` vs `upstream`) | 762440 |
+| Deletions (`local` vs `upstream`) | 777286 |
 
 ## Top 40 upstream-only buckets
 
@@ -176,7 +176,7 @@ Generated: `2026-07-02T18:02:58.637233+00:00`
 
 - Upstream missing by patch-id: `13006`
 - Upstream represented by patch-id: `6`
-- Local unique by patch-id: `1056`
+- Local unique by patch-id: `1057`
 - Intentional divergence tracked items: `12` (covered files: `1279`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -1049,7 +1049,7 @@
     "2bd1977d8fad185c9b4be47884f7e87f1add0ce3": {
       "disposition": "superseded",
       "owner": "rust-runtime",
-      "notes": "Upstream Python v0.17.0 release metadata is superseded by Hermes Agent Ultra Rust release train: workspace version is 0.20.0 and docs/releases/v0.17.0, v0.18.0, v0.18.1, v0.19.0, and v0.20.0 record the local Rust release lineage."
+      "notes": "Upstream Python v0.17.0 release metadata is superseded by Hermes Agent Ultra Rust release train: workspace version is 0.21.0 and docs/releases/v0.17.0, v0.18.0, v0.18.1, v0.19.0, v0.20.0, and v0.21.0 record the local Rust release lineage."
     },
     "2c02583c2b19f72b3904481c9d219e325b35ef10": {
       "disposition": "ported",

--- a/docs/parity/test-coverage-audit.json
+++ b/docs/parity/test-coverage-audit.json
@@ -90,7 +90,7 @@
     }
   ],
   "critical_gaps": [],
-  "generated_at_utc": "2026-07-02T18:24:05.654979+00:00",
+  "generated_at_utc": "2026-07-02T18:30:54.008059+00:00",
   "intent_domains": [
     {
       "classification": "direct_rust_test",

--- a/docs/parity/test-coverage-audit.md
+++ b/docs/parity/test-coverage-audit.md
@@ -1,6 +1,6 @@
 # Test Coverage Audit
 
-Generated: `2026-07-02T18:24:05.654979+00:00`
+Generated: `2026-07-02T18:30:54.008059+00:00`
 
 ## Gate
 

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-07-02T18:05:33.094276+00:00`
+Generated: `2026-07-02T18:30:49.107336+00:00`
 
 - Range: `HEAD..upstream/main`; total commits tracked: `8262`.
 

--- a/docs/parity/workstream-status.json
+++ b/docs/parity/workstream-status.json
@@ -1,6 +1,6 @@
 {
-  "generated_at_utc": "2026-06-30T17:01:54-06:00",
-  "head_sha": "74c52efb207a4607bcddf715432951022e1851dd",
+  "generated_at_utc": "2026-07-02T12:28:16-06:00",
+  "head_sha": "13085efc6e7264168d174136cf3aad00f9df6452",
   "states": {
     "complete": 6,
     "in_progress": 1

--- a/docs/parity/workstream-status.md
+++ b/docs/parity/workstream-status.md
@@ -1,6 +1,6 @@
 # Workstream Status
 
-- Local HEAD: `74c52efb207a4607bcddf715432951022e1851dd`
+- Local HEAD: `13085efc6e7264168d174136cf3aad00f9df6452`
 - Upstream: `upstream/main` (`a9b5598909585b851b1ed65f05034033676d1a86`)
 
 | Workstream | Title | State |

--- a/docs/releases/v0.21.0.md
+++ b/docs/releases/v0.21.0.md
@@ -1,0 +1,98 @@
+# Hermes Agent Ultra v0.21.0
+
+Release date: 2026-07-02
+
+This minor release publishes the post-`v0.20.0` Rust parity catch-up. The important result is simple: the upstream catch-up queue is back to zero pending items, the tracked behavior coverage remains fully Rust-owned, and the new runtime surfaces are implemented as first-class Rust behavior rather than Python fallback shims.
+
+## Release Snapshot
+
+| Signal | v0.21.0 State |
+| --- | ---: |
+| Workspace version | `0.21.0` |
+| Runtime catch-up PR | `#706` |
+| Upstream queue total | `8,262` rows |
+| Upstream queue pending | `0` |
+| Queue dispositions | `99 mirrored` / `569 ported` / `7,594 superseded` |
+| Shared diff pending review | `0` |
+| Shared diff pending classification | `0` |
+| Coverage manifests | `460 / 460` entries reference valid Rust tests |
+| Rust test functions tracked by audit | `7,254` |
+| Global release gate | PASS |
+| Runtime language posture | Rust runtime; no Python runtime fallback added |
+
+## Minimal Flow
+
+```text
+v0.20.0 one-true harness
+        |
+        v
+Rust catch-up closeout (#706)
+        |
+        +--> memory: FTS-backed holographic retrieval
+        +--> image: Codex/OpenAI reference-image generation
+        +--> browser/TUI: coverage manifests refreshed to current upstream rows
+        +--> CLI: `hermes serve` dashboard-compatible API alias
+        +--> tools: safer Teams filenames + parent-tool delegation inheritance
+        +--> tests: deterministic kanban store isolation
+        |
+        v
+parity proof
+  queue pending = 0
+  shared pending = 0
+  coverage missing refs = 0
+  critical gaps = 0
+        |
+        v
+v0.21.0 release
+```
+
+## Behavioral And Functional Changes
+
+- Added Rust-native holographic memory FTS retrieval with sanitized FTS5 queries, LIKE fallback behavior, category/trust filters, retrieval metrics, and coverage for natural-language and special-character query paths.
+- Added Codex/OpenAI image reference support in Rust image generation, including local raster inlining, URL/data URI support, SVG rejection, source-image caps, modality reporting, and provider capability metadata.
+- Added `hermes serve` as a dashboard-compatible HTTP API alias with host, port, no-open, and insecure bind controls.
+- Hardened Teams recording filename handling so path components, separator-only values, and dot-only names cannot escape into unsafe persisted filenames.
+- Removed the model-facing delegate `toolset` schema while keeping internal compatibility; subagents now inherit the current session's enabled parent tools by default.
+- Fixed a parallel `HERMES_HOME` test race in kanban store coverage by using path-scoped store helpers in tests while preserving production storage behavior.
+
+## Parity And Coverage Changes
+
+- Regenerated shared-diff, upstream-queue, parity-matrix, workstream-status, adapter-matrix, test-intent, coverage-audit, divergence-validation, and global proof artifacts.
+- Added coverage manifest rows for newly surfaced Python suite references: provider fallback, browser CDP, browser hybrid routing, and file sync.
+- Added coverage manifest rows for newly surfaced `ui-tui` reference files: `scripts/build.mjs`, `src/config/timing.ts`, and `src/lib/editor.ts`.
+- Refreshed intentional divergence review dates for current Rust-primary CLI/TUI and skills catalog surfaces.
+
+## Exceptional-To-Upstream Posture
+
+| Area | Why this is exceptional rather than merely equivalent |
+| --- | --- |
+| Memory retrieval | Rust FTS retrieval sanitizes model/user query input and falls back safely when FTS is unavailable. |
+| Image generation | Reference-image generation is provider-aware, capability-reported, and rejects unsupported local vectors instead of silently degrading. |
+| Tool delegation | Parent-tool inheritance is a runtime policy, not a model-controlled schema knob. |
+| Test reliability | The release fixed a real parallel env race discovered by the full workspace gate. |
+| Parity governance | Queue closure, coverage refs, and release proof are regenerated and contract-tested on the same tree. |
+
+## Verification
+
+```bash
+# Local scoped memory/policy recall completed before release prep.
+export EXTERNAL_TARGET_DIR="${EXTERNAL_TARGET_DIR:-target}"
+cargo fmt --all --check
+git diff --check
+scripts/check-rust-runtime-no-python.sh
+scripts/check-runtime-placeholders.sh
+CARGO_TARGET_DIR=$EXTERNAL_TARGET_DIR scripts/clippy-warning-gate.sh --check
+CARGO_TARGET_DIR=$EXTERNAL_TARGET_DIR cargo test -p hermes-tools image_gen -- --nocapture
+CARGO_TARGET_DIR=$EXTERNAL_TARGET_DIR cargo test -p hermes-tools teams_pipeline -- --nocapture
+CARGO_TARGET_DIR=$EXTERNAL_TARGET_DIR cargo test -p hermes-tools tools::delegation -- --nocapture
+CARGO_TARGET_DIR=$EXTERNAL_TARGET_DIR cargo test -p hermes-cli cli_parse_serve_alias_for_headless_dashboard_api -- --nocapture
+CARGO_TARGET_DIR=$EXTERNAL_TARGET_DIR cargo test -p hermes-cli kanban::tests -- --nocapture
+CARGO_TARGET_DIR=$EXTERNAL_TARGET_DIR cargo test -p hermes-agent memory_plugins::holographic -- --nocapture
+CARGO_TARGET_DIR=$EXTERNAL_TARGET_DIR cargo test -p hermes-source-parity-tests --test global_parity_governance -- --nocapture
+CARGO_TARGET_DIR=$EXTERNAL_TARGET_DIR cargo test -p hermes-source-parity-tests --test python_test_suite_coverage_contract -- --nocapture
+CARGO_TARGET_DIR=$EXTERNAL_TARGET_DIR cargo test -p hermes-source-parity-tests --test ui_tui_source_coverage_contract -- --nocapture
+CARGO_TARGET_DIR=$EXTERNAL_TARGET_DIR cargo test --workspace
+CARGO_TARGET_DIR=$EXTERNAL_TARGET_DIR cargo metadata --format-version 1 --no-deps
+```
+
+The release workflow remains tag-triggered; GitHub builds and publishes release assets from the tagged commit.


### PR DESCRIPTION
## Summary
- Bump the Rust workspace release train to `0.21.0`.
- Add `docs/releases/v0.21.0.md` with the post-`v0.20.0` parity catch-up summary.
- Refresh generated parity proof artifacts for the `v0.21.0` release lineage.

## Release Evidence
- Upstream queue: `8,262` total, `0` pending, `99 mirrored` / `569 ported` / `7,594 superseded`.
- Coverage audit: `460` manifest entries, `0` missing Rust refs, `0` critical gaps.
- Global release gate: `pass=true`.
- Latest prior release was `v0.20.0` published 2026-06-30.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target scripts/clippy-warning-gate.sh --check` -> `seen=183 allowlist=183 new=0 stale=0`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target cargo test --workspace`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target cargo metadata --format-version 1 --no-deps` -> all Hermes packages `0.21.0`
