### PR TITLE
release: v0.21.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,7 +1487,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-acp"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1544,7 +1544,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-app-runtime"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "futures",
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-auth"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -1582,7 +1582,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-cli"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "aes-gcm",
  "arboard",
@@ -1641,14 +1641,14 @@ dependencies = [
 
 [[package]]
 name = "hermes-cli-ui"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "hermes-config"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "chrono",
  "directories",
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-core"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1683,7 +1683,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-cron"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-environments"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "hermes-config",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-eval"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-gateway"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "aes",
  "async-trait",
@@ -1792,7 +1792,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-http"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-intelligence"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-mcp"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -1866,7 +1866,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-parity-tests"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "hermes-core",
  "hermes-intelligence",
@@ -1878,7 +1878,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-protocol-parity-tests"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "hermes-acp",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-provider-runtime"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "futures",
@@ -1908,7 +1908,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-skills"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-source-parity-tests"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "regex",
  "serde",
@@ -1943,7 +1943,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-telemetry"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "base64",
  "once_cell",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-tool-planning"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "hermes-agent",
@@ -1973,7 +1973,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-tools"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.21.0"
+version = "0.21.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/sheawinkler/hermes-agent-ultra"

--- a/docs/releases/v0.21.1.md
+++ b/docs/releases/v0.21.1.md
@@ -1,0 +1,68 @@
+# Hermes Agent Ultra v0.21.1
+
+Release date: 2026-07-02
+
+This patch release republishes the `v0.21.0` catch-up release from current `main` so downloadable artifacts include the post-release `/journey` parity hotfix.
+
+## Release Snapshot
+
+| Signal | v0.21.1 State |
+| --- | ---: |
+| Workspace version | `0.21.1` |
+| Base catch-up release | `v0.21.0` |
+| Catch-up PR | `#706` |
+| Release PR | `#707` |
+| Patch PR | `#708` |
+| Upstream queue pending | `0` |
+| Shared diff pending review/classification | `0 / 0` |
+| Slash parity gate | PASS |
+| Surface coverage gate | PASS |
+| Runtime language posture | Rust runtime; no Python runtime fallback added |
+
+## Why This Exists
+
+`v0.21.0` shipped the full Rust parity catch-up and cleared the tracked upstream backlog. After the tag was cut, CI detected one newly surfaced upstream slash-command delta: `/journey`.
+
+`v0.21.1` makes that fix part of the released binaries and installers.
+
+## Included Since v0.21.0
+
+- Added Rust-native `/journey` slash parity with aliases `/learning` and `/memory-graph`.
+- Routed `/journey graph`, `/journey ledger`, `/journey tail`, `/journey walkthrough`, and `/journey timetravel` into the existing Rust graph, objective-ledger, walkthrough, and timetravel surfaces.
+- Added catalog, completion, canonical-alias, quick-dispatch, and runtime behavior tests for the journey surface.
+- Added intentional-divergence ownership for upstream Vertex provider plugin files, reflecting Hermes Ultra's Rust/OpenAI-compatible provider routing instead of a Python Vertex adapter.
+- Restored upstream slash parity and upstream surface coverage gates to green.
+
+## Minimal Flow
+
+```text
+v0.21.0 catch-up release
+        |
+        v
+CI detects upstream /journey slash drift
+        |
+        v
+Rust journey surface + Vertex divergence proof (#708)
+        |
+        v
+slash parity PASS + surface coverage PASS
+        |
+        v
+v0.21.1 released from current main
+```
+
+## Verification
+
+```bash
+export EXTERNAL_TARGET_DIR="${EXTERNAL_TARGET_DIR:-target}"
+cargo fmt --all --check
+git diff --check
+CARGO_TARGET_DIR=$EXTERNAL_TARGET_DIR cargo test -p hermes-cli journey -- --nocapture
+CARGO_TARGET_DIR=$EXTERNAL_TARGET_DIR cargo test -p hermes-cli-ui canonical_command_maps_known_aliases -- --nocapture
+python3 scripts/validate-intentional-divergence.py --check --allow-warnings
+python3 scripts/run-upstream-slash-parity-gate.py --local-ref HEAD --upstream-ref upstream/main
+python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref upstream/main --local-ref HEAD
+CARGO_TARGET_DIR=$EXTERNAL_TARGET_DIR cargo metadata --format-version 1 --no-deps
+```
+
+The release workflow remains tag-triggered; GitHub builds and publishes release assets from the tagged commit.


### PR DESCRIPTION
## Summary
- bump workspace packages from `0.21.0` to `0.21.1`
- add `docs/releases/v0.21.1.md`
- publish a patch release candidate so downloadable artifacts include the merged `/journey` slash parity hotfix from PR #708

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target cargo metadata --format-version 1 --no-deps` with all Hermes packages resolving to `0.21.1`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target cargo test -p hermes-cli journey -- --nocapture`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target cargo test -p hermes-cli-ui canonical_command_maps_known_aliases -- --nocapture`
- `python3 scripts/validate-intentional-divergence.py --check --allow-warnings`
- `python3 scripts/run-upstream-slash-parity-gate.py --local-ref HEAD --upstream-ref upstream/main`
- `python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref upstream/main --local-ref HEAD`

## Notes
- The tracked parity backlog is zero pending as of the release note and parity gates.
- This PR intentionally does not regenerate broader parity artifacts; it is a patch release artifact-sync only.
