### PR TITLE
ci: add repo-local gold standard runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ Fast confidence check against published artifacts:
 bash scripts/smoke-release-artifact.sh --version v0.21.3
 ```
 
+Repo-local CI is the authoritative gate for development and release confidence.
+GitHub Actions are a hosted mirror of the repo contract when they run; they are
+not required as the source of truth.
+
+```bash
+CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-target} bash scripts/run-repo-ci.sh
+```
+
 See [docs/demo.md](./docs/demo.md) for the one-command demo/readiness path.
 
 ## What You Get

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -22,7 +22,11 @@ What it proves:
 
 ## Source Tree Confidence Path
 
+Repo-local CI is the gold standard. Hosted GitHub Actions can mirror this, but
+the repo-owned command is the artifact to trust when hosted CI is unavailable.
+
 ```bash
+CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-target} bash scripts/run-repo-ci.sh
 python3 scripts/generate-release-readiness-summary.py --repo-root . --check
 CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-target} cargo test -p hermes-cli --test e2e_sota_workflow_replay -- --nocapture
 CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-target} cargo test -p hermes-cli harness_command_reports_issue_backed_cockpit_and_teach_skill -- --nocapture

--- a/docs/parity/adapter-feature-matrix.json
+++ b/docs/parity/adapter-feature-matrix.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-07-03T20:54:02.804055+00:00",
+  "generated_at_utc": "2026-07-04T06:47:43.270955+00:00",
   "items": [
     {
       "category": "memory_plugin",

--- a/docs/parity/adapter-feature-matrix.md
+++ b/docs/parity/adapter-feature-matrix.md
@@ -1,6 +1,6 @@
 # Adapter Feature Matrix
 
-Generated: `2026-07-03T20:54:02.804055+00:00`
+Generated: `2026-07-04T06:47:43.270955+00:00`
 
 | Category | Name | Feature Flag | Status |
 | --- | --- | --- | --- |

--- a/docs/parity/divergence-validation.json
+++ b/docs/parity/divergence-validation.json
@@ -1,6 +1,6 @@
 {
   "divergence_file": "/Volumes/wd_black/hermes-agent-ultra/repo/docs/parity/intentional-divergence.json",
-  "generated_at_utc": "2026-07-03T20:54:03.926069+00:00",
+  "generated_at_utc": "2026-07-04T06:47:44.366771+00:00",
   "items": [
     {
       "errors": [],
@@ -297,7 +297,7 @@
   "summary": {
     "errors": 0,
     "items": 13,
-    "local_paths": 4063,
+    "local_paths": 4064,
     "review_overdue": 0,
     "unowned": 0,
     "upstream_paths": 6057,

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-07-03T21:02:23.196063+00:00",
+  "generated_at_utc": "2026-07-04T06:47:45.918725+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -298,7 +298,7 @@
   },
   "queue_summary": {
     "by_disposition": {
-      "ported": 1
+      "superseded": 1
     },
     "by_target_ticket": {
       "20": 1
@@ -516,9 +516,9 @@
       "divergence_unowned": 0,
       "missing_rust_test_refs": 0,
       "queue_pending": 0,
-      "queue_total": 8262,
+      "queue_total": 1,
       "rust_test_files": 418,
-      "rust_test_functions": 7263,
+      "rust_test_functions": 7270,
       "test_intent_mapping_ratio": 1.0,
       "test_intents_mapped": 10,
       "test_intents_total": 10,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-07-03T21:02:23.196063+00:00`
+Generated: `2026-07-04T06:47:45.918725+00:00`
 
 ## Gate Status
 

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-07-03T20:54:00.827628+00:00",
+  "generated_at_utc": "2026-07-04T06:47:41.384014+00:00",
   "refs": {
     "local_ref": "HEAD",
-    "local_sha": "074c0dd09f61171ecd5795a289f6bde205a08945",
+    "local_sha": "c905df14be39b3f43623d2ec17f98c587ea97a83",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "19d4174454624a1ca91bc47b8f2a7ae8c3b4b5d3",
+    "upstream_sha": "5445e42b87b9918d5b1bfa9f4eadd8e4bb10ff37",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 1,
-    "commits_ahead": 1325,
+    "commits_ahead": 1326,
     "upstream_patch_missing": 1,
     "upstream_patch_represented": 0,
-    "local_patch_unique": 1062,
+    "local_patch_unique": 1063,
     "files_only_upstream": 3319,
-    "files_only_local": 1325,
+    "files_only_local": 1326,
     "files_shared_identical": 1470,
     "files_shared_different": 1268,
-    "tree_files_changed": 5810,
-    "tree_insertions": 1317910,
-    "tree_deletions": 778645
+    "tree_files_changed": 5811,
+    "tree_insertions": 1317915,
+    "tree_deletions": 596164
   },
   "top_upstream_only": [
     {
@@ -399,11 +399,11 @@
       "count": 16
     },
     {
-      "path": "crates/hermes-environments",
-      "count": 15
+      "path": "docs/releases",
+      "count": 16
     },
     {
-      "path": "docs/releases",
+      "path": "crates/hermes-environments",
       "count": 15
     },
     {
@@ -723,11 +723,11 @@
       "count": 16
     },
     {
-      "path": "crates/hermes-environments",
-      "count": 15
+      "path": "docs/releases",
+      "count": 16
     },
     {
-      "path": "docs/releases",
+      "path": "crates/hermes-environments",
       "count": 15
     },
     {
@@ -858,7 +858,7 @@
       "name": "UX parity",
       "upstream_only": 582,
       "shared_different": 329,
-      "local_only": 132,
+      "local_only": 133,
       "risk": "high",
       "effort": "XL"
     },
@@ -906,10 +906,10 @@
   "commit_mapping": {
     "upstream_patch_missing": 1,
     "upstream_patch_represented": 0,
-    "local_patch_unique": 1062,
+    "local_patch_unique": 1063,
     "local_patch_equivalent_to_upstream": 0,
     "upstream_patch_missing_sample": [
-      "19d4174454624a1ca91bc47b8f2a7ae8c3b4b5d3"
+      "5445e42b87b9918d5b1bfa9f4eadd8e4bb10ff37"
     ],
     "upstream_patch_represented_sample": [],
     "local_patch_unique_sample": [

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,11 +1,11 @@
 # Parity Matrix
 
-Generated: `2026-07-03T20:54:00.827628+00:00`
+Generated: `2026-07-04T06:47:41.384014+00:00`
 
 ## Scope
 
-- Local ref: `HEAD` (`074c0dd09f61171ecd5795a289f6bde205a08945`)
-- Upstream ref: `upstream/main` (`19d4174454624a1ca91bc47b8f2a7ae8c3b4b5d3`)
+- Local ref: `HEAD` (`c905df14be39b3f43623d2ec17f98c587ea97a83`)
+- Upstream ref: `upstream/main` (`5445e42b87b9918d5b1bfa9f4eadd8e4bb10ff37`)
 - Merge base: `none (history divergence)`
 
 ## Summary
@@ -13,17 +13,17 @@ Generated: `2026-07-03T20:54:00.827628+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 1 |
-| Commits ahead local (`local` ancestry only) | 1325 |
+| Commits ahead local (`local` ancestry only) | 1326 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 1 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 0 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 1062 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 1063 |
 | Files only in upstream tree | 3319 |
-| Files only in local tree | 1325 |
+| Files only in local tree | 1326 |
 | Shared files identical content | 1470 |
 | Shared files different content | 1268 |
-| Total files changed (`local` vs `upstream`) | 5810 |
-| Insertions (`local` vs `upstream`) | 1317910 |
-| Deletions (`local` vs `upstream`) | 778645 |
+| Total files changed (`local` vs `upstream`) | 5811 |
+| Insertions (`local` vs `upstream`) | 1317915 |
+| Deletions (`local` vs `upstream`) | 596164 |
 
 ## Top 40 upstream-only buckets
 
@@ -132,8 +132,8 @@ Generated: `2026-07-03T20:54:00.827628+00:00`
 | `crates/hermes-acp` | 22 |
 | `crates/hermes-core` | 18 |
 | `crates/hermes-eval` | 16 |
+| `docs/releases` | 16 |
 | `crates/hermes-environments` | 15 |
-| `docs/releases` | 15 |
 | `crates/hermes-parity-tests` | 13 |
 | `crates/hermes-source-parity-tests` | 13 |
 | `skills/mlops` | 13 |
@@ -176,7 +176,7 @@ Generated: `2026-07-03T20:54:00.827628+00:00`
 
 - Upstream missing by patch-id: `1`
 - Upstream represented by patch-id: `0`
-- Local unique by patch-id: `1062`
+- Local unique by patch-id: `1063`
 - Intentional divergence tracked items: `13` (covered files: `1338`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -2064,6 +2064,11 @@
       "disposition": "ported",
       "notes": "rust gateway already supports vision/image URL handling and platform media send paths; this slice adds MEDIA marker extraction/routing with unsafe path blocking to close generated screenshot/image delivery parity"
     },
+    "5445e42b87b9918d5b1bfa9f4eadd8e4bb10ff37": {
+      "disposition": "superseded",
+      "owner": "rust-runtime",
+      "notes": "Upstream PR #57969 / head 4bf749fd changed only Electron desktop copy-button tooltip and scrollbar-offset UI in apps/desktop/src/components/assistant-ui/tool/fallback.tsx and apps/desktop/src/components/ui/copy-button.tsx. Hermes Agent Ultra does not ship the Electron desktop app; Rust CLI/TUI/gateway/tool surfaces own copy/display behavior, so there is no Rust runtime port target."
+    },
     "546193aa6d0ab3aff44a9691723c3c0a63ffda99": {
       "disposition": "superseded",
       "owner": "rust-runtime",

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -125,7 +125,7 @@
       "classification": "intentional_divergence",
       "classification_path": "README.md",
       "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "8869e032ff2722724e1f31fe4f21fb3415200abe",
+      "local_blob": "6f19299d645b8c96cfa8eccc9cfc75eacc957a51",
       "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "README.md",
@@ -19021,12 +19021,12 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-07-03T21:02:21.831191+00:00",
+  "generated_at_utc": "2026-07-04T06:47:44.628337+00:00",
   "refs": {
     "local_ref": "HEAD",
-    "local_sha": "074c0dd09f61171ecd5795a289f6bde205a08945",
+    "local_sha": "c905df14be39b3f43623d2ec17f98c587ea97a83",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "19d4174454624a1ca91bc47b8f2a7ae8c3b4b5d3"
+    "upstream_sha": "5445e42b87b9918d5b1bfa9f4eadd8e4bb10ff37"
   },
   "summary": {
     "by_classification": {

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,6 +1,6 @@
 # Shared-Different Backlog
 
-Generated: `2026-07-03T21:02:21.831191+00:00`
+Generated: `2026-07-04T06:47:44.628337+00:00`
 
 ## Summary
 

--- a/docs/parity/test-coverage-audit.json
+++ b/docs/parity/test-coverage-audit.json
@@ -90,7 +90,7 @@
     }
   ],
   "critical_gaps": [],
-  "generated_at_utc": "2026-07-03T20:54:02.745718+00:00",
+  "generated_at_utc": "2026-07-04T06:47:43.205545+00:00",
   "intent_domains": [
     {
       "classification": "direct_rust_test",
@@ -628,9 +628,9 @@
     "divergence_unowned": 0,
     "missing_rust_test_refs": 0,
     "queue_pending": 0,
-    "queue_total": 8262,
+    "queue_total": 1,
     "rust_test_files": 418,
-    "rust_test_functions": 7263,
+    "rust_test_functions": 7270,
     "test_intent_mapping_ratio": 1.0,
     "test_intents_mapped": 10,
     "test_intents_total": 10,

--- a/docs/parity/test-coverage-audit.md
+++ b/docs/parity/test-coverage-audit.md
@@ -1,6 +1,6 @@
 # Test Coverage Audit
 
-Generated: `2026-07-03T20:54:02.745718+00:00`
+Generated: `2026-07-04T06:47:43.205545+00:00`
 
 ## Gate
 
@@ -16,12 +16,12 @@ Generated: `2026-07-03T20:54:02.745718+00:00`
 | `covered_behavior_rows` | 470 |
 | `tracked_behavior_coverage_ratio` | 1.0 |
 | `rust_test_files` | 418 |
-| `rust_test_functions` | 7263 |
+| `rust_test_functions` | 7270 |
 | `coverage_manifest_entries` | 460 |
 | `coverage_manifest_entries_with_valid_rust_tests` | 460 |
 | `missing_rust_test_refs` | 0 |
 | `queue_pending` | 0 |
-| `queue_total` | 8262 |
+| `queue_total` | 1 |
 | `test_intents_total` | 10 |
 | `test_intents_mapped` | 10 |
 

--- a/docs/parity/test-intent-mapping.json
+++ b/docs/parity/test-intent-mapping.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-07-03T20:54:02.029055+00:00",
+  "generated_at_utc": "2026-07-04T06:47:42.617538+00:00",
   "intent_unit": "domain_intent",
   "intents": [
     {

--- a/docs/parity/test-intent-mapping.md
+++ b/docs/parity/test-intent-mapping.md
@@ -1,6 +1,6 @@
 # Test Intent Mapping
 
-Generated: `2026-07-03T20:54:02.029055+00:00`
+Generated: `2026-07-04T06:47:42.617538+00:00`
 
 | Intent | Mapped | Evidence Count |
 | --- | --- | ---: |

--- a/docs/parity/upstream-missing-queue.json
+++ b/docs/parity/upstream-missing-queue.json
@@ -2,7 +2,7 @@
   "commits": [
     {
       "classification_rule": "sha_override",
-      "disposition": "ported",
+      "disposition": "superseded",
       "files_sample": [
         ".dockerignore",
         ".env.example",
@@ -26,7 +26,7 @@
         ".github/pr-screenshots/telegram-overflow/topic-final-response-clipped.jpg"
       ],
       "files_touched": 6057,
-      "notes": "Ported in Rust gateway: /sessions search and /sessions find now route to user-scoped SessionManager search over session title, UUID id, and canonical gateway key with punctuation-normalized matching; missing-query usage and cross-user non-leakage are covered by gateway parser/runtime tests.",
+      "notes": "Upstream PR #57969 / head 4bf749fd changed only Electron desktop copy-button tooltip and scrollbar-offset UI in apps/desktop/src/components/assistant-ui/tool/fallback.tsx and apps/desktop/src/components/ui/copy-button.tsx. Hermes Agent Ultra does not ship the Electron desktop app; Rust CLI/TUI/gateway/tool surfaces own copy/display behavior, so there is no Rust runtime port target.",
       "owner": "rust-runtime",
       "rust_only_guard": {
         "allow_python_test_surfaces": false,
@@ -34,15 +34,15 @@
         "rust_primary_surface_only_commit": false,
         "superseded_by_guard": false
       },
-      "sha": "19d4174454624a1ca91bc47b8f2a7ae8c3b4b5d3",
-      "subject": "feat(gateway): add /sessions search <query> (#57685)",
+      "sha": "5445e42b87b9918d5b1bfa9f4eadd8e4bb10ff37",
+      "subject": "Merge pull request #57969 from alelpoan/fix/copy-button-tooltip",
       "target_ticket": 20,
       "target_ticket_name": "GPAR-01 tests+CI parity"
     }
   ],
-  "generated_at_utc": "2026-07-03T21:02:23.131785+00:00",
+  "generated_at_utc": "2026-07-04T06:47:45.845372+00:00",
   "refs": {
-    "baseline_start_sha": "99af222ecf56c0eed0d3eb82903a6bf33b6ff7d5",
+    "baseline_start_sha": "19d4174454624a1ca91bc47b8f2a7ae8c3b4b5d3",
     "local_ref": "HEAD",
     "prior_ref": "HEAD",
     "prior_source": "HEAD",
@@ -52,7 +52,7 @@
   },
   "summary": {
     "by_disposition": {
-      "ported": 1
+      "superseded": 1
     },
     "by_target_ticket": {
       "20": 1

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-07-03T21:02:23.131785+00:00`
+Generated: `2026-07-04T06:47:45.845372+00:00`
 
 - Range: `HEAD..upstream/main`; total commits tracked: `1`.
 
@@ -10,7 +10,7 @@ Generated: `2026-07-03T21:02:23.131785+00:00`
 
 | Disposition | Commit Count |
 | --- | ---: |
-| ported | 1 |
+| superseded | 1 |
 
 ## First 100 Pending Commits
 

--- a/docs/parity/workstream-status.json
+++ b/docs/parity/workstream-status.json
@@ -1,12 +1,12 @@
 {
-  "generated_at_utc": "2026-07-03T14:36:48-06:00",
-  "head_sha": "074c0dd09f61171ecd5795a289f6bde205a08945",
+  "generated_at_utc": "2026-07-03T15:57:55-06:00",
+  "head_sha": "c905df14be39b3f43623d2ec17f98c587ea97a83",
   "states": {
     "complete": 6,
     "in_progress": 1
   },
   "upstream_ref": "upstream/main",
-  "upstream_sha": "19d4174454624a1ca91bc47b8f2a7ae8c3b4b5d3",
+  "upstream_sha": "5445e42b87b9918d5b1bfa9f4eadd8e4bb10ff37",
   "workstreams": [
     {
       "evidence": [

--- a/docs/parity/workstream-status.md
+++ b/docs/parity/workstream-status.md
@@ -1,7 +1,7 @@
 # Workstream Status
 
-- Local HEAD: `074c0dd09f61171ecd5795a289f6bde205a08945`
-- Upstream: `upstream/main` (`19d4174454624a1ca91bc47b8f2a7ae8c3b4b5d3`)
+- Local HEAD: `c905df14be39b3f43623d2ec17f98c587ea97a83`
+- Upstream: `upstream/main` (`5445e42b87b9918d5b1bfa9f4eadd8e4bb10ff37`)
 
 | Workstream | Title | State |
 | --- | --- | --- |

--- a/scripts/run-repo-ci.sh
+++ b/scripts/run-repo-ci.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+UPSTREAM_REMOTE="${UPSTREAM_REMOTE:-upstream}"
+UPSTREAM_URL="${UPSTREAM_URL:-https://github.com/NousResearch/hermes-agent.git}"
+UPSTREAM_REF="${UPSTREAM_REF:-${UPSTREAM_REMOTE}/main}"
+SKIP_UPSTREAM_FETCH="${SKIP_UPSTREAM_FETCH:-false}"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/run-repo-ci.sh [--skip-upstream-fetch]
+
+Run the repository-local CI contract. This is the authoritative gate for local
+changes; hosted GitHub Actions are a convenience mirror when they run.
+
+Environment:
+  CARGO_TARGET_DIR       Optional external Cargo target directory.
+  CARGO_INCREMENTAL      Optional Cargo incremental setting.
+  UPSTREAM_REMOTE        Upstream remote name (default: upstream).
+  UPSTREAM_URL           Upstream remote URL (default: NousResearch/hermes-agent).
+  UPSTREAM_REF           Upstream ref used by parity gates (default: upstream/main).
+  SKIP_UPSTREAM_FETCH    true/false; skip refreshing upstream/main when true.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skip-upstream-fetch)
+      SKIP_UPSTREAM_FETCH=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+run() {
+  echo
+  echo "[repo-ci] $*"
+  "$@"
+}
+
+refresh_upstream() {
+  if [[ "${SKIP_UPSTREAM_FETCH}" == "true" ]]; then
+    echo "[repo-ci] skipping upstream fetch; using ${UPSTREAM_REF} as-is"
+    return
+  fi
+  if ! git -C "${REPO_ROOT}" remote get-url "${UPSTREAM_REMOTE}" >/dev/null 2>&1; then
+    git -C "${REPO_ROOT}" remote add "${UPSTREAM_REMOTE}" "${UPSTREAM_URL}"
+  fi
+  run git -C "${REPO_ROOT}" fetch --no-tags --depth=1 \
+    "${UPSTREAM_REMOTE}" \
+    "refs/heads/main:refs/remotes/${UPSTREAM_REMOTE}/main"
+}
+
+cd "${REPO_ROOT}"
+
+refresh_upstream
+
+run python3 scripts/generate-parity-matrix.py --local-ref HEAD
+run python3 scripts/generate-workstream-status.py
+run python3 scripts/generate-test-intent-mapping.py
+run python3 scripts/generate-test-coverage-audit.py --check
+run python3 scripts/generate-adapter-matrix.py
+run python3 scripts/validate-intentional-divergence.py --check --allow-warnings
+run python3 scripts/generate-shared-diff-backlog.py --local-ref HEAD --no-fetch
+run python3 scripts/generate-upstream-patch-queue.py --local-ref HEAD --max-commits 0
+run python3 scripts/generate-global-parity-proof.py
+
+run cargo fmt --all --check
+run bash scripts/clippy-warning-gate.sh --check
+run cargo test -p hermes-source-parity-tests --test rust_module_size_policy -- --nocapture
+run bash scripts/check-runtime-placeholders.sh
+run cargo test --workspace
+run cargo test -p hermes-parity-tests
+run cargo test -p hermes-source-parity-tests --test cli_command_contract
+run cargo test -p hermes-protocol-parity-tests --test protocol_differential_contracts
+run python3 scripts/run-upstream-slash-parity-gate.py --upstream-ref "${UPSTREAM_REF}"
+run python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref "${UPSTREAM_REF}" --local-ref HEAD
+run cargo test -p hermes-source-parity-tests --test global_parity_governance
+
+for script in \
+  scripts/upstream_webhook_sync.py \
+  scripts/publish_automation_summary.py \
+  scripts/run-golden-parity-harness.py \
+  scripts/run-upstream-slash-parity-gate.py \
+  scripts/run-upstream-surface-coverage-gate.py \
+  scripts/generate-shared-diff-backlog.py \
+  scripts/generate-test-coverage-audit.py \
+  scripts/generate-release-readiness-summary.py \
+  scripts/release_secret_scan.py; do
+  run python3 -m py_compile "${script}"
+done
+
+echo
+printf '[repo-ci] PASS\n'

--- a/tests/test_repo_ci_contract.py
+++ b/tests/test_repo_ci_contract.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "run-repo-ci.sh"
+README = REPO_ROOT / "README.md"
+CI = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def test_repo_ci_runner_exists_and_declares_authority() -> None:
+    text = SCRIPT.read_text()
+    assert SCRIPT.exists()
+    assert "repository-local CI contract" in text
+    assert "hosted GitHub Actions are a convenience mirror" in text
+    assert "refs/heads/main:refs/remotes/${UPSTREAM_REMOTE}/main" in text
+    assert "[repo-ci] PASS" in text
+
+
+def test_repo_ci_runner_covers_workflow_test_job_gates() -> None:
+    script = SCRIPT.read_text()
+    workflow = CI.read_text()
+    for command in [
+        "python3 scripts/generate-parity-matrix.py --local-ref HEAD",
+        "python3 scripts/generate-workstream-status.py",
+        "python3 scripts/generate-test-intent-mapping.py",
+        "python3 scripts/generate-test-coverage-audit.py --check",
+        "python3 scripts/generate-adapter-matrix.py",
+        "python3 scripts/validate-intentional-divergence.py --check --allow-warnings",
+        "python3 scripts/generate-shared-diff-backlog.py --local-ref HEAD --no-fetch",
+        "python3 scripts/generate-upstream-patch-queue.py --local-ref HEAD --max-commits 0",
+        "python3 scripts/generate-global-parity-proof.py",
+        "cargo fmt --all --check",
+        "bash scripts/clippy-warning-gate.sh --check",
+        "cargo test -p hermes-source-parity-tests --test rust_module_size_policy -- --nocapture",
+        "bash scripts/check-runtime-placeholders.sh",
+        "cargo test --workspace",
+        "cargo test -p hermes-parity-tests",
+        "cargo test -p hermes-source-parity-tests --test cli_command_contract",
+        "cargo test -p hermes-protocol-parity-tests --test protocol_differential_contracts",
+        "cargo test -p hermes-source-parity-tests --test global_parity_governance",
+    ]:
+        assert command in workflow
+        assert command in script
+
+    assert 'python3 scripts/run-upstream-slash-parity-gate.py --upstream-ref "${UPSTREAM_REF}"' in script
+    assert 'python3 scripts/run-upstream-surface-coverage-gate.py --repo-root . --upstream-ref "${UPSTREAM_REF}" --local-ref HEAD' in script
+
+
+def test_readme_names_repo_ci_as_gold_standard() -> None:
+    text = README.read_text()
+    assert "Repo-local CI is the authoritative gate" in text
+    assert "GitHub Actions are a hosted mirror" in text
+    assert "bash scripts/run-repo-ci.sh" in text


### PR DESCRIPTION
## Summary
- add scripts/run-repo-ci.sh as the repository-local CI contract and document it as the authoritative gate
- add a Python contract test that keeps the runner aligned with the hosted CI test-job commands
- classify upstream PR #57969 as superseded because its real patch is Electron desktop-only copy-button tooltip/scrollbar UI, then regenerate parity ledgers with zero pending queue items

## Verification
- bash -n scripts/run-repo-ci.sh && bash scripts/run-repo-ci.sh --help
- pytest tests/test_repo_ci_contract.py tests/test_release_artifact_smoke_contract.py tests/test_release_readiness_summary.py -q
- CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target CARGO_INCREMENTAL=0 bash scripts/run-repo-ci.sh
- git diff --check