### PR TITLE
fix(ci): add journey slash parity surface

### DIFF
--- a/crates/hermes-cli-ui/src/lib.rs
+++ b/crates/hermes-cli-ui/src/lib.rs
@@ -167,6 +167,7 @@ pub fn canonical_command(cmd: &str) -> &str {
         "/scheduler" => "/background",
         "/gateway" => "/platforms",
         "/onboard" => "/walkthrough",
+        "/learning" | "/memory-graph" => "/journey",
         "/reload-skills" | "/reload_skills" => "/reload-skills",
         "/reload_mcp" => "/reload-mcp",
         "/fork" => "/branch",
@@ -348,6 +349,8 @@ mod tests {
         assert_eq!(canonical_command("/compose"), "/prompt");
         assert_eq!(canonical_command("/ts"), "/timestamps");
         assert_eq!(canonical_command("/generate-pet"), "/hatch");
+        assert_eq!(canonical_command("/learning"), "/journey");
+        assert_eq!(canonical_command("/memory-graph"), "/journey");
         assert_eq!(canonical_command("/custom"), "/custom");
     }
 

--- a/crates/hermes-cli/src/commands/command_catalog.rs
+++ b/crates/hermes-cli/src/commands/command_catalog.rs
@@ -248,6 +248,12 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
         "Show graph-memory, ContextLattice status, and embedding diagnostics",
     ),
     (
+        "/journey",
+        "Learning journey timeline across graph-memory, objective learning, walkthrough events, and snapshots",
+    ),
+    ("/learning", "Alias for /journey"),
+    ("/memory-graph", "Alias for /journey"),
+    (
         "/qos",
         "Provider QoS router controls (`status|health|autotune [plan|apply]`)",
     ),

--- a/crates/hermes-cli/src/commands/command_catalog/skill_resolution/completions.rs
+++ b/crates/hermes-cli/src/commands/command_catalog/skill_resolution/completions.rs
@@ -350,6 +350,7 @@ fn command_subcommand_overrides(cmd: &str) -> &'static [&'static str] {
         ],
         "/simulate" => &["status"],
         "/timetravel" => &["list", "latest", "goto", "undo", "branch"],
+        "/journey" => &["status", "graph", "ledger", "tail", "walkthrough", "timetravel"],
         "/autocompact" => &["status", "now", "governance"],
         "/qos" => &["status", "health", "autotune"],
         "/claims" => &["status", "on", "off"],

