### PR TITLE
release: make systems gate portable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,7 +1487,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-acp"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1544,7 +1544,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-app-runtime"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "async-trait",
  "futures",
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-auth"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -1582,7 +1582,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-cli"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "aes-gcm",
  "arboard",
@@ -1641,14 +1641,14 @@ dependencies = [
 
 [[package]]
 name = "hermes-cli-ui"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "hermes-config"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "chrono",
  "directories",
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-core"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1683,7 +1683,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-cron"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-environments"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "async-trait",
  "hermes-config",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-eval"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-gateway"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "aes",
  "async-trait",
@@ -1792,7 +1792,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-http"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "async-trait",
  "axum",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-intelligence"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-mcp"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -1866,7 +1866,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-parity-tests"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "hermes-core",
  "hermes-intelligence",
@@ -1878,7 +1878,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-protocol-parity-tests"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "async-trait",
  "hermes-acp",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-provider-runtime"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "async-trait",
  "futures",
@@ -1908,7 +1908,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-skills"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-source-parity-tests"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "regex",
  "serde",
@@ -1943,7 +1943,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-telemetry"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "base64",
  "once_cell",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-tool-planning"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "async-trait",
  "hermes-agent",
@@ -1973,7 +1973,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-tools"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.21.2"
+version = "0.21.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/sheawinkler/hermes-agent-ultra"

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Rust-first autonomous agent runtime with functional parity goals against `NousRe
 
 ## Current Release And Parity Baseline
 
-Current release baseline: [`v0.21.2`](./docs/releases/v0.21.2.md).
+Current release baseline: [`v0.21.3`](./docs/releases/v0.21.3.md).
 
-As of `v0.21.2`, the tracked upstream parity backlog is closed in the local
+As of `v0.21.3`, the tracked upstream parity backlog is closed in the local
 governance artifacts: upstream queue pending is `0`, shared-diff pending
 classification/review is `0 / 0`, coverage critical gaps are `0`, and SOTA
 harness critical gaps are `0`. Future upstream changes can create new drift;
@@ -27,7 +27,7 @@ the scheduled parity audit and release-readiness summary are the public guard.
 Fast confidence check against published artifacts:
 
 ```bash
-bash scripts/smoke-release-artifact.sh --version v0.21.2
+bash scripts/smoke-release-artifact.sh --version v0.21.3
 ```
 
 See [docs/demo.md](./docs/demo.md) for the one-command demo/readiness path.

--- a/crates/hermes-cli/src/systems.rs
+++ b/crates/hermes-cli/src/systems.rs
@@ -155,6 +155,15 @@ fn repo_root() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("."))
 }
 
+fn source_tree_root() -> Option<PathBuf> {
+    let root = repo_root();
+    source_tree_is_available(&root).then_some(root)
+}
+
+fn source_tree_is_available(root: &Path) -> bool {
+    root.join("Cargo.toml").is_file() && root.join("crates/hermes-cli/src/systems.rs").is_file()
+}
+
 fn report_output(value: &Value, json_only: bool, output: Option<&str>) -> Result<(), AgentError> {
     let rendered = serde_json::to_string_pretty(value)
         .map_err(|err| AgentError::Config(format!("serialize systems report: {err}")))?;
@@ -397,7 +406,14 @@ pub async fn handle_cli_systems(options: SystemsCliOptions) -> Result<(), AgentE
 }
 
 pub fn build_status_report(state: &Path) -> SystemStatusReport {
-    let root = repo_root();
+    let source_root = source_tree_root();
+    build_status_report_for_source_root(state, source_root.as_deref())
+}
+
+fn build_status_report_for_source_root(
+    state: &Path,
+    source_root: Option<&Path>,
+) -> SystemStatusReport {
     let replay_dir = replay_dir(state);
     let handoff_dir = handoff_request_dir(state);
     let provenance_key = provenance_key_path(state);
@@ -405,7 +421,7 @@ pub fn build_status_report(state: &Path) -> SystemStatusReport {
         SystemItem {
             id: 1,
             system: "MCP bridge".to_string(),
-            status: file_status(&root.join("crates/hermes-mcp/src/server.rs")),
+            status: source_file_status(source_root, "crates/hermes-mcp/src/server.rs"),
             command: "hermes systems mcp conformance --json".to_string(),
             evidence: vec![
                 "crates/hermes-mcp/src/server.rs handles initialize/tools/resources/prompts/ping".to_string(),
@@ -415,7 +431,7 @@ pub fn build_status_report(state: &Path) -> SystemStatusReport {
         SystemItem {
             id: 2,
             system: "ACP bridge".to_string(),
-            status: file_status(&root.join("crates/hermes-acp/src/handler.rs")),
+            status: source_file_status(source_root, "crates/hermes-acp/src/handler.rs"),
             command: "hermes systems acp conformance --json".to_string(),
             evidence: vec![
                 "crates/hermes-acp/src/protocol.rs defines lifecycle/session/prompt/tool methods".to_string(),
@@ -452,7 +468,7 @@ pub fn build_status_report(state: &Path) -> SystemStatusReport {
         SystemItem {
             id: 6,
             system: "Release gate".to_string(),
-            status: file_status(&root.join(".github/workflows/release.yml")),
+            status: source_file_status(source_root, ".github/workflows/release.yml"),
             command: "hermes systems release --json".to_string(),
             evidence: vec![
                 ".github/workflows/release.yml runs security gate, cross-builds, signing, and publishing".to_string(),
@@ -481,53 +497,65 @@ pub fn build_status_report(state: &Path) -> SystemStatusReport {
 }
 
 pub fn build_release_gate_report() -> ReleaseGateReport {
-    let root = repo_root();
+    let source_root = source_tree_root();
+    build_release_gate_report_for_source_root(source_root.as_deref())
+}
+
+fn build_release_gate_report_for_source_root(source_root: Option<&Path>) -> ReleaseGateReport {
     let gates = vec![
-        file_gate(
+        source_file_gate(
             "workspace manifest",
-            &root.join("Cargo.toml"),
+            source_root,
+            "Cargo.toml",
             "workspace package version and release metadata are present",
             None,
         ),
-        file_gate(
+        source_file_gate(
             "systems command module",
-            &root.join("crates/hermes-cli/src/systems.rs"),
+            source_root,
+            "crates/hermes-cli/src/systems.rs",
             "systems command surface is compiled into hermes-cli",
             Some("cargo test -p hermes-cli systems -- --nocapture"),
         ),
-        file_gate(
+        source_file_gate(
             "MCP implementation",
-            &root.join("crates/hermes-mcp/src/server.rs"),
+            source_root,
+            "crates/hermes-mcp/src/server.rs",
             "MCP protocol handler exists for in-process conformance checks",
             Some("cargo test -p hermes-mcp"),
         ),
-        file_gate(
+        source_file_gate(
             "ACP implementation",
-            &root.join("crates/hermes-acp/src/handler.rs"),
+            source_root,
+            "crates/hermes-acp/src/handler.rs",
             "ACP protocol handler exists for in-process conformance checks",
             Some("cargo test -p hermes-acp"),
         ),
-        file_gate(
+        source_file_gate(
             "provider parity snapshot",
-            &root.join("docs/parity/upstream-provider-auth-snapshot.json"),
+            source_root,
+            "docs/parity/upstream-provider-auth-snapshot.json",
             "provider capability matrix is grounded in the provider parity snapshot",
             Some("cargo test -p hermes-cli providers -- --nocapture"),
         ),
-        file_gate(
+        source_file_gate(
             "release workflow",
-            &root.join(".github/workflows/release.yml"),
+            source_root,
+            ".github/workflows/release.yml",
             "tag release workflow builds, signs, and publishes artifacts",
             None,
         ),
-        file_gate(
+        source_file_gate(
             "release security gate",
-            &root.join("scripts/run-security-release-gate-v2.py"),
+            source_root,
+            "scripts/run-security-release-gate-v2.py",
             "local release gate checks secrets, SBOM metadata, signatures, redaction, and ACP multimodal tests",
             Some("python3 scripts/run-security-release-gate-v2.py --repo-root ."),
         ),
-        file_gate(
+        source_file_gate(
             "installer",
-            &root.join("scripts/install.sh"),
+            source_root,
+            "scripts/install.sh",
             "release installer script is present",
             None,
         ),
@@ -560,12 +588,39 @@ fn file_gate(name: &str, path: &Path, detail: &str, command: Option<&str>) -> Ev
     }
 }
 
+fn source_file_gate(
+    name: &str,
+    source_root: Option<&Path>,
+    relative_path: &str,
+    detail: &str,
+    command: Option<&str>,
+) -> EvalGate {
+    if let Some(root) = source_root {
+        return file_gate(name, &root.join(relative_path), detail, command);
+    }
+    EvalGate {
+        name: name.to_string(),
+        status: "pass".to_string(),
+        detail: format!(
+            "{detail}; source checkout is not present, so the installed binary is reporting compiled release metadata instead of host source paths"
+        ),
+        command: command.map(str::to_string),
+    }
+}
+
 fn file_status(path: &Path) -> String {
     if path.exists() {
         "implemented".to_string()
     } else {
         "missing".to_string()
     }
+}
+
+fn source_file_status(source_root: Option<&Path>, relative_path: &str) -> String {
+    source_root.map_or_else(
+        || "implemented".to_string(),
+        |root| file_status(&root.join(relative_path)),
+    )
 }
 
 fn replay_dir(state: &Path) -> PathBuf {
@@ -1199,6 +1254,58 @@ mod tests {
                 "missing {expected}: {report:#?}"
             );
         }
+    }
+
+    #[test]
+    fn systems_status_stays_implemented_without_source_checkout() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let report = build_status_report_for_source_root(temp.path(), None);
+
+        assert_eq!(report.total, SYSTEM_COUNT);
+        assert_eq!(report.implemented, SYSTEM_COUNT);
+        assert!(report.items.iter().all(|item| item.status == "implemented"));
+    }
+
+    #[test]
+    fn release_gate_report_is_portable_without_source_checkout() {
+        let report = build_release_gate_report_for_source_root(None);
+        let rendered = serde_json::to_string(&report).expect("serialize report");
+
+        assert!(
+            report.passed,
+            "installed release report should pass: {report:#?}"
+        );
+        assert!(report.gates.iter().all(|gate| gate.status == "pass"));
+        assert!(report
+            .gates
+            .iter()
+            .all(|gate| gate.detail.contains("source checkout is not present")));
+        assert!(!rendered.contains(env!("CARGO_MANIFEST_DIR")));
+    }
+
+    #[test]
+    fn release_gate_report_still_fails_missing_files_in_source_checkout() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        fs::create_dir_all(root.join("crates/hermes-cli/src")).expect("mkdir source");
+        fs::write(root.join("Cargo.toml"), "[workspace]\n").expect("write manifest");
+        fs::write(
+            root.join("crates/hermes-cli/src/systems.rs"),
+            "// systems\n",
+        )
+        .expect("write systems");
+
+        assert!(source_tree_is_available(root));
+        let report = build_release_gate_report_for_source_root(Some(root));
+
+        assert!(
+            !report.passed,
+            "source checkout with missing required files should fail: {report:#?}"
+        );
+        assert!(report
+            .gates
+            .iter()
+            .any(|gate| gate.name == "MCP implementation" && gate.status == "fail"));
     }
 
     #[test]

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -7,12 +7,12 @@ the same smoke should pass without using the local development tree.
 ## One Command
 
 ```bash
-bash scripts/smoke-release-artifact.sh --version v0.21.2
+bash scripts/smoke-release-artifact.sh --version v0.21.3
 ```
 
 What it proves:
 
-- downloads the published `install.sh` from the `v0.21.2` GitHub release
+- downloads the published `install.sh` from the `v0.21.3` GitHub release
 - installs the published platform artifact into a temporary `bin` directory
 - fails if the installer falls back to building from source
 - verifies `hermes-agent-ultra` and `hermes-ultra`
@@ -37,8 +37,8 @@ CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-target} cargo test -p hermes-http dashboard
 | Claim | Public surface | Deterministic proof |
 | --- | --- | --- |
 | Current parity baseline is closed | release-readiness summary | `scripts/generate-release-readiness-summary.py --check` |
-| Published artifacts install cleanly | release artifact smoke | `scripts/smoke-release-artifact.sh --version v0.21.2` |
-| Upstream `hermes` can coexist | installer smoke sentinel | `scripts/smoke-release-artifact.sh --version v0.21.2` |
+| Published artifacts install cleanly | release artifact smoke | `scripts/smoke-release-artifact.sh --version v0.21.3` |
+| Upstream `hermes` can coexist | installer smoke sentinel | `scripts/smoke-release-artifact.sh --version v0.21.3` |
 | One-true-harness cockpit exists | `/harness`, `harness_cockpit` | `cargo test -p hermes-cli harness_command_reports_issue_backed_cockpit_and_teach_skill` |
 | Tool simulator exists | `/simulate`, `tool_policy_simulate` | `cargo test -p hermes-cli test_simulate_command_is_registered_and_completable` |
 | Time-travel/session replay exists | `/timetravel`, replay fixture | `cargo test -p hermes-cli --test e2e_sota_workflow_replay` |

--- a/docs/releases/v0.21.3.md
+++ b/docs/releases/v0.21.3.md
@@ -1,0 +1,29 @@
+# Hermes Agent Ultra v0.21.3
+
+Release date: 2026-07-03
+
+`v0.21.3` is a patch release for installed-artifact confidence after the
+`v0.21.2` public smoke exposed that `hermes systems release --json` was still
+using CI source-checkout paths baked in at compile time.
+
+## What Changed
+
+| Area | Change |
+| --- | --- |
+| Installed release gate | `systems release --json` now distinguishes source-tree checks from installed-binary runtime confidence. Source checkouts still fail missing required files; installed artifacts report compiled release metadata without requiring the CI checkout path to exist on the user machine. |
+| Systems status | `systems status --json` no longer marks compiled MCP, ACP, or release surfaces missing just because an installed binary has no local source tree. |
+| Regression coverage | Added Rust tests for source-tree failure behavior and installed-artifact portable release/status reports. |
+| Release smoke baseline | Updated the published-artifact smoke default and public demo/readiness docs to `v0.21.3`. |
+
+## Verification Targets
+
+```bash
+CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-target} cargo test -p hermes-cli release_gate_report -- --nocapture
+CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-target} cargo test -p hermes-cli systems_status -- --nocapture
+python3 scripts/generate-release-readiness-summary.py --repo-root . --check
+bash scripts/smoke-release-artifact.sh --version v0.21.3
+```
+
+The important behavioral fix is portability: the released binary must pass the
+same smoke from a temporary install directory without depending on the release
+runner's source checkout path.

--- a/docs/roadmaps/CURRENT_ROADMAP_STATUS.md
+++ b/docs/roadmaps/CURRENT_ROADMAP_STATUS.md
@@ -9,7 +9,7 @@ remains the generated parity artifacts under `docs/parity/`.
 
 | Signal | Current state | Evidence |
 | --- | ---: | --- |
-| Latest release baseline | `v0.21.2` | `docs/releases/v0.21.2.md` |
+| Latest release baseline | `v0.21.3` | `docs/releases/v0.21.3.md` |
 | Upstream missing queue pending | `0` | `docs/parity/upstream-missing-queue.json` |
 | Shared diff pending classification/review | `0 / 0` | `docs/parity/shared-diff-backlog.json` |
 | Coverage critical gaps | `0` | `docs/parity/test-coverage-audit.json` |
@@ -37,7 +37,7 @@ future upstream commits cannot create new drift.
 | Area | Required state | Local gate |
 | --- | --- | --- |
 | Release readiness summary | PASS | `python3 scripts/generate-release-readiness-summary.py --repo-root . --check` |
-| Released binary smoke | PASS for current tag | `bash scripts/smoke-release-artifact.sh --version v0.21.2` |
+| Released binary smoke | PASS for current tag | `bash scripts/smoke-release-artifact.sh --version v0.21.3` |
 | Upstream missing queue | `pending = 0` before release | `python3 scripts/generate-upstream-patch-queue.py --max-commits 0` |
 | Global parity proof | Pass release gate locally | `python3 scripts/generate-global-parity-proof.py --check-release` |
 | SOTA harness coverage | All domains covered | `python3 scripts/generate-sota-harness-hardening.py --check` |
@@ -58,7 +58,7 @@ future upstream commits cannot create new drift.
 - Use released-artifact smoke evidence, not local-source assumptions, before
   claiming installer or distribution behavior.
 - Keep public issue/status truth synchronized with release artifacts. Issue
-  #585 is resolved by the `v0.21.2` zero-backlog baseline and should be closed
+  #585 is resolved by the `v0.21.3` zero-backlog baseline and should be closed
   after this post-release confidence PR lands.
 - Treat stale roadmap prose as non-authoritative when it conflicts with
   generated parity artifacts, release workflow evidence, or closed GitHub issue

--- a/scripts/smoke-release-artifact.sh
+++ b/scripts/smoke-release-artifact.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 REPO="${REPO:-sheawinkler/hermes-agent-ultra}"
-VERSION="${VERSION:-v0.21.2}"
+VERSION="${VERSION:-v0.21.3}"
 KEEP_TMP="${KEEP_TMP:-false}"
 RUN_SETUP_HELP="${RUN_SETUP_HELP:-true}"
 HERMES_SMOKE_COMMAND_TIMEOUT_SECONDS="${HERMES_SMOKE_COMMAND_TIMEOUT_SECONDS:-30}"


### PR DESCRIPTION
## Summary
- make `hermes systems release --json` portable for installed artifacts by separating source-tree file checks from installed-binary runtime confidence
- keep source checkouts strict: missing required release/MCP/ACP/source files still fail when a checkout is present
- keep `systems status --json` from marking compiled MCP/ACP/release surfaces missing only because an installed artifact has no local source tree
- bump patch release baseline to `v0.21.3` and add release notes/docs/smoke default updates

## Verification
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target cargo fmt --all --check`
- `python3 -m py_compile scripts/generate-release-readiness-summary.py`
- `bash -n scripts/smoke-release-artifact.sh`
- `git diff --check`
- `cargo metadata --locked --no-deps --format-version 1`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target cargo test -p hermes-cli systems -- --nocapture`
- `pytest tests/test_release_artifact_smoke_contract.py tests/test_release_readiness_summary.py -q`
- `python3 scripts/generate-release-readiness-summary.py --repo-root . --check`
- `scripts/check-rust-runtime-no-python.sh`
- `scripts/check-runtime-placeholders.sh`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target scripts/clippy-warning-gate.sh --check`
