### PR TITLE
chore(cli): strengthen provider terminal config

### DIFF
--- a/crates/hermes-cli/src/cli.rs
+++ b/crates/hermes-cli/src/cli.rs
@@ -21,6 +21,12 @@ pub enum CliCommand {
     ///   hermes model                    — show current model
     ///   hermes model openai:gpt-4o      — switch to gpt-4o via openai provider
     Model {
+        /// Print provider:model completion candidates, one per line.
+        #[arg(long, hide = true, conflicts_with = "completion_providers")]
+        completion_values: bool,
+        /// Print provider completion candidates, one per line.
+        #[arg(long, hide = true)]
+        completion_providers: bool,
         /// Provider:model identifier (e.g. "openai:gpt-4o", "anthropic:claude-3-opus").
         provider_model: Option<String>,
     },

--- a/crates/hermes-cli/src/cli/tests.rs
+++ b/crates/hermes-cli/src/cli/tests.rs
@@ -19,7 +19,13 @@ fn cli_parse_default() {
 fn cli_parse_model() {
     let cli = Cli::try_parse_from(vec!["hermes", "model", "openai:gpt-4o"]).unwrap();
     match cli.command {
-        Some(CliCommand::Model { provider_model }) => {
+        Some(CliCommand::Model {
+            completion_values,
+            completion_providers,
+            provider_model,
+        }) => {
+            assert!(!completion_values);
+            assert!(!completion_providers);
             assert_eq!(provider_model.as_deref(), Some("openai:gpt-4o"));
         }
         _ => panic!("Expected Model command"),

--- a/crates/hermes-cli/src/main/auth_commands.rs
+++ b/crates/hermes-cli/src/main/auth_commands.rs
@@ -1,4 +1,4 @@
-async fn print_auth_status_matrix(cli: &Cli, manager: &AuthManager) -> Result<(), AgentError> {
+async fn print_auth_status_matrix(cli: &Cli, token_store: &FileTokenStore) -> Result<(), AgentError> {
     let cfg_path = hermes_state_root(cli).join("config.yaml");
     let disk = load_user_config_file(&cfg_path).map_err(|e| AgentError::Config(e.to_string()))?;
 
@@ -15,7 +15,7 @@ async fn print_auth_status_matrix(cli: &Cli, manager: &AuthManager) -> Result<()
                     .ok()
                     .map(|v| !v.trim().is_empty())
                     .unwrap_or(false));
-        let store_present = manager.get_access_token(provider).await?.is_some();
+        let store_present = token_store.get(provider).await.is_some();
         let auth_state_present = if provider_supports_oauth(provider) {
             read_provider_auth_state(provider)?.is_some()
         } else {

--- a/crates/hermes-cli/src/main/auth_commands/portal_secrets.rs
+++ b/crates/hermes-cli/src/main/auth_commands/portal_secrets.rs
@@ -960,7 +960,7 @@ async fn run_auth(
         }
         _ => {
             if provider == "all" || provider == "*" {
-                print_auth_status_matrix(&cli, &manager).await?;
+                print_auth_status_matrix(&cli, &token_store).await?;
                 return Ok(());
             }
             if provider == "telegram" {
@@ -1049,7 +1049,7 @@ async fn run_auth(
             }
             if provider == "nous" {
                 let env_present = provider_api_key_from_env(&provider).is_some();
-                let store_present = manager.get_access_token(&provider).await?.is_some();
+                let store_present = token_store.get(&provider).await.is_some();
                 let auth_state_present = read_valid_nous_auth_state()?.is_some();
                 let (has_token, source) = if env_present {
                     (true, "env")
@@ -1069,7 +1069,7 @@ async fn run_auth(
             if provider == "qwen-oauth" {
                 let qwen_status = get_qwen_auth_status().await;
                 let auth_state_present = read_provider_auth_state(&provider)?.is_some();
-                let store_present = manager.get_access_token(&provider).await?.is_some();
+                let store_present = token_store.get(&provider).await.is_some();
                 let env_present = provider_api_key_from_env(&provider).is_some();
                 let (has_token, source) = if env_present {
                     (true, "env")
@@ -1105,7 +1105,7 @@ async fn run_auth(
             if provider == "google-gemini-cli" {
                 let google_status = get_gemini_oauth_auth_status().await;
                 let auth_state_present = read_provider_auth_state(&provider)?.is_some();
-                let store_present = manager.get_access_token(&provider).await?.is_some();
+                let store_present = token_store.get(&provider).await.is_some();
                 let env_present = provider_api_key_from_env(&provider).is_some();
                 let (has_token, source) = if env_present {
                     (true, "env")
@@ -1147,7 +1147,7 @@ async fn run_auth(
             if provider == "anthropic" {
                 let anthropic_status = get_anthropic_oauth_status().await;
                 let auth_state_present = read_provider_auth_state(&provider)?.is_some();
-                let store_present = manager.get_access_token(&provider).await?.is_some();
+                let store_present = token_store.get(&provider).await.is_some();
                 let env_present = provider_api_key_from_env(&provider).is_some();
                 let (has_token, source) = if env_present {
                     (true, "env")
@@ -1180,7 +1180,7 @@ async fn run_auth(
                 return Ok(());
             }
             let env_present = provider_api_key_from_env(&provider).is_some();
-            let store_present = manager.get_access_token(&provider).await?.is_some();
+            let store_present = token_store.get(&provider).await.is_some();
             let auth_state_present = if provider_supports_oauth(&provider) {
                 read_provider_auth_state(&provider)?.is_some()
             } else {

--- a/crates/hermes-cli/src/main/cron_webhook.rs
+++ b/crates/hermes-cli/src/main/cron_webhook.rs
@@ -963,8 +963,76 @@ fn run_completion(shell: Option<String>) -> Result<(), AgentError> {
         "elvish" => CompletionShell::Elvish,
         _ => CompletionShell::Zsh,
     };
-    generate(sh, &mut cmd, "hermes-agent-ultra", &mut std::io::stdout());
+    let mut out = Vec::new();
+    generate(sh, &mut cmd, "hermes-agent-ultra", &mut out);
+    if sh == CompletionShell::Zsh {
+        let script = String::from_utf8(out).map_err(|e| AgentError::Config(e.to_string()))?;
+        std::io::stdout()
+            .write_all(enhance_zsh_provider_completion(script).as_bytes())
+            .map_err(|e| AgentError::Io(e.to_string()))?;
+    } else {
+        std::io::stdout()
+            .write_all(&out)
+            .map_err(|e| AgentError::Io(e.to_string()))?;
+    }
     Ok(())
+}
+
+fn enhance_zsh_provider_completion(mut script: String) -> String {
+    script = script.replace(":MODEL:_default", ":MODEL:_hermes_agent_ultra_model_values");
+    script = script.replace(
+        ":PROVIDER:_default",
+        ":PROVIDER:_hermes_agent_ultra_provider_values",
+    );
+    script = script.replace(
+        "Provider\\:model identifier (e.g. \"openai\\:gpt-4o\", \"anthropic\\:claude-3-opus\"):_default",
+        "Provider\\:model identifier (e.g. \"openai\\:gpt-4o\", \"anthropic\\:claude-3-opus\"):_hermes_agent_ultra_model_values",
+    );
+    script.push_str(
+        r#"
+
+_hermes_agent_ultra_completion_binary() {
+    local cmd="${words[1]:-hermes-agent-ultra}"
+    if command -v "$cmd" >/dev/null 2>&1; then
+        echo "$cmd"
+        return
+    fi
+    for cmd in hermes-agent-ultra hermes-ultra hermes; do
+        if command -v "$cmd" >/dev/null 2>&1; then
+            echo "$cmd"
+            return
+        fi
+    done
+}
+
+_hermes_agent_ultra_model_values() {
+    local cmd="$(_hermes_agent_ultra_completion_binary)"
+    local -a values
+    if [[ -n "$cmd" ]]; then
+        values=("${(@f)$("$cmd" model --completion-values 2>/dev/null)}")
+    fi
+    if (( ${#values[@]} )); then
+        compadd -a values
+    else
+        _default
+    fi
+}
+
+_hermes_agent_ultra_provider_values() {
+    local cmd="$(_hermes_agent_ultra_completion_binary)"
+    local -a values
+    if [[ -n "$cmd" ]]; then
+        values=("${(@f)$("$cmd" model --completion-providers 2>/dev/null)}")
+    fi
+    if (( ${#values[@]} )); then
+        compadd -a values
+    else
+        _default
+    fi
+}
+"#,
+    );
+    script
 }
 
 async fn run_uninstall(yes: bool) -> Result<(), AgentError> {
@@ -1018,4 +1086,3 @@ async fn run_lumio(action: Option<String>, model: Option<String>) -> Result<(), 
     }
     Ok(())
 }
-

--- a/crates/hermes-cli/src/main/entrypoint.rs
+++ b/crates/hermes-cli/src/main/entrypoint.rs
@@ -231,7 +231,17 @@ async fn main() {
                 .await
             }
         }
-        CliCommand::Model { provider_model } => run_model(cli, provider_model).await,
+        CliCommand::Model {
+            completion_values,
+            completion_providers,
+            provider_model,
+        } => {
+            if completion_values || completion_providers {
+                run_model_completion_values(cli, completion_providers).await
+            } else {
+                run_model(cli, provider_model).await
+            }
+        }
         CliCommand::Tools {
             action,
             name,

--- a/crates/hermes-cli/src/main/tests.rs
+++ b/crates/hermes-cli/src/main/tests.rs
@@ -14,6 +14,28 @@ mod tests {
             .expect("env lock poisoned")
     }
 
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set_path(key: &'static str, value: &std::path::Path) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match self.previous.as_deref() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
     #[test]
     fn gateway_memory_notifications_follow_display_config() {
         let mut cfg = GatewayConfig::default();
@@ -142,6 +164,58 @@ mod tests {
 
         let cfg = load_user_config_file(&tmp.path().join("config.yaml")).expect("load config");
         assert_eq!(cfg.model.as_deref(), Some("nous:nousresearch/hermes-4-70b"));
+    }
+
+    #[tokio::test]
+    async fn auth_status_does_not_refresh_expired_stored_credential() {
+        let _guard = env_lock();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _home = EnvVarGuard::set_path("HERMES_HOME", tmp.path());
+        let cli = cli_for_temp_state_root(tmp.path());
+        let token_store = FileTokenStore::new(secret_vault_path_for_cli(&cli))
+            .await
+            .expect("token store");
+        AuthManager::new(token_store)
+            .save_credential(OAuthCredential {
+                provider: "nous".to_string(),
+                access_token: "expired-access-token".to_string(),
+                refresh_token: Some("refresh-token-without-handler".to_string()),
+                token_type: "bearer".to_string(),
+                scope: None,
+                expires_at: Some(chrono::Utc::now() - chrono::Duration::minutes(5)),
+            })
+            .await
+            .expect("save expired credential");
+
+        run_auth(
+            cli,
+            Some("status".to_string()),
+            Some("nous".to_string()),
+            None,
+            None,
+            None,
+            None,
+            false,
+        )
+        .await
+        .expect("auth status must be passive");
+    }
+
+    #[test]
+    fn zsh_completion_uses_catalog_backed_provider_and_model_candidates() {
+        let script = concat!(
+            "'--model=[Override]:MODEL:_default' \\\n",
+            "'--provider=[Override]:PROVIDER:_default' \\\n",
+            "'::provider_model -- Provider\\:model identifier (e.g. \"openai\\:gpt-4o\", \"anthropic\\:claude-3-opus\"):_default' \\\n",
+        );
+        let enhanced = enhance_zsh_provider_completion(script.to_string());
+
+        assert!(enhanced.contains(":MODEL:_hermes_agent_ultra_model_values"));
+        assert!(enhanced.contains(":PROVIDER:_hermes_agent_ultra_provider_values"));
+        assert!(enhanced.contains("provider_model -- Provider\\:model identifier"));
+        assert!(enhanced.contains("_hermes_agent_ultra_model_values()"));
+        assert!(enhanced.contains("model --completion-values"));
+        assert!(enhanced.contains("model --completion-providers"));
     }
 
     #[test]

--- a/crates/hermes-cli/src/main/tools_config.rs
+++ b/crates/hermes-cli/src/main/tools_config.rs
@@ -84,6 +84,27 @@ async fn run_model(cli: Cli, provider_model: Option<String>) -> Result<(), Agent
     Ok(())
 }
 
+async fn run_model_completion_values(cli: Cli, providers_only: bool) -> Result<(), AgentError> {
+    let config =
+        load_config(cli.config_dir.as_deref()).map_err(|e| AgentError::Config(e.to_string()))?;
+    let mut seen = std::collections::BTreeSet::new();
+    for entry in provider_catalog_entries_for_config(&config).await {
+        if providers_only {
+            if seen.insert(entry.provider.clone()) {
+                println!("{}", entry.provider);
+            }
+            continue;
+        }
+        for model in entry.models {
+            let candidate = format!("{}:{}", entry.provider, model);
+            if seen.insert(candidate.clone()) {
+                println!("{candidate}");
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Handle `hermes tools [action]`.
 async fn run_tools(
     cli: Cli,
@@ -718,4 +739,3 @@ async fn run_config(
     }
     Ok(())
 }
-


### PR DESCRIPTION
## Summary
- make `hermes-ultra auth status` passive so expired stored OAuth credentials do not trigger missing refresh-handler failures
- add hidden provider/model completion emitters backed by the merged provider catalog
- enhance generated zsh completions to use live provider/model candidates for `--provider`, `--model`, and `hermes model <provider:model>`

## Verification
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target cargo fmt --all --check`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target cargo test -p hermes-cli auth_status_does_not_refresh_expired_stored_credential`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target cargo test -p hermes-cli zsh_completion_uses_catalog_backed_provider_and_model_candidates`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target cargo test -p hermes-cli cli_parse_model`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target cargo build -p hermes-cli --bin hermes-ultra`
- `/Volumes/wd_black/hermes-agent-ultra/target/debug/hermes-ultra auth status`
- `/Volumes/wd_black/hermes-agent-ultra/target/debug/hermes-ultra model --completion-providers` -> 43 providers
- `/Volumes/wd_black/hermes-agent-ultra/target/debug/hermes-ultra model --completion-values` -> 1036 provider:model candidates
- `/Volumes/wd_black/hermes-agent-ultra/target/debug/hermes-ultra completion zsh` contains catalog-backed model/provider hooks
- `git diff --check`