--- a/crates/hermes-cli/src/commands/command_dispatch_model/quick_dispatch.rs
+++ b/crates/hermes-cli/src/commands/command_dispatch_model/quick_dispatch.rs
@@ -310,6 +310,7 @@ async fn dispatch_slash_command(
         "/plan" => handle_plan_command(app, args),
         "/lsp" => handle_lsp_command(app, args),
         "/graph" => handle_graph_command(app, args).await,
+        "/journey" => handle_journey_command(app, args).await,
         "/qos" => handle_qos_command(app, args).await,
         "/image" => handle_image_command(app, args),
         "/config" => handle_config_command(app, args),

--- a/crates/hermes-cli/src/commands/command_kanban_objective/graph_objective.rs
+++ b/crates/hermes-cli/src/commands/command_kanban_objective/graph_objective.rs
@@ -1,3 +1,91 @@
+async fn handle_journey_command(
+    app: &mut App,
+    args: &[&str],
+) -> Result<CommandResult, AgentError> {
+    let sub = args
+        .first()
+        .map(|v| v.to_ascii_lowercase())
+        .unwrap_or_else(|| "status".to_string());
+    match sub.as_str() {
+        "status" | "show" | "timeline" => {
+            let ledger = load_objective_learning_ledger().ok();
+            let (entries, updated_at, latest) = ledger
+                .as_ref()
+                .map(|ledger| {
+                    let latest = ledger
+                        .entries
+                        .last()
+                        .map(|entry| {
+                            format!(
+                                "{} state={} decision={}",
+                                entry.recorded_at, entry.objective_state, entry.decision
+                            )
+                        })
+                        .unwrap_or_else(|| "none".to_string());
+                    (ledger.entries.len(), ledger.updated_at.clone(), latest)
+                })
+                .unwrap_or_else(|| (0, "unavailable".to_string(), "none".to_string()));
+            let mut out = String::new();
+            let _ = writeln!(out, "Learning journey timeline");
+            let _ = writeln!(out, "  objective_learning_entries: {}", entries);
+            let _ = writeln!(out, "  objective_learning_updated_at: {}", updated_at);
+            let _ = writeln!(out, "  latest_learning_entry: {}", latest);
+            out.push_str("\nRust journey surfaces:\n");
+            out.push_str("  - /graph status: graph-memory and ContextLattice diagnostics\n");
+            out.push_str("  - /objective ledger tail: objective learning decisions\n");
+            out.push_str("  - /walkthrough insights: guided operator journey events\n");
+            out.push_str("  - /timetravel list: session snapshots and replay checkpoints\n");
+            out.push_str("\nAliases: /learning, /memory-graph");
+            emit_command_output(app, out.trim_end());
+            Ok(CommandResult::Handled)
+        }
+        "graph" | "memory" | "memory-graph" => {
+            let forwarded = if args.len() > 1 {
+                &args[1..]
+            } else {
+                &["status"][..]
+            };
+            handle_graph_command(app, forwarded).await
+        }
+        "ledger" => {
+            let mut forwarded = vec!["ledger"];
+            forwarded.extend_from_slice(args.get(1..).unwrap_or(&[]));
+            handle_objective_command(app, &forwarded)
+        }
+        "tail" => {
+            let mut forwarded = vec!["ledger", "tail"];
+            forwarded.extend_from_slice(args.get(1..).unwrap_or(&[]));
+            handle_objective_command(app, &forwarded)
+        }
+        "walkthrough" => {
+            let forwarded = if args.len() > 1 {
+                &args[1..]
+            } else {
+                &["insights"][..]
+            };
+            handle_walkthrough_command(app, forwarded)
+        }
+        "timetravel" | "snapshots" => {
+            let forwarded = if args.len() > 1 {
+                &args[1..]
+            } else {
+                &["list"][..]
+            };
+            handle_timetravel_command(app, forwarded)
+        }
+        other => {
+            emit_command_output(
+                app,
+                format!(
+                    "Unknown /journey action '{}'. Use `/journey status|graph|ledger|tail|walkthrough|timetravel`.",
+                    other
+                ),
+            );
+            Ok(CommandResult::Handled)
+        }
+    }
+}
+
 async fn handle_graph_command(app: &mut App, args: &[&str]) -> Result<CommandResult, AgentError> {
     let sub = args
         .first()

--- a/crates/hermes-cli/src/commands/tests/runtime_parity_ops.rs
+++ b/crates/hermes-cli/src/commands/tests/runtime_parity_ops.rs
@@ -187,6 +187,8 @@ fn test_upstream_compat_aliases_are_mapped() {
     assert_eq!(canonical_command("/bg"), "/background");
     assert_eq!(canonical_command("/curator"), "/skills");
     assert_eq!(canonical_command("/tt"), "/timetravel");
+    assert_eq!(canonical_command("/learning"), "/journey");
+    assert_eq!(canonical_command("/memory-graph"), "/journey");
     assert_eq!(canonical_command("/rb"), "/runbook");
 }
 
@@ -310,6 +312,40 @@ fn test_memory_command_is_registered_completable_and_cataloged() {
     let catalog = render_command_catalog(Some("memory"));
     assert!(catalog.contains("/memory"));
     assert!(catalog.contains("Show memory backend status"));
+}
+
+#[test]
+fn test_journey_command_is_registered_completable_and_cataloged() {
+    assert!(SLASH_COMMANDS.iter().any(|(name, _)| *name == "/journey"));
+    assert!(SLASH_COMMANDS.iter().any(|(name, _)| *name == "/learning"));
+    assert!(SLASH_COMMANDS
+        .iter()
+        .any(|(name, _)| *name == "/memory-graph"));
+    let results = autocomplete("/jour");
+    assert!(results.contains(&"/journey"));
+    let alias_results = autocomplete("/memory-g");
+    assert!(alias_results.contains(&"/memory-graph"));
+    let catalog = render_command_catalog(Some("journey"));
+    assert!(catalog.contains("/journey"));
+    assert!(catalog.contains("Learning journey timeline"));
+}
+
+#[tokio::test]
+async fn journey_status_surfaces_rust_learning_timeline() {
+    let _guard = env_test_lock();
+    let tmp = tempdir().expect("tempdir");
+    let _home_guard = TempHomeGuard::new(tmp.path());
+    let mut app = build_test_app_with_stream(tmp.path()).await;
+
+    handle_slash_command(&mut app, "/journey", &[])
+        .await
+        .expect("journey status");
+    let out = latest_ui_assistant_text(&app);
+    assert!(out.contains("Learning journey timeline"));
+    assert!(out.contains("/graph status"));
+    assert!(out.contains("/objective ledger tail"));
+    assert!(out.contains("/walkthrough insights"));
+    assert!(out.contains("/timetravel list"));
 }
 
 #[test]

--- a/docs/parity/divergence-validation.json
+++ b/docs/parity/divergence-validation.json
@@ -1,6 +1,6 @@
 {
   "divergence_file": "/Volumes/wd_black/hermes-agent-ultra/repo/docs/parity/intentional-divergence.json",
-  "generated_at_utc": "2026-07-02T18:04:58.270235+00:00",
+  "generated_at_utc": "2026-07-02T19:11:11.590561+00:00",
   "items": [
     {
       "errors": [],
@@ -199,6 +199,22 @@
     },
     {
       "errors": [],
+      "id": "rust-vertex-provider-plugin-parity",
+      "last_reviewed": "2026-07-02",
+      "matched_files": 2,
+      "matched_sample": [
+        "plugins/model-providers/vertex/__init__.py",
+        "plugins/model-providers/vertex/plugin.yaml"
+      ],
+      "overdue": false,
+      "owner": "sheawinkler",
+      "review_date": "2026-10-02",
+      "status": "approved",
+      "ticket": 700,
+      "warnings": []
+    },
+    {
+      "errors": [],
       "id": "rust-cli-tui-primary-ux-surface",
       "last_reviewed": "2026-07-02",
       "matched_files": 1272,
@@ -280,8 +296,8 @@
   ],
   "summary": {
     "errors": 0,
-    "items": 12,
-    "local_paths": 4055,
+    "items": 13,
+    "local_paths": 4056,
     "review_overdue": 0,
     "unowned": 0,
     "upstream_paths": 5966,

--- a/docs/parity/intentional-divergence.json
+++ b/docs/parity/intentional-divergence.json
@@ -148,6 +148,20 @@
       ]
     },
     {
+      "id": "rust-vertex-provider-plugin-parity",
+      "status": "approved",
+      "workstream": "WS3",
+      "summary": "Keep upstream Vertex Python provider plugin files out of the Rust runtime while tracking equivalent Rust provider surfaces.",
+      "owner": "sheawinkler",
+      "ticket": 700,
+      "last_reviewed": "2026-07-02",
+      "review_date": "2026-10-02",
+      "rationale": "Upstream Vertex provider metadata points to a Python vertex_adapter. Hermes Ultra keeps runtime provider behavior in Rust via generic/OpenAI-compatible provider routing, Gemini-compatible request shaping, custom base_url/header support, and OAuth provider surfaces; the Python plugin files are reference-only and should not be vendored into the Rust runtime.",
+      "path_prefixes": [
+        "plugins/model-providers/vertex/"
+      ]
+    },
+    {
       "id": "rust-cli-tui-primary-ux-surface",
       "status": "approved",
       "workstream": "WS5",


### PR DESCRIPTION
## Summary
- Add `/journey` as a Rust-native slash command surface, with `/learning` and `/memory-graph` aliases.
- Route journey subcommands into existing first-class Rust surfaces: `/graph`, `/objective ledger`, `/walkthrough`, and `/timetravel`.
- Add focused command/catalog/dispatch tests.
- Add an explicit Vertex provider plugin divergence record so the upstream surface gate does not require vendoring Python provider files into the Rust runtime.

## Root Cause
CI fetched fresh `upstream/main` after the `v0.21.0` release and failed `scripts/run-upstream-slash-parity-gate.py --upstream-ref upstream/main` because upstream added `/journey`. The broader surface gate also exposed two fresh Vertex Python plugin metadata files that need explicit Rust-runtime divergence ownership.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target cargo test -p hermes-cli journey -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target cargo test -p hermes-cli-ui canonical_command_maps_known_aliases -- --nocapture`
- `python3 scripts/validate-intentional-divergence.py --check --allow-warnings` -> errors `0`
- `python3 scripts/run-upstream-slash-parity-gate.py --local-ref HEAD --upstream-ref upstream/main` -> missing_unallowlisted `0`
- `python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref upstream/main --local-ref HEAD` -> missing `0`
