### PR TITLE
parity(runtime): close memory web sessions and gateway gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ Setup:
 hermes-ultra setup
 ```
 
+Mem0 memory setup supports cloud, self-hosted, and OSS-style endpoints:
+
+```bash
+hermes-ultra memory setup mem0 --mode selfhosted --host http://127.0.0.1:24220 -y
+```
+
+Add `--api-key ...` only when the self-hosted server requires auth; Hermes writes the host to `mem0.json` and the secret to `$HERMES_HOME/.env`.
+
 Interactive session:
 
 ```bash

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1,0 +1,65 @@
+# Hermes Ultra CLI configuration example
+# Copy to ~/.hermes-agent-ultra/config.yaml or ~/.hermes/config.yaml and edit.
+# Environment variables and managed profile overlays can still override these values.
+
+# Keep the default model dynamic; provider routing resolves the concrete model at runtime.
+model: "openai-codex:dynamic"
+max_turns: 250
+
+model_switch:
+  persist_switch_by_default: true
+
+llm_providers:
+  openai-codex:
+    api_mode: "codex_responses"
+    model: "dynamic"
+    oauth_token_url: "${HERMES_OPENAI_CODEX_OAUTH_TOKEN_URL}"
+    oauth_client_id: "${HERMES_OPENAI_CODEX_OAUTH_CLIENT_ID}"
+    request_timeout_seconds: 900
+    model_context_windows:
+      dynamic: 272000
+      gpt-5: 272000
+  openrouter:
+    base_url: "https://openrouter.ai/api/v1"
+    api_key_env: "OPENROUTER_API_KEY"
+    model: "anthropic/claude-opus-4.6"
+  local-openai:
+    base_url: "http://127.0.0.1:1234/v1"
+    api_key_env: "LMSTUDIO_API_KEY"
+    model: "local-model"
+    discover_models: true
+
+fallback_models:
+  - "openrouter:anthropic/claude-sonnet-4.6"
+
+smart_model_routing:
+  enabled: true
+  max_simple_chars: 160
+  max_simple_words: 28
+  cheap_model:
+    provider: "openrouter"
+    model: "openai/gpt-5-mini"
+
+terminal:
+  backend: "local"
+  cwd: "."
+  timeout: 180
+  lifetime_seconds: 300
+  home_mode: "auto"
+  docker_mount_cwd_to_workspace: false
+
+web:
+  search_backend: "auto"
+  extract_backend: "auto"
+  crawl_backend: "auto"
+
+sessions:
+  auto_prune: true
+  retention_days: 90
+  vacuum_after_prune: true
+
+kanban:
+  dispatch_in_gateway: true
+
+agent:
+  preflight_context_compress: true

--- a/crates/hermes-agent/src/memory_plugins/mem0.rs
+++ b/crates/hermes-agent/src/memory_plugins/mem0.rs
@@ -24,6 +24,7 @@ use crate::memory_plugins::config_io;
 
 const BREAKER_THRESHOLD: u32 = 5;
 const BREAKER_COOLDOWN_SECS: u64 = 120;
+const MEM0_CLOUD_BASE_URL: &str = "https://api.mem0.ai/v1";
 
 // ---------------------------------------------------------------------------
 // Tool schemas
@@ -150,10 +151,10 @@ impl Mem0Config {
             } else if !env_host.trim().is_empty() {
                 env_host
             } else {
-                "https://api.mem0.ai/v1".into()
+                MEM0_CLOUD_BASE_URL.into()
             },
             api_timeout_secs: 10.0,
-            rerank: true,
+            rerank: false,
         };
 
         let config_path = Self::config_path(hermes_home);
@@ -205,8 +206,24 @@ impl Mem0Config {
 
 fn normalize_mem0_mode(raw: &str) -> String {
     match raw.trim().to_ascii_lowercase().as_str() {
-        "oss" | "self-hosted" | "self_hosted" | "local" => "oss".to_string(),
+        "oss" | "selfhosted" | "self-hosted" | "self_hosted" | "local" => "oss".to_string(),
         _ => "platform".to_string(),
+    }
+}
+
+fn mem0_base_url_is_cloud(base_url: &str) -> bool {
+    let normalized = base_url.trim().trim_end_matches('/');
+    normalized.eq_ignore_ascii_case(MEM0_CLOUD_BASE_URL)
+        || normalized.eq_ignore_ascii_case("https://api.mem0.ai")
+}
+
+fn mem0_mode_label(config: &Mem0Config) -> String {
+    if config.mode == "oss" {
+        "OSS/self-hosted".to_string()
+    } else if !mem0_base_url_is_cloud(&config.base_url) {
+        format!("self-hosted HTTP at {}", config.base_url)
+    } else {
+        "platform".to_string()
     }
 }
 
@@ -517,14 +534,7 @@ impl MemoryProviderPlugin for Mem0MemoryPlugin {
         let config = self.config.lock().unwrap();
         let (user_id, mode_label) = config
             .as_ref()
-            .map(|c| {
-                let mode_label = if c.mode == "oss" {
-                    format!("OSS/self-hosted at {}", c.base_url)
-                } else {
-                    "platform".to_string()
-                };
-                (c.user_id.as_str(), mode_label)
-            })
+            .map(|c| (c.user_id.as_str(), mem0_mode_label(c)))
             .unwrap_or(("hermes-user", "platform".to_string()));
         format!(
             "# Mem0 Memory\n\
@@ -808,14 +818,14 @@ impl MemoryProviderPlugin for Mem0MemoryPlugin {
             .unwrap_or_else(|| "platform".to_string());
         let api_key_required = mode != "oss";
         Some(json!([
-            {"key": "mode", "description": "Mem0 mode", "default": "platform", "choices": ["platform", "oss"], "env_var": "MEM0_MODE"},
+            {"key": "mode", "description": "Mem0 mode", "default": "platform", "choices": ["platform", "selfhosted", "oss"], "env_var": "MEM0_MODE"},
             {"key": "api_key", "description": "Mem0 API key", "secret": true, "required": api_key_required, "env_var": "MEM0_API_KEY", "url": "https://app.mem0.ai"},
             {"key": "host", "description": "Self-hosted Mem0 URL (alias for base_url)", "default": "", "env_var": "MEM0_HOST"},
             {"key": "user_id", "description": "User identifier", "default": "hermes-user"},
             {"key": "agent_id", "description": "Agent identifier", "default": "hermes"},
-            {"key": "base_url", "description": "Mem0 API base URL", "default": "https://api.mem0.ai/v1", "env_var": "MEM0_BASE_URL"},
+            {"key": "base_url", "description": "Mem0 API base URL", "default": MEM0_CLOUD_BASE_URL, "env_var": "MEM0_BASE_URL"},
             {"key": "api_timeout_secs", "description": "HTTP timeout seconds", "default": "10"},
-            {"key": "rerank", "description": "Enable reranking for recall", "default": "true"}
+            {"key": "rerank", "description": "Enable reranking for recall", "default": "false"}
         ]))
     }
 
@@ -948,11 +958,56 @@ mod tests {
     }
 
     #[test]
+    fn test_mem0_prompt_label_matches_effective_self_hosted_route() {
+        let plugin = Mem0MemoryPlugin::new();
+        let cfg = Mem0Config {
+            mode: "platform".to_string(),
+            api_key: String::new(),
+            user_id: "operator".to_string(),
+            agent_id: "hermes".to_string(),
+            base_url: "http://127.0.0.1:24220".to_string(),
+            api_timeout_secs: 5.0,
+            rerank: false,
+        };
+        *plugin.config.lock().expect("config lock") = Some(cfg);
+
+        let block = plugin.system_prompt_block();
+
+        assert!(block.contains("self-hosted HTTP at http://127.0.0.1:24220"));
+        assert!(!block.contains("Mode: platform"));
+    }
+
+    #[test]
+    fn test_mem0_load_defaults_rerank_to_false() {
+        let _guard = config_io::TEST_ENV_LOCK.lock().expect("env lock");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _api = EnvGuard::remove("MEM0_API_KEY");
+        let _host = EnvGuard::remove("MEM0_HOST");
+        let _base = EnvGuard::remove("MEM0_BASE_URL");
+
+        let cfg = Mem0Config::load(tmp.path().to_str().expect("utf8"));
+
+        assert!(!cfg.rerank);
+    }
+
+    #[test]
     fn test_mem0_config_schema_marks_api_key_optional_in_oss_mode() {
         let _guard = config_io::TEST_ENV_LOCK.lock().expect("env lock");
-        let _mode = EnvGuard::set("MEM0_MODE", "oss");
+        let _mode = EnvGuard::set("MEM0_MODE", "selfhosted");
 
         let schema = Mem0MemoryPlugin::new().get_config_schema().expect("schema");
+        let mode = schema
+            .as_array()
+            .expect("array")
+            .iter()
+            .find(|item| item.get("key").and_then(Value::as_str) == Some("mode"))
+            .expect("mode field");
+        assert!(mode
+            .get("choices")
+            .and_then(Value::as_array)
+            .expect("mode choices")
+            .iter()
+            .any(|choice| choice.as_str() == Some("selfhosted")));
         let api_key = schema
             .as_array()
             .expect("array")
@@ -960,6 +1015,13 @@ mod tests {
             .find(|item| item.get("key").and_then(Value::as_str) == Some("api_key"))
             .expect("api key field");
         assert_eq!(api_key.get("required"), Some(&Value::Bool(false)));
+        let rerank = schema
+            .as_array()
+            .expect("array")
+            .iter()
+            .find(|item| item.get("key").and_then(Value::as_str) == Some("rerank"))
+            .expect("rerank field");
+        assert_eq!(rerank.get("default").and_then(Value::as_str), Some("false"));
     }
 
     #[test]

--- a/crates/hermes-agent/src/memory_plugins/retaindb.rs
+++ b/crates/hermes-agent/src/memory_plugins/retaindb.rs
@@ -2,10 +2,15 @@
 //!
 //! Mirrors Python `plugins/memory/retaindb/__init__.py` (core memory + ingest).
 
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::Duration;
 
-use reqwest::blocking::{Client, RequestBuilder};
+use reqwest::blocking::{
+    multipart::{Form, Part},
+    Client, RequestBuilder,
+};
+use rusqlite::{params, Connection};
 use serde_json::{json, Value};
 
 use crate::memory_manager::MemoryProviderPlugin;
@@ -75,6 +80,74 @@ fn forget_schema() -> Value {
     })
 }
 
+fn upload_file_schema() -> Value {
+    json!({
+        "name": "retaindb_upload_file",
+        "description": "Upload a file to the shared RetainDB file store. Returns an rdb:// URI any agent can reference.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "local_path": {"type": "string", "description": "Local file path to upload."},
+                "remote_path": {"type": "string", "description": "Destination path, e.g. /reports/q1.pdf"},
+                "scope": {"type": "string", "enum": ["USER", "PROJECT", "ORG"], "description": "Access scope (default: PROJECT)."},
+                "ingest": {"type": "boolean", "description": "Also extract memories from file after upload (default: false)."}
+            },
+            "required": ["local_path"]
+        }
+    })
+}
+
+fn list_files_schema() -> Value {
+    json!({
+        "name": "retaindb_list_files",
+        "description": "List files in the shared RetainDB file store.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "prefix": {"type": "string", "description": "Path prefix to filter by, e.g. /reports/"},
+                "limit": {"type": "integer", "description": "Max results (default: 50)."}
+            },
+            "required": []
+        }
+    })
+}
+
+fn read_file_schema() -> Value {
+    json!({
+        "name": "retaindb_read_file",
+        "description": "Read the text content of a stored RetainDB file by file ID.",
+        "parameters": {
+            "type": "object",
+            "properties": { "file_id": {"type": "string", "description": "File ID returned from upload or list."} },
+            "required": ["file_id"]
+        }
+    })
+}
+
+fn ingest_file_schema() -> Value {
+    json!({
+        "name": "retaindb_ingest_file",
+        "description": "Chunk, embed, and extract memories from a stored RetainDB file.",
+        "parameters": {
+            "type": "object",
+            "properties": { "file_id": {"type": "string", "description": "File ID to ingest."} },
+            "required": ["file_id"]
+        }
+    })
+}
+
+fn delete_file_schema() -> Value {
+    json!({
+        "name": "retaindb_delete_file",
+        "description": "Delete a stored RetainDB file.",
+        "parameters": {
+            "type": "object",
+            "properties": { "file_id": {"type": "string", "description": "File ID to delete."} },
+            "required": ["file_id"]
+        }
+    })
+}
+
 #[derive(Clone)]
 struct RetainState {
     client: Client,
@@ -82,7 +155,9 @@ struct RetainState {
     token: String,
     project: String,
     user_id: String,
+    agent_id: String,
     session_id: String,
+    queue_db_path: PathBuf,
 }
 
 fn bearer_token(raw: &str) -> String {
@@ -97,6 +172,12 @@ fn with_retain_headers(req: RequestBuilder, token: &str) -> RequestBuilder {
     req.header("Authorization", format!("Bearer {}", t))
         .header("X-API-Key", t)
         .header("Content-Type", "application/json")
+        .header("x-sdk-runtime", "hermes-agent-rust")
+}
+
+fn with_retain_auth_headers(req: RequestBuilder, token: &str) -> RequestBuilder {
+    let t = bearer_token(token);
+    req.header("Authorization", format!("Bearer {}", t))
         .header("x-sdk-runtime", "hermes-agent-rust")
 }
 
@@ -152,15 +233,23 @@ impl MemoryProviderPlugin for RetainDbMemoryPlugin {
                 return;
             }
         };
+        let queue_db_path = Path::new(hermes_home).join("retaindb_queue.db");
         *self.state.lock().unwrap() = Some(RetainState {
             client,
             base,
             token: api_key,
             project,
             user_id: "default".into(),
+            agent_id: "hermes".into(),
             session_id: session_id.to_string(),
+            queue_db_path,
         });
         tracing::info!("RetainDB memory plugin initialized");
+        if let Some(st) = self.state.lock().unwrap().clone() {
+            ensure_retaindb_queue(&st.queue_db_path);
+            seed_retaindb_soul(&st, Path::new(hermes_home));
+            drain_retaindb_queue_async(st);
+        }
     }
 
     fn system_prompt_block(&self) -> String {
@@ -172,7 +261,7 @@ impl MemoryProviderPlugin for RetainDbMemoryPlugin {
         format!(
             "# RetainDB Memory\n\
              Active. Project: {}.\n\
-             Use retaindb_search, retaindb_remember, retaindb_profile, retaindb_context.",
+             Use retaindb_search, retaindb_remember, retaindb_profile, retaindb_context, and RetainDB file tools.",
             proj
         )
     }
@@ -216,21 +305,19 @@ impl MemoryProviderPlugin for RetainDbMemoryPlugin {
             session_id.to_string()
         };
         let body = json!({
-            "project": st.project,
             "session_id": sid,
             "user_id": st.user_id,
             "messages": [
                 {"role": "user", "content": user_content, "timestamp": now},
                 {"role": "assistant", "content": assistant_content, "timestamp": now}
-            ],
-            "write_mode": "sync"
+            ]
         });
-        std::thread::spawn(move || {
-            let url = format!("{}/v1/memory/ingest/session", st.base);
-            let req = st.client.post(&url).json(&body);
-            let req = with_retain_headers(req, &st.token);
-            let _ = req.send();
-        });
+        if let Some(row_id) = enqueue_retaindb_turn(&st.queue_db_path, &body) {
+            std::thread::spawn(move || {
+                let _ = flush_retaindb_queue_row(&st, row_id, body);
+                drain_retaindb_queue(&st);
+            });
+        }
     }
 
     fn get_tool_schemas(&self) -> Vec<Value> {
@@ -240,6 +327,11 @@ impl MemoryProviderPlugin for RetainDbMemoryPlugin {
             context_schema(),
             remember_schema(),
             forget_schema(),
+            upload_file_schema(),
+            list_files_schema(),
+            read_file_schema(),
+            ingest_file_schema(),
+            delete_file_schema(),
         ]
     }
 
@@ -298,7 +390,22 @@ fn retaindb_prefetch_overlay(st: &RetainState, query: &str) -> Result<String, St
         _ => json!({}),
     };
 
-    Ok(build_overlay(&profile, &query_result))
+    let mut parts = Vec::new();
+    let overlay = build_overlay(&profile, &query_result);
+    if !overlay.trim().is_empty() {
+        parts.push(overlay);
+    }
+    if let Ok(answer) = retaindb_user_synthesis(st, query) {
+        if !answer.trim().is_empty() {
+            parts.push(format!("[RetainDB User Synthesis]\n{}", answer.trim()));
+        }
+    }
+    if let Ok(model) = retaindb_agent_self_model(st) {
+        if !model.trim().is_empty() {
+            parts.push(model);
+        }
+    }
+    Ok(parts.join("\n\n"))
 }
 
 fn urlencoding_query(s: &str) -> String {
@@ -344,6 +451,333 @@ fn build_overlay(profile: &Value, query_result: &Value) -> String {
         }
     }
     lines.join("\n")
+}
+
+fn retaindb_user_synthesis(st: &RetainState, query: &str) -> Result<String, String> {
+    let body = json!({
+        "project": st.project,
+        "query": query,
+        "reasoning_level": reasoning_level_for_query(query),
+    });
+    let url = format!(
+        "{}/v1/memory/profile/{}/ask",
+        st.base,
+        urlencoding_query(&st.user_id)
+    );
+    let req = st.client.post(&url).json(&body);
+    let req = with_retain_headers(req, &st.token);
+    let resp = req.send().map_err(|e| e.to_string())?;
+    if !resp.status().is_success() {
+        return Err(format!("user synthesis {}", resp.status()));
+    }
+    let value: Value = resp.json().map_err(|e| e.to_string())?;
+    Ok(value
+        .get("answer")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string())
+}
+
+fn retaindb_agent_self_model(st: &RetainState) -> Result<String, String> {
+    let url = format!(
+        "{}/v1/memory/agent/{}/model?project={}",
+        st.base,
+        urlencoding_query(&st.agent_id),
+        urlencoding_query(&st.project)
+    );
+    let req = st.client.get(&url);
+    let req = with_retain_headers(req, &st.token);
+    let resp = req.send().map_err(|e| e.to_string())?;
+    if !resp.status().is_success() {
+        return Err(format!("agent self-model {}", resp.status()));
+    }
+    let value: Value = resp.json().map_err(|e| e.to_string())?;
+    Ok(retaindb_agent_self_model_from_value(&value))
+}
+
+fn retaindb_agent_self_model_from_value(value: &Value) -> String {
+    if value
+        .get("memory_count")
+        .and_then(Value::as_u64)
+        .unwrap_or_default()
+        == 0
+    {
+        return String::new();
+    }
+    let mut lines = Vec::new();
+    if let Some(persona) = value.get("persona").and_then(Value::as_str) {
+        if !persona.trim().is_empty() {
+            lines.push(format!("Persona: {}", persona.trim()));
+        }
+    }
+    if let Some(instructions) = value
+        .get("persistent_instructions")
+        .and_then(Value::as_array)
+    {
+        let rendered = instructions
+            .iter()
+            .filter_map(Value::as_str)
+            .filter(|item| !item.trim().is_empty())
+            .map(|item| format!("- {}", item.trim()))
+            .collect::<Vec<_>>();
+        if !rendered.is_empty() {
+            lines.push(format!("Instructions:\n{}", rendered.join("\n")));
+        }
+    }
+    if let Some(style) = value.get("working_style").and_then(Value::as_str) {
+        if !style.trim().is_empty() {
+            lines.push(format!("Working style: {}", style.trim()));
+        }
+    }
+    if lines.is_empty() {
+        String::new()
+    } else {
+        format!("[RetainDB Agent Self-Model]\n{}", lines.join("\n"))
+    }
+}
+
+fn reasoning_level_for_query(query: &str) -> &'static str {
+    match query.chars().count() {
+        0..=119 => "low",
+        120..=399 => "medium",
+        _ => "high",
+    }
+}
+
+fn ensure_retaindb_queue(path: &Path) {
+    if let Some(parent) = path.parent() {
+        if let Err(err) = std::fs::create_dir_all(parent) {
+            tracing::warn!("RetainDB queue directory setup failed: {}", err);
+            return;
+        }
+    }
+    match Connection::open(path) {
+        Ok(conn) => {
+            if let Err(err) = conn.execute(
+                "CREATE TABLE IF NOT EXISTS pending (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    payload_json TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    last_error TEXT
+                )",
+                [],
+            ) {
+                tracing::warn!("RetainDB queue schema setup failed: {}", err);
+            }
+        }
+        Err(err) => tracing::warn!("RetainDB queue open failed: {}", err),
+    }
+}
+
+fn enqueue_retaindb_turn(path: &Path, payload: &Value) -> Option<i64> {
+    ensure_retaindb_queue(path);
+    let conn = match Connection::open(path) {
+        Ok(conn) => conn,
+        Err(err) => {
+            tracing::warn!("RetainDB queue open failed: {}", err);
+            return None;
+        }
+    };
+    let now = chrono::Utc::now().to_rfc3339();
+    let payload_json = payload.to_string();
+    match conn.execute(
+        "INSERT INTO pending (payload_json, created_at) VALUES (?1, ?2)",
+        params![payload_json, now],
+    ) {
+        Ok(_) => Some(conn.last_insert_rowid()),
+        Err(err) => {
+            tracing::warn!("RetainDB queue insert failed: {}", err);
+            None
+        }
+    }
+}
+
+fn queued_payload_for_ingest(st: &RetainState, payload: &Value) -> Value {
+    json!({
+        "project": st.project,
+        "session_id": payload.get("session_id").cloned().unwrap_or_else(|| json!(st.session_id)),
+        "user_id": payload.get("user_id").cloned().unwrap_or_else(|| json!(st.user_id)),
+        "messages": payload.get("messages").cloned().unwrap_or_else(|| json!([])),
+        "write_mode": "sync",
+    })
+}
+
+fn flush_retaindb_queue_row(st: &RetainState, row_id: i64, payload: Value) -> Result<(), String> {
+    let body = queued_payload_for_ingest(st, &payload);
+    let url = format!("{}/v1/memory/ingest/session", st.base);
+    let req = st.client.post(&url).json(&body);
+    let req = with_retain_headers(req, &st.token);
+    let resp = req.send().map_err(|e| e.to_string())?;
+    if !resp.status().is_success() {
+        let err = format!("ingest {}", resp.status());
+        mark_retaindb_queue_error(&st.queue_db_path, row_id, &err);
+        return Err(err);
+    }
+    delete_retaindb_queue_row(&st.queue_db_path, row_id);
+    Ok(())
+}
+
+fn drain_retaindb_queue_async(st: RetainState) {
+    std::thread::spawn(move || drain_retaindb_queue(&st));
+}
+
+fn drain_retaindb_queue(st: &RetainState) {
+    ensure_retaindb_queue(&st.queue_db_path);
+    let rows = match pending_retaindb_rows(&st.queue_db_path) {
+        Ok(rows) => rows,
+        Err(err) => {
+            tracing::warn!("RetainDB queue read failed: {}", err);
+            return;
+        }
+    };
+    for (row_id, payload) in rows {
+        if let Err(err) = flush_retaindb_queue_row(st, row_id, payload) {
+            tracing::debug!("RetainDB queued ingest still pending: {}", err);
+            break;
+        }
+    }
+}
+
+fn pending_retaindb_rows(path: &Path) -> Result<Vec<(i64, Value)>, String> {
+    let conn = Connection::open(path).map_err(|e| e.to_string())?;
+    let mut stmt = conn
+        .prepare("SELECT id, payload_json FROM pending ORDER BY id ASC LIMIT 200")
+        .map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map([], |row| {
+            let id: i64 = row.get(0)?;
+            let payload_json: String = row.get(1)?;
+            let payload = serde_json::from_str(&payload_json).unwrap_or_else(|_| json!({}));
+            Ok((id, payload))
+        })
+        .map_err(|e| e.to_string())?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row.map_err(|e| e.to_string())?);
+    }
+    Ok(out)
+}
+
+fn delete_retaindb_queue_row(path: &Path, row_id: i64) {
+    if let Ok(conn) = Connection::open(path) {
+        let _ = conn.execute("DELETE FROM pending WHERE id = ?1", params![row_id]);
+    }
+}
+
+fn mark_retaindb_queue_error(path: &Path, row_id: i64, error: &str) {
+    if let Ok(conn) = Connection::open(path) {
+        let _ = conn.execute(
+            "UPDATE pending SET last_error = ?1 WHERE id = ?2",
+            params![error, row_id],
+        );
+    }
+}
+
+fn seed_retaindb_soul(st: &RetainState, hermes_home: &Path) {
+    let soul_path = hermes_home.join("SOUL.md");
+    let Ok(content) = std::fs::read_to_string(soul_path) else {
+        return;
+    };
+    let content = content.trim().to_string();
+    if content.is_empty() {
+        return;
+    }
+    let st = st.clone();
+    std::thread::spawn(move || {
+        let body = json!({
+            "project": st.project,
+            "content": content,
+            "source": "soul_md",
+        });
+        let url = format!(
+            "{}/v1/memory/agent/{}/seed",
+            st.base,
+            urlencoding_query(&st.agent_id)
+        );
+        let req = st.client.post(&url).json(&body);
+        let req = with_retain_headers(req, &st.token);
+        let _ = req.send();
+    });
+}
+
+fn retain_file_mime_type(path: &Path) -> &'static str {
+    match path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "txt" | "text" => "text/plain",
+        "md" | "markdown" => "text/markdown",
+        "json" => "application/json",
+        "csv" => "text/csv",
+        "yaml" | "yml" => "application/yaml",
+        "xml" => "application/xml",
+        "html" | "htm" => "text/html",
+        "pdf" => "application/pdf",
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        _ => "application/octet-stream",
+    }
+}
+
+fn retain_file_is_text(file_info: &Value) -> bool {
+    let mime = file_info
+        .get("mime_type")
+        .or_else(|| file_info.get("mimeType"))
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    if mime.starts_with("text/")
+        || matches!(
+            mime.as_str(),
+            "application/json" | "application/xml" | "application/yaml" | "application/x-yaml"
+        )
+    {
+        return true;
+    }
+    let name = file_info
+        .get("name")
+        .or_else(|| file_info.get("filename"))
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    [
+        ".txt", ".md", ".json", ".csv", ".yaml", ".yml", ".xml", ".html",
+    ]
+    .iter()
+    .any(|suffix| name.ends_with(suffix))
+}
+
+fn valid_retaindb_file_scope(scope: &str) -> bool {
+    matches!(scope, "USER" | "PROJECT" | "ORG")
+}
+
+fn extract_retaindb_file_id(upload_result: &Value) -> Option<String> {
+    upload_result
+        .pointer("/file/id")
+        .or_else(|| upload_result.get("id"))
+        .and_then(Value::as_str)
+        .filter(|id| !id.trim().is_empty())
+        .map(ToString::to_string)
+}
+
+fn retaindb_ingest_file(st: &RetainState, file_id: &str) -> Result<Value, String> {
+    let body = json!({
+        "user_id": st.user_id,
+        "agent_id": st.agent_id,
+    });
+    let url = format!("{}/v1/files/{}/ingest", st.base, urlencoding_query(file_id));
+    let req = st.client.post(&url).json(&body);
+    let req = with_retain_headers(req, &st.token);
+    let resp = req.send().map_err(|e| e.to_string())?;
+    if !resp.status().is_success() {
+        return Err(format!("ingest file {}", resp.status()));
+    }
+    Ok(resp.json().unwrap_or_else(|_| json!({"ok": true})))
 }
 
 fn tool_dispatch(st: &RetainState, tool_name: &str, args: &Value) -> Result<Value, String> {
@@ -462,6 +896,166 @@ fn tool_dispatch(st: &RetainState, tool_name: &str, args: &Value) -> Result<Valu
             }
             Ok(resp.json().unwrap_or(json!({"ok": true})))
         }
+        "retaindb_upload_file" => {
+            let local_path = args
+                .get("local_path")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .trim();
+            if local_path.is_empty() {
+                return Err("local_path is required".into());
+            }
+            let path = Path::new(local_path);
+            if !path.exists() {
+                return Err(format!("File not found: {local_path}"));
+            }
+            let metadata = std::fs::metadata(path).map_err(|e| e.to_string())?;
+            if !metadata.is_file() {
+                return Err(format!("Not a regular file: {local_path}"));
+            }
+            let bytes = std::fs::read(path).map_err(|e| e.to_string())?;
+            let filename = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .filter(|name| !name.trim().is_empty())
+                .unwrap_or("upload")
+                .to_string();
+            let remote_path = args
+                .get("remote_path")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToString::to_string)
+                .unwrap_or_else(|| format!("/{filename}"));
+            let scope = args
+                .get("scope")
+                .and_then(Value::as_str)
+                .unwrap_or("PROJECT")
+                .trim()
+                .to_ascii_uppercase();
+            if !valid_retaindb_file_scope(&scope) {
+                return Err("scope must be USER, PROJECT, or ORG".into());
+            }
+            let mime = retain_file_mime_type(path);
+            let part = Part::bytes(bytes)
+                .file_name(filename)
+                .mime_str(mime)
+                .map_err(|e| e.to_string())?;
+            let form = Form::new()
+                .part("file", part)
+                .text("path", remote_path)
+                .text("scope", scope);
+            let url = format!("{}/v1/files", st.base);
+            let req = st.client.post(&url).multipart(form);
+            let req = with_retain_auth_headers(req, &st.token);
+            let resp = req.send().map_err(|e| e.to_string())?;
+            if !resp.status().is_success() {
+                return Err(format!("upload file {}", resp.status()));
+            }
+            let mut result: Value = resp.json().map_err(|e| e.to_string())?;
+            if args.get("ingest").and_then(Value::as_bool).unwrap_or(false) {
+                if let Some(file_id) = extract_retaindb_file_id(&result) {
+                    let ingest = retaindb_ingest_file(st, &file_id)?;
+                    if let Value::Object(ref mut map) = result {
+                        map.insert("ingest".to_string(), ingest);
+                    }
+                }
+            }
+            Ok(result)
+        }
+        "retaindb_list_files" => {
+            let limit = args
+                .get("limit")
+                .and_then(Value::as_u64)
+                .unwrap_or(50)
+                .clamp(1, 200)
+                .to_string();
+            let mut query = vec![("limit", limit.as_str())];
+            if let Some(prefix) = args
+                .get("prefix")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                query.push(("prefix", prefix));
+            }
+            let url = format!("{}/v1/files", st.base);
+            let req = st.client.get(&url).query(&query);
+            let req = with_retain_headers(req, &st.token);
+            let resp = req.send().map_err(|e| e.to_string())?;
+            if !resp.status().is_success() {
+                return Err(format!("list files {}", resp.status()));
+            }
+            Ok(resp.json().map_err(|e| e.to_string())?)
+        }
+        "retaindb_read_file" => {
+            let file_id = args.get("file_id").and_then(Value::as_str).unwrap_or("");
+            if file_id.is_empty() {
+                return Err("file_id is required".into());
+            }
+            let fid = urlencoding_query(file_id);
+            let meta_url = format!("{}/v1/files/{}", st.base, fid);
+            let meta_req = with_retain_headers(st.client.get(&meta_url), &st.token);
+            let meta_resp = meta_req.send().map_err(|e| e.to_string())?;
+            if !meta_resp.status().is_success() {
+                return Err(format!("read file metadata {}", meta_resp.status()));
+            }
+            let meta: Value = meta_resp.json().map_err(|e| e.to_string())?;
+            let file_info = meta.get("file").unwrap_or(&meta);
+            let content_url = format!("{}/v1/files/{}/content", st.base, fid);
+            let content_req = with_retain_auth_headers(st.client.get(&content_url), &st.token);
+            let content_resp = content_req.send().map_err(|e| e.to_string())?;
+            if !content_resp.status().is_success() {
+                return Err(format!("read file content {}", content_resp.status()));
+            }
+            let bytes = content_resp.bytes().map_err(|e| e.to_string())?;
+            let name = file_info
+                .get("name")
+                .or_else(|| file_info.get("filename"))
+                .cloned()
+                .unwrap_or(Value::Null);
+            let rdb_uri = file_info.get("rdb_uri").cloned().unwrap_or(Value::Null);
+            if !retain_file_is_text(file_info) {
+                return Ok(json!({
+                    "file_id": file_id,
+                    "rdb_uri": rdb_uri,
+                    "name": name,
+                    "content": Value::Null,
+                    "note": "Binary file - use retaindb_ingest_file to extract text into memory."
+                }));
+            }
+            let text = String::from_utf8_lossy(&bytes);
+            let truncated = text.chars().count() > 32_000;
+            let content = text.chars().take(32_000).collect::<String>();
+            Ok(json!({
+                "file_id": file_id,
+                "rdb_uri": rdb_uri,
+                "name": name,
+                "content": content,
+                "truncated": truncated
+            }))
+        }
+        "retaindb_ingest_file" => {
+            let file_id = args.get("file_id").and_then(Value::as_str).unwrap_or("");
+            if file_id.is_empty() {
+                return Err("file_id is required".into());
+            }
+            retaindb_ingest_file(st, file_id)
+        }
+        "retaindb_delete_file" => {
+            let file_id = args.get("file_id").and_then(Value::as_str).unwrap_or("");
+            if file_id.is_empty() {
+                return Err("file_id is required".into());
+            }
+            let url = format!("{}/v1/files/{}", st.base, urlencoding_query(file_id));
+            let req = st.client.delete(&url);
+            let req = with_retain_headers(req, &st.token);
+            let resp = req.send().map_err(|e| e.to_string())?;
+            if !resp.status().is_success() {
+                return Err(format!("delete file {}", resp.status()));
+            }
+            Ok(resp.json().unwrap_or_else(|_| json!({"ok": true})))
+        }
         _ => Err(format!("Unknown tool: {}", tool_name)),
     }
 }
@@ -469,10 +1063,286 @@ fn tool_dispatch(st: &RetainState, tool_name: &str, args: &Value) -> Result<Valu
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::mpsc;
+    use std::time::Duration as StdDuration;
+
+    fn read_http_request(stream: &mut std::net::TcpStream) -> String {
+        stream
+            .set_read_timeout(Some(StdDuration::from_secs(2)))
+            .expect("timeout");
+        let mut buf = Vec::new();
+        let mut chunk = [0u8; 4096];
+        let mut header_end = None;
+        let mut content_len = 0usize;
+        loop {
+            let n = stream.read(&mut chunk).expect("read request");
+            if n == 0 {
+                break;
+            }
+            buf.extend_from_slice(&chunk[..n]);
+            if header_end.is_none() {
+                if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                    header_end = Some(pos + 4);
+                    let headers = String::from_utf8_lossy(&buf[..pos]);
+                    for line in headers.lines() {
+                        if let Some(value) = line.strip_prefix("Content-Length:") {
+                            content_len = value.trim().parse().unwrap_or(0);
+                        } else if let Some(value) = line.strip_prefix("content-length:") {
+                            content_len = value.trim().parse().unwrap_or(0);
+                        }
+                    }
+                }
+            }
+            if let Some(end) = header_end {
+                if buf.len() >= end + content_len {
+                    break;
+                }
+            }
+        }
+        String::from_utf8_lossy(&buf).to_string()
+    }
+
+    fn retain_server(
+        responses: Vec<(u16, &'static str, &'static str)>,
+    ) -> (String, mpsc::Receiver<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            for (status, content_type, body) in responses {
+                let (mut stream, _) = listener.accept().expect("accept");
+                let request = read_http_request(&mut stream);
+                tx.send(request).expect("send request");
+                let reason = if (200..300).contains(&status) {
+                    "OK"
+                } else {
+                    "Error"
+                };
+                let response = format!(
+                    "HTTP/1.1 {status} {reason}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("write response");
+            }
+        });
+        (format!("http://{addr}"), rx)
+    }
+
+    fn state_for(base: String, queue_db_path: PathBuf) -> RetainState {
+        RetainState {
+            client: Client::builder()
+                .timeout(Duration::from_secs(2))
+                .build()
+                .expect("client"),
+            base,
+            token: "test-token".to_string(),
+            project: "proj".to_string(),
+            user_id: "user-1".to_string(),
+            agent_id: "agent-1".to_string(),
+            session_id: "session-1".to_string(),
+            queue_db_path,
+        }
+    }
 
     #[test]
     fn name_is_retaindb() {
         let p = RetainDbMemoryPlugin::new();
         assert_eq!(p.name(), "retaindb");
+    }
+
+    #[test]
+    fn retaindb_tool_schemas_include_memory_and_shared_file_store() {
+        let p = RetainDbMemoryPlugin::new();
+        let schemas = p.get_tool_schemas();
+        let names = schemas
+            .iter()
+            .filter_map(|schema| schema.get("name").and_then(Value::as_str))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            names,
+            vec![
+                "retaindb_profile",
+                "retaindb_search",
+                "retaindb_context",
+                "retaindb_remember",
+                "retaindb_forget",
+                "retaindb_upload_file",
+                "retaindb_list_files",
+                "retaindb_read_file",
+                "retaindb_ingest_file",
+                "retaindb_delete_file",
+            ]
+        );
+    }
+
+    #[test]
+    fn retaindb_file_tool_validation_is_local_and_precise() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let st = state_for(
+            "http://127.0.0.1:9".to_string(),
+            tmp.path().join("retaindb_queue.db"),
+        );
+        assert_eq!(
+            tool_dispatch(&st, "retaindb_upload_file", &json!({})).unwrap_err(),
+            "local_path is required"
+        );
+        assert!(tool_dispatch(
+            &st,
+            "retaindb_upload_file",
+            &json!({"local_path": tmp.path().join("missing.md").display().to_string()})
+        )
+        .unwrap_err()
+        .contains("File not found"));
+        assert_eq!(
+            tool_dispatch(&st, "retaindb_ingest_file", &json!({})).unwrap_err(),
+            "file_id is required"
+        );
+        assert_eq!(
+            tool_dispatch(&st, "retaindb_delete_file", &json!({})).unwrap_err(),
+            "file_id is required"
+        );
+    }
+
+    #[test]
+    fn retaindb_upload_file_posts_multipart_and_optional_ingest() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let file = tmp.path().join("note.md");
+        std::fs::write(&file, "hello retain").expect("write file");
+        let (base, rx) = retain_server(vec![
+            (
+                200,
+                "application/json",
+                r#"{"file":{"id":"file-1","rdb_uri":"rdb://file-1","name":"note.md"}}"#,
+            ),
+            (200, "application/json", r#"{"ingested":true}"#),
+        ]);
+        let st = state_for(base, tmp.path().join("retaindb_queue.db"));
+
+        let result = tool_dispatch(
+            &st,
+            "retaindb_upload_file",
+            &json!({
+                "local_path": file.display().to_string(),
+                "remote_path": "/reports/note.md",
+                "scope": "project",
+                "ingest": true,
+            }),
+        )
+        .expect("upload dispatch");
+
+        assert_eq!(result["file"]["id"], "file-1");
+        assert_eq!(result["ingest"]["ingested"], true);
+        let upload = rx
+            .recv_timeout(StdDuration::from_secs(2))
+            .expect("upload request");
+        let upload_lower = upload.to_ascii_lowercase();
+        assert!(upload.starts_with("POST /v1/files HTTP/1.1"));
+        assert!(upload_lower.contains("authorization: bearer test-token"));
+        assert!(upload.contains("name=\"path\""));
+        assert!(upload.contains("/reports/note.md"));
+        assert!(upload.contains("name=\"scope\""));
+        assert!(upload.contains("PROJECT"));
+        assert!(upload.contains("hello retain"));
+
+        let ingest = rx
+            .recv_timeout(StdDuration::from_secs(2))
+            .expect("ingest request");
+        assert!(ingest.starts_with("POST /v1/files/file-1/ingest HTTP/1.1"));
+        assert!(ingest.contains("\"user_id\":\"user-1\""));
+        assert!(ingest.contains("\"agent_id\":\"agent-1\""));
+    }
+
+    #[test]
+    fn retaindb_list_read_and_delete_files_use_expected_routes() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let (base, rx) = retain_server(vec![
+            (200, "application/json", r#"{"files":[]}"#),
+            (
+                200,
+                "application/json",
+                r#"{"file":{"id":"file-1","rdb_uri":"rdb://file-1","name":"note.md","mime_type":"text/markdown"}}"#,
+            ),
+            (200, "text/plain", "body text"),
+            (200, "application/json", r#"{"deleted":true}"#),
+        ]);
+        let st = state_for(base, tmp.path().join("retaindb_queue.db"));
+
+        let listed = tool_dispatch(
+            &st,
+            "retaindb_list_files",
+            &json!({"prefix": "/reports", "limit": 999}),
+        )
+        .expect("list");
+        assert_eq!(listed["files"], json!([]));
+        let list_req = rx
+            .recv_timeout(StdDuration::from_secs(2))
+            .expect("list req");
+        assert!(list_req.starts_with("GET /v1/files?limit=200&prefix=%2Freports HTTP/1.1"));
+
+        let read =
+            tool_dispatch(&st, "retaindb_read_file", &json!({"file_id": "file-1"})).expect("read");
+        assert_eq!(read["content"], "body text");
+        assert_eq!(read["truncated"], false);
+        let meta_req = rx
+            .recv_timeout(StdDuration::from_secs(2))
+            .expect("meta req");
+        assert!(meta_req.starts_with("GET /v1/files/file-1 HTTP/1.1"));
+        let content_req = rx
+            .recv_timeout(StdDuration::from_secs(2))
+            .expect("content req");
+        assert!(content_req.starts_with("GET /v1/files/file-1/content HTTP/1.1"));
+
+        let deleted = tool_dispatch(&st, "retaindb_delete_file", &json!({"file_id": "file-1"}))
+            .expect("delete");
+        assert_eq!(deleted["deleted"], true);
+        let delete_req = rx
+            .recv_timeout(StdDuration::from_secs(2))
+            .expect("delete req");
+        assert!(delete_req.starts_with("DELETE /v1/files/file-1 HTTP/1.1"));
+    }
+
+    #[test]
+    fn retaindb_durable_queue_flush_deletes_successful_rows() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let (base, rx) = retain_server(vec![(200, "application/json", r#"{"ok":true}"#)]);
+        let st = state_for(base, tmp.path().join("retaindb_queue.db"));
+        let payload = json!({
+            "session_id": "session-2",
+            "user_id": "user-1",
+            "messages": [{"role":"user","content":"hi"}],
+        });
+        let row_id = enqueue_retaindb_turn(&st.queue_db_path, &payload).expect("row");
+
+        flush_retaindb_queue_row(&st, row_id, payload).expect("flush");
+
+        let req = rx.recv_timeout(StdDuration::from_secs(2)).expect("request");
+        assert!(req.starts_with("POST /v1/memory/ingest/session HTTP/1.1"));
+        assert!(req.contains("\"project\":\"proj\""));
+        assert!(req.contains("\"session_id\":\"session-2\""));
+        assert!(pending_retaindb_rows(&st.queue_db_path)
+            .expect("pending rows")
+            .is_empty());
+    }
+
+    #[test]
+    fn retaindb_prefetch_helpers_render_synthesis_and_self_model() {
+        assert_eq!(reasoning_level_for_query("short"), "low");
+        assert_eq!(reasoning_level_for_query(&"x".repeat(200)), "medium");
+        assert_eq!(reasoning_level_for_query(&"x".repeat(500)), "high");
+
+        let rendered = retaindb_agent_self_model_from_value(&json!({
+            "memory_count": 3,
+            "persona": "direct",
+            "persistent_instructions": ["verify evidence"],
+            "working_style": "surgical"
+        }));
+        assert!(rendered.contains("[RetainDB Agent Self-Model]"));
+        assert!(rendered.contains("Persona: direct"));
+        assert!(rendered.contains("- verify evidence"));
     }
 }

--- a/crates/hermes-auth/src/lib.rs
+++ b/crates/hermes-auth/src/lib.rs
@@ -11,6 +11,7 @@ use chrono::{DateTime, Duration, Utc};
 use hermes_core::AgentError;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use tokio::io::AsyncWriteExt;
 use tokio::sync::RwLock;
 use url::{form_urlencoded, Url};
 
@@ -245,14 +246,41 @@ async fn write_file_private(path: &Path, content: &[u8]) -> Result<(), AgentErro
             .map_err(|e| AgentError::Io(e.to_string()))?;
     }
     let tmp_path = path.with_extension(format!("{}.tmp", uuid::Uuid::new_v4().simple()));
-    tokio::fs::write(&tmp_path, content)
-        .await
-        .map_err(|e| AgentError::Io(e.to_string()))?;
-    set_private_permissions(&tmp_path).await?;
-    tokio::fs::rename(&tmp_path, path)
-        .await
-        .map_err(|e| AgentError::Io(e.to_string()))?;
-    set_private_permissions(path).await
+
+    let result = async {
+        let mut file = private_create_new_options()
+            .open(&tmp_path)
+            .await
+            .map_err(|e| AgentError::Io(e.to_string()))?;
+        file.write_all(content)
+            .await
+            .map_err(|e| AgentError::Io(e.to_string()))?;
+        file.sync_all()
+            .await
+            .map_err(|e| AgentError::Io(e.to_string()))?;
+        drop(file);
+        set_private_permissions(&tmp_path).await?;
+        tokio::fs::rename(&tmp_path, path)
+            .await
+            .map_err(|e| AgentError::Io(e.to_string()))?;
+        set_private_permissions(path).await
+    }
+    .await;
+
+    if result.is_err() {
+        let _ = tokio::fs::remove_file(&tmp_path).await;
+    }
+    result
+}
+
+fn private_create_new_options() -> tokio::fs::OpenOptions {
+    let mut options = tokio::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        options.mode(0o600);
+    }
+    options
 }
 
 async fn set_private_permissions(path: &Path) -> Result<(), AgentError> {
@@ -594,6 +622,25 @@ mod tests {
         let reopened = FileTokenStore::new(&path).await.unwrap();
         let got = reopened.get("openai").await.unwrap();
         assert_eq!(got.access_token, "super-secret-token");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn private_create_new_options_creates_owner_only_temp_before_write() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("tokens.json.tmp");
+
+        let mut file = private_create_new_options().open(&path).await.unwrap();
+        let mode = tokio::fs::metadata(&path)
+            .await
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
+        file.write_all(b"secret").await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/hermes-cli/src/cli.rs
+++ b/crates/hermes-cli/src/cli.rs
@@ -670,11 +670,23 @@ pub enum CliCommand {
     Memory {
         /// Action: setup/status/off/reset
         action: Option<String>,
-        /// Reset target (all|memory|user) for `memory reset`.
+        /// Provider for `memory setup` (e.g. mem0) or reset target (all|memory|user).
         target: Option<String>,
         /// Skip reset confirmation prompt.
         #[arg(short = 'y', long)]
         yes: bool,
+        /// Memory provider setup mode, currently used by Mem0: platform|selfhosted|oss.
+        #[arg(long)]
+        mode: Option<String>,
+        /// Self-hosted memory provider host, currently used by Mem0.
+        #[arg(long)]
+        host: Option<String>,
+        /// Memory provider API key, currently written to `$HERMES_HOME/.env` for Mem0.
+        #[arg(long = "api-key")]
+        api_key: Option<String>,
+        /// Show the provider setup plan without writing config or env files.
+        #[arg(long)]
+        dry_run: bool,
     },
 
     /// MCP server management.
@@ -701,12 +713,38 @@ pub enum CliCommand {
     Sessions {
         /// Action: list/export/delete/prune/optimize/repair/stats/rename/browse
         action: Option<String>,
+        /// Session ID/prefix for export/delete/rename, export output path, or day count for prune.
+        session: Option<String>,
         /// Session ID.
         #[arg(long)]
         id: Option<String>,
+        /// Session ID/prefix for export, matching upstream `sessions export --session-id`.
+        #[arg(long = "session-id")]
+        session_id: Option<String>,
         /// New name (for rename).
         #[arg(long)]
         name: Option<String>,
+        /// Export format: json, jsonl, md, markdown, or html.
+        #[arg(long)]
+        format: Option<String>,
+        /// Export a filtered view, currently `user-prompts`.
+        #[arg(long)]
+        only: Option<String>,
+        /// Export output path. Use `-` for stdout where supported.
+        #[arg(long)]
+        output: Option<String>,
+        /// Redact common secret fields and token-like strings in exported content.
+        #[arg(long)]
+        redact: bool,
+        /// Confirm destructive actions without prompting.
+        #[arg(long)]
+        yes: bool,
+        /// Restrict prune to sessions with this source marker.
+        #[arg(long)]
+        source: Option<String>,
+        /// Prune sessions older than N days.
+        #[arg(long = "older-than")]
+        older_than: Option<u64>,
     },
 
     /// Resume an interactive session from saved session state.

--- a/crates/hermes-cli/src/commands/command_cli_plugins_memory_mcp.rs
+++ b/crates/hermes-cli/src/commands/command_cli_plugins_memory_mcp.rs
@@ -597,7 +597,7 @@ include!("command_cli_plugins_memory_mcp/memory_setup.rs");
 pub async fn handle_cli_memory(
     action: Option<String>,
     target: Option<String>,
-    yes: bool,
+    options: MemorySetupCliOptions,
 ) -> Result<(), hermes_core::AgentError> {
     let hermes_home = hermes_config::hermes_home();
     let memories_dir = hermes_home.join("memories");
@@ -611,17 +611,27 @@ pub async fn handle_cli_memory(
             println!("{}", render_memory_backend_status(&hermes_home));
         }
         "setup" => {
-            if let Some(provider) = target
+            let provider = target
                 .as_deref()
                 .map(str::trim)
                 .filter(|provider| !provider.is_empty())
+                .or_else(|| options.has_mem0_specific_options().then_some("mem0"));
+            if let Some(provider) = provider
             {
-                let path = setup_memory_provider_target(provider, yes)?;
-                println!("Configured memory provider '{}'.", provider);
-                println!("  Config: {}", path.display());
-                println!(
-                    "Memory provider config is owner-only and activates on subsequent sessions."
-                );
+                let result = setup_memory_provider_target(provider, &options)?;
+                if result.dry_run {
+                    println!("Dry run complete; memory provider '{}' was not written.", provider);
+                    println!("  Config: {}", result.config_path.display());
+                } else {
+                    println!("Configured memory provider '{}'.", provider);
+                    println!("  Config: {}", result.config_path.display());
+                    if let Some(env_path) = result.env_path {
+                        println!("  Secret env: {}", env_path.display());
+                    }
+                    println!(
+                        "Memory provider config is owner-only and activates on subsequent sessions."
+                    );
+                }
                 return Ok(());
             }
             println!("Memory Provider Setup");
@@ -666,7 +676,7 @@ pub async fn handle_cli_memory(
             println!("Run `hermes memory setup` to re-enable.");
         }
         "reset" => {
-            if !yes {
+            if !options.yes {
                 return Err(hermes_core::AgentError::Config(
                     "memory reset requires confirmation flag: use `hermes memory reset [all|memory|user] -y`"
                         .into(),

--- a/crates/hermes-cli/src/commands/command_cli_plugins_memory_mcp/memory_setup.rs
+++ b/crates/hermes-cli/src/commands/command_cli_plugins_memory_mcp/memory_setup.rs
@@ -49,6 +49,161 @@ fn memory_setup_bool_value(raw: &str, default: bool) -> bool {
     }
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct MemorySetupCliOptions {
+    pub yes: bool,
+    pub mode: Option<String>,
+    pub host: Option<String>,
+    pub api_key: Option<String>,
+    pub dry_run: bool,
+}
+
+impl MemorySetupCliOptions {
+    pub fn yes_only(yes: bool) -> Self {
+        Self {
+            yes,
+            ..Self::default()
+        }
+    }
+
+    fn has_mem0_specific_options(&self) -> bool {
+        self.mode
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty())
+            || self
+                .host
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+            || self
+                .api_key
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+            || self.dry_run
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MemorySetupResult {
+    config_path: PathBuf,
+    env_path: Option<PathBuf>,
+    dry_run: bool,
+}
+
+impl MemorySetupResult {
+    fn config_only(config_path: PathBuf) -> Self {
+        Self {
+            config_path,
+            env_path: None,
+            dry_run: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Mem0SetupMode {
+    Platform,
+    SelfHosted,
+    Oss,
+}
+
+impl Mem0SetupMode {
+    fn config_mode(self) -> &'static str {
+        match self {
+            Self::Platform => "platform",
+            Self::SelfHosted | Self::Oss => "oss",
+        }
+    }
+
+    fn prompt_default(self) -> &'static str {
+        match self {
+            Self::Platform => "platform",
+            Self::SelfHosted => "selfhosted",
+            Self::Oss => "oss",
+        }
+    }
+
+    fn requires_cloud_key(self) -> bool {
+        matches!(self, Self::Platform)
+    }
+
+    fn uses_host(self) -> bool {
+        matches!(self, Self::SelfHosted | Self::Oss)
+    }
+}
+
+fn normalize_mem0_setup_mode(raw: &str) -> Option<Mem0SetupMode> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "" => None,
+        "platform" | "cloud" | "mem0" => Some(Mem0SetupMode::Platform),
+        "selfhosted" | "self-hosted" | "self_hosted" | "selfhost" | "self-host" | "local" => {
+            Some(Mem0SetupMode::SelfHosted)
+        }
+        "oss" | "open-source" | "open_source" | "opensource" => Some(Mem0SetupMode::Oss),
+        _ => None,
+    }
+}
+
+fn mem0_url_is_cloud(base_url: &str) -> bool {
+    const MEM0_CLOUD_BASE_URL: &str = "https://api.mem0.ai/v1";
+    let normalized = base_url.trim().trim_end_matches('/');
+    normalized.eq_ignore_ascii_case(MEM0_CLOUD_BASE_URL)
+        || normalized.eq_ignore_ascii_case("https://api.mem0.ai")
+}
+
+fn default_mem0_setup_mode(base_url_default: &str) -> Mem0SetupMode {
+    std::env::var("MEM0_MODE")
+        .ok()
+        .and_then(|value| normalize_mem0_setup_mode(&value))
+        .unwrap_or_else(|| {
+            if mem0_url_is_cloud(base_url_default) {
+                Mem0SetupMode::Platform
+            } else {
+                Mem0SetupMode::SelfHosted
+            }
+        })
+}
+
+fn mem0_setup_reachability_timeout() -> Duration {
+    let ms = std::env::var("HERMES_MEM0_SETUP_REACHABILITY_TIMEOUT_MS")
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .unwrap_or(750);
+    Duration::from_millis(ms.min(5_000))
+}
+
+fn probe_mem0_self_hosted_reachability(base_url: &str, api_key: &str) -> Result<(), String> {
+    let timeout = mem0_setup_reachability_timeout();
+    if timeout.is_zero() {
+        return Ok(());
+    }
+    let root = base_url.trim().trim_end_matches('/');
+    if root.is_empty() {
+        return Err("empty host".to_string());
+    }
+    let client = reqwest::blocking::Client::builder()
+        .timeout(timeout)
+        .build()
+        .map_err(|e| e.to_string())?;
+    for path in ["/health", "/v1/health", "/"] {
+        let url = format!("{root}{path}");
+        let mut request = client.get(&url);
+        if !api_key.trim().is_empty() {
+            request = request.bearer_auth(api_key.trim());
+        }
+        match request.send() {
+            Ok(response) => {
+                if response.status().is_server_error() {
+                    return Err(format!("{} returned {}", url, response.status()));
+                }
+                return Ok(());
+            }
+            Err(last_error) if path == "/" => return Err(last_error.to_string()),
+            Err(_) => continue,
+        }
+    }
+    Ok(())
+}
+
 fn active_honcho_host_key_for_cli() -> String {
     if let Ok(explicit) = std::env::var("HERMES_HONCHO_HOST") {
         let explicit = explicit.trim();
@@ -248,38 +403,130 @@ fn build_honcho_setup_config(input: HonchoSetupConfigInput<'_>) -> serde_json::V
     serde_json::Value::Object(root)
 }
 
-fn setup_mem0_provider(yes: bool) -> Result<PathBuf, AgentError> {
+fn setup_mem0_provider(options: &MemorySetupCliOptions) -> Result<MemorySetupResult, AgentError> {
+    const MEM0_CLOUD_BASE_URL: &str = "https://api.mem0.ai/v1";
+
     let api_key_default = std::env::var("MEM0_API_KEY").unwrap_or_default();
     let user_id_default =
         std::env::var("MEM0_USER_ID").unwrap_or_else(|_| "hermes-user".to_string());
     let agent_id_default = std::env::var("MEM0_AGENT_ID").unwrap_or_else(|_| "hermes".to_string());
-    let base_url_default =
-        std::env::var("MEM0_BASE_URL").unwrap_or_else(|_| "https://api.mem0.ai/v1".to_string());
+    let base_url_default = options
+        .host
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+        .or_else(|| std::env::var("MEM0_HOST").ok())
+        .or_else(|| std::env::var("MEM0_BASE_URL").ok())
+        .unwrap_or_else(|| MEM0_CLOUD_BASE_URL.to_string());
+    let default_mode = options
+        .mode
+        .as_deref()
+        .and_then(normalize_mem0_setup_mode)
+        .unwrap_or_else(|| default_mem0_setup_mode(&base_url_default));
+    let mode_input = if let Some(mode) = options.mode.clone() {
+        mode
+    } else {
+        prompt_memory_setup_value(
+            "Mem0 mode (platform|selfhosted|oss)",
+            Some(default_mode.prompt_default()),
+            options.yes,
+        )?
+    };
+    let mode = normalize_mem0_setup_mode(&mode_input).ok_or_else(|| {
+        AgentError::Config(
+            "Mem0 setup mode must be one of: platform, selfhosted, oss.".into(),
+        )
+    })?;
 
-    let api_key = prompt_memory_setup_value("Mem0 API key", Some(&api_key_default), yes)?;
-    if api_key.trim().is_empty() {
+    let api_key_default = options
+        .api_key
+        .as_deref()
+        .unwrap_or(&api_key_default)
+        .to_string();
+    let api_label = if mode.requires_cloud_key() {
+        "Mem0 API key"
+    } else {
+        "Mem0 self-hosted API key (blank for no-auth server)"
+    };
+    let api_key = prompt_memory_setup_value(api_label, Some(&api_key_default), options.yes)?;
+    let user_id = prompt_memory_setup_value("Mem0 user_id", Some(&user_id_default), options.yes)?;
+    let agent_id =
+        prompt_memory_setup_value("Mem0 agent_id", Some(&agent_id_default), options.yes)?;
+    let base_url = if mode.uses_host() {
+        prompt_memory_setup_value("Mem0 self-hosted host", Some(&base_url_default), options.yes)?
+    } else {
+        prompt_memory_setup_value("Mem0 base_url", Some(MEM0_CLOUD_BASE_URL), options.yes)?
+    };
+    let base_url = base_url.trim().trim_end_matches('/').to_string();
+    if mode.requires_cloud_key() && api_key.trim().is_empty() {
         return Err(AgentError::Config(
             "Mem0 setup requires MEM0_API_KEY or an API key entered at the prompt.".into(),
         ));
     }
-    let user_id = prompt_memory_setup_value("Mem0 user_id", Some(&user_id_default), yes)?;
-    let agent_id = prompt_memory_setup_value("Mem0 agent_id", Some(&agent_id_default), yes)?;
-    let base_url = prompt_memory_setup_value("Mem0 base_url", Some(&base_url_default), yes)?;
+    if mode.uses_host() && base_url.trim().is_empty() {
+        return Err(AgentError::Config(
+            "Mem0 self-hosted setup requires --host or MEM0_HOST.".into(),
+        ));
+    }
 
     let config = serde_json::json!({
-        "api_key": api_key,
+        "mode": mode.config_mode(),
+        "api_key": "",
+        "host": if mode.uses_host() { base_url.as_str() } else { "" },
         "user_id": user_id,
         "agent_id": agent_id,
         "base_url": base_url,
-        "rerank": true
+        "rerank": false
     });
+    let config_path = hermes_config::hermes_home().join("mem0.json");
+    if options.dry_run {
+        println!(
+            "Dry run: would configure Mem0 mode={} host={} config={}",
+            mode.prompt_default(),
+            config
+                .get("base_url")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or(""),
+            config_path.display()
+        );
+        if !api_key.trim().is_empty() {
+            println!(
+                "Dry run: would write MEM0_API_KEY to {}",
+                hermes_config::hermes_home().join(".env").display()
+            );
+        }
+        return Ok(MemorySetupResult {
+            config_path,
+            env_path: None,
+            dry_run: true,
+        });
+    }
+
     hermes_agent::memory_plugins::mem0::Mem0MemoryPlugin::new()
         .save_config(&config)
         .map_err(AgentError::Config)?;
-    Ok(hermes_config::hermes_home().join("mem0.json"))
+    let env_path = if !api_key.trim().is_empty() {
+        let result = set_user_config_value(&hermes_config::hermes_home(), "MEM0_API_KEY", &api_key)
+            .map_err(|e| AgentError::Config(e.to_string()))?;
+        result.env_path
+    } else {
+        None
+    };
+    if mode.uses_host() {
+        match probe_mem0_self_hosted_reachability(&base_url, &api_key) {
+            Ok(()) => println!("Mem0 self-hosted reachability check passed."),
+            Err(error) => println!("Mem0 self-hosted reachability check warning: {error}"),
+        }
+    }
+    Ok(MemorySetupResult {
+        config_path,
+        env_path,
+        dry_run: false,
+    })
 }
 
-fn setup_supermemory_provider(yes: bool) -> Result<PathBuf, AgentError> {
+fn setup_supermemory_provider(yes: bool) -> Result<MemorySetupResult, AgentError> {
     const API_KEY_URL: &str = "https://app.supermemory.ai/integrations?connect=hermes";
 
     let api_key_default = std::env::var("SUPERMEMORY_API_KEY").unwrap_or_default();
@@ -331,10 +578,12 @@ fn setup_supermemory_provider(yes: bool) -> Result<PathBuf, AgentError> {
         if auto_recall { "on" } else { "off" },
         if auto_capture { "on" } else { "off" }
     );
-    Ok(hermes_config::hermes_home().join("supermemory.json"))
+    Ok(MemorySetupResult::config_only(
+        hermes_config::hermes_home().join("supermemory.json"),
+    ))
 }
 
-fn setup_byterover_provider(yes: bool) -> Result<PathBuf, AgentError> {
+fn setup_byterover_provider(yes: bool) -> Result<MemorySetupResult, AgentError> {
     let api_key_default = std::env::var("BRV_API_KEY").unwrap_or_default();
     let api_key = prompt_memory_setup_value("ByteRover API key", Some(&api_key_default), yes)?;
     let auto_extract = memory_setup_bool_value(
@@ -349,10 +598,12 @@ fn setup_byterover_provider(yes: bool) -> Result<PathBuf, AgentError> {
     hermes_agent::memory_plugins::byterover::ByteRoverPlugin::new()
         .save_config(&config)
         .map_err(AgentError::Config)?;
-    Ok(hermes_config::hermes_home().join("byterover.json"))
+    Ok(MemorySetupResult::config_only(
+        hermes_config::hermes_home().join("byterover.json"),
+    ))
 }
 
-fn setup_honcho_provider(yes: bool) -> Result<PathBuf, AgentError> {
+fn setup_honcho_provider(yes: bool) -> Result<MemorySetupResult, AgentError> {
     let env_api_key = std::env::var("HONCHO_API_KEY").unwrap_or_default();
     let env_base_url = std::env::var("HONCHO_BASE_URL").unwrap_or_default();
     let default_deployment =
@@ -444,7 +695,9 @@ fn setup_honcho_provider(yes: bool) -> Result<PathBuf, AgentError> {
     hermes_agent::memory_plugins::honcho::HonchoMemoryPlugin::new()
         .save_config(&config)
         .map_err(AgentError::Config)?;
-    Ok(hermes_config::hermes_home().join("honcho.json"))
+    Ok(MemorySetupResult::config_only(
+        hermes_config::hermes_home().join("honcho.json"),
+    ))
 }
 
 fn normalize_openviking_setup_endpoint(raw: &str) -> String {
@@ -529,7 +782,7 @@ fn build_openviking_setup_config(
     }))
 }
 
-fn setup_openviking_provider(yes: bool) -> Result<PathBuf, AgentError> {
+fn setup_openviking_provider(yes: bool) -> Result<MemorySetupResult, AgentError> {
     let endpoint_default = std::env::var("OPENVIKING_ENDPOINT")
         .unwrap_or_else(|_| "http://127.0.0.1:1933".to_string());
     let endpoint = normalize_openviking_setup_endpoint(&prompt_memory_setup_value(
@@ -590,18 +843,157 @@ fn setup_openviking_provider(yes: bool) -> Result<PathBuf, AgentError> {
     hermes_agent::memory_plugins::openviking::OpenVikingMemoryPlugin::new()
         .save_config(&config)
         .map_err(AgentError::Config)?;
-    Ok(hermes_config::hermes_home().join("openviking.json"))
+    Ok(MemorySetupResult::config_only(
+        hermes_config::hermes_home().join("openviking.json"),
+    ))
 }
 
-fn setup_memory_provider_target(provider: &str, yes: bool) -> Result<PathBuf, AgentError> {
+fn setup_memory_provider_target(
+    provider: &str,
+    options: &MemorySetupCliOptions,
+) -> Result<MemorySetupResult, AgentError> {
     match provider.trim().to_ascii_lowercase().as_str() {
-        "byterover" | "brv" => setup_byterover_provider(yes),
-        "mem0" => setup_mem0_provider(yes),
-        "supermemory" | "sm" => setup_supermemory_provider(yes),
-        "honcho" => setup_honcho_provider(yes),
-        "openviking" | "ov" => setup_openviking_provider(yes),
+        "byterover" | "brv" => setup_byterover_provider(options.yes),
+        "mem0" => setup_mem0_provider(options),
+        "supermemory" | "sm" => setup_supermemory_provider(options.yes),
+        "honcho" => setup_honcho_provider(options.yes),
+        "openviking" | "ov" => setup_openviking_provider(options.yes),
         other => Err(AgentError::Config(format!(
             "Unsupported memory provider setup target '{other}'. Supported: byterover, honcho, mem0, openviking, supermemory"
         ))),
+    }
+}
+
+#[cfg(test)]
+mod mem0_setup_tests {
+    use super::*;
+    use serde_json::Value;
+    use std::sync::{Mutex, OnceLock};
+
+    static TEST_ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    fn env_test_lock() -> std::sync::MutexGuard<'static, ()> {
+        TEST_ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("env test lock")
+    }
+
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
+    #[test]
+    fn setup_mem0_accepts_self_hosted_host_without_cloud_api_key() {
+        let _guard = env_test_lock();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _home = EnvGuard::set("HERMES_HOME", tmp.path());
+        let _api = EnvGuard::remove("MEM0_API_KEY");
+        let _base = EnvGuard::remove("MEM0_BASE_URL");
+        let _host = EnvGuard::set("MEM0_HOST", "http://127.0.0.1:24220");
+        let _reachability = EnvGuard::set("HERMES_MEM0_SETUP_REACHABILITY_TIMEOUT_MS", "0");
+
+        let path = setup_mem0_provider(&MemorySetupCliOptions::yes_only(true))
+            .expect("setup mem0")
+            .config_path;
+        let value: Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).expect("read mem0 config"))
+                .expect("parse mem0 config");
+
+        assert_eq!(value["mode"], "oss");
+        assert_eq!(value["base_url"], "http://127.0.0.1:24220");
+        assert_eq!(value["api_key"], "");
+        assert_eq!(value["rerank"], false);
+    }
+
+    #[test]
+    fn setup_mem0_selfhosted_flags_write_host_config_and_secret_env() {
+        let _guard = env_test_lock();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _home = EnvGuard::set("HERMES_HOME", tmp.path());
+        let _api = EnvGuard::remove("MEM0_API_KEY");
+        let _host_env = EnvGuard::remove("MEM0_HOST");
+        let _base = EnvGuard::remove("MEM0_BASE_URL");
+        let _reachability = EnvGuard::set("HERMES_MEM0_SETUP_REACHABILITY_TIMEOUT_MS", "0");
+
+        let result = setup_mem0_provider(&MemorySetupCliOptions {
+            yes: true,
+            mode: Some("selfhosted".to_string()),
+            host: Some("http://127.0.0.1:24220/".to_string()),
+            api_key: Some("local-secret".to_string()),
+            dry_run: false,
+        })
+        .expect("setup mem0");
+        let value: Value = serde_json::from_str(
+            &std::fs::read_to_string(&result.config_path).expect("read mem0 config"),
+        )
+        .expect("parse mem0 config");
+        let env_text =
+            std::fs::read_to_string(result.env_path.expect("env path")).expect("read env");
+
+        assert_eq!(value["mode"], "oss");
+        assert_eq!(value["host"], "http://127.0.0.1:24220");
+        assert_eq!(value["base_url"], "http://127.0.0.1:24220");
+        assert_eq!(value["api_key"], "");
+        assert!(env_text.contains("MEM0_API_KEY=local-secret"));
+    }
+
+    #[test]
+    fn setup_mem0_dry_run_does_not_write_config_or_secret() {
+        let _guard = env_test_lock();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _home = EnvGuard::set("HERMES_HOME", tmp.path());
+        let _api = EnvGuard::remove("MEM0_API_KEY");
+        let _host_env = EnvGuard::remove("MEM0_HOST");
+        let _base = EnvGuard::remove("MEM0_BASE_URL");
+
+        let result = setup_mem0_provider(&MemorySetupCliOptions {
+            yes: true,
+            mode: Some("selfhosted".to_string()),
+            host: Some("http://127.0.0.1:24220".to_string()),
+            api_key: Some("local-secret".to_string()),
+            dry_run: true,
+        })
+        .expect("dry-run mem0 setup");
+
+        assert!(result.dry_run);
+        assert!(!result.config_path.exists());
+        assert!(!tmp.path().join(".env").exists());
+    }
+
+    #[test]
+    fn mem0_setup_mode_accepts_upstream_selfhosted_spelling() {
+        assert_eq!(
+            normalize_mem0_setup_mode("selfhosted"),
+            Some(Mem0SetupMode::SelfHosted)
+        );
+        assert_eq!(
+            normalize_mem0_setup_mode("self-hosted"),
+            Some(Mem0SetupMode::SelfHosted)
+        );
     }
 }

--- a/crates/hermes-cli/src/commands/command_cli_sessions_acp.rs
+++ b/crates/hermes-cli/src/commands/command_cli_sessions_acp.rs
@@ -1,19 +1,906 @@
 const CLI_SESSIONS_ACTIONS: &str =
     "list, export, delete, prune, optimize, repair, stats, rename, browse";
 
+pub struct CliSessionsOptions {
+    pub action: Option<String>,
+    pub session: Option<String>,
+    pub id: Option<String>,
+    pub session_id: Option<String>,
+    pub name: Option<String>,
+    pub format: Option<String>,
+    pub only: Option<String>,
+    pub output: Option<String>,
+    pub redact: bool,
+    pub yes: bool,
+    pub source: Option<String>,
+    pub older_than: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+struct SessionSnapshotEntry {
+    id: String,
+    path: PathBuf,
+    modified: SystemTime,
+    source: Option<String>,
+}
+
 fn file_size_mb(path: &Path) -> f64 {
     std::fs::metadata(path)
         .map(|meta| meta.len() as f64 / (1024.0 * 1024.0))
         .unwrap_or(0.0)
 }
 
+fn session_subject(session: Option<String>, id: Option<String>) -> Option<String> {
+    id.or(session)
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn read_session_snapshot_source(path: &Path) -> Option<String> {
+    let text = std::fs::read_to_string(path).ok()?;
+    let value = serde_json::from_str::<serde_json::Value>(&text).ok()?;
+    value
+        .get("source")
+        .or_else(|| value.pointer("/session_info/source"))
+        .or_else(|| value.pointer("/metadata/source"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|source| !source.is_empty())
+        .map(ToString::to_string)
+}
+
+fn list_session_snapshot_entries(
+    sessions_dir: &Path,
+) -> Result<Vec<SessionSnapshotEntry>, hermes_core::AgentError> {
+    if !sessions_dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut entries = Vec::new();
+    let rd = std::fs::read_dir(sessions_dir).map_err(|e| {
+        hermes_core::AgentError::Io(format!(
+            "Failed to read sessions directory {}: {}",
+            sessions_dir.display(),
+            e
+        ))
+    })?;
+    for entry in rd.filter_map(Result::ok) {
+        let path = entry.path();
+        if !path.extension().map(|e| e == "json").unwrap_or(false) {
+            continue;
+        }
+        let Some(id) = path.file_stem().map(|s| s.to_string_lossy().into_owned()) else {
+            continue;
+        };
+        let modified = std::fs::metadata(&path)
+            .and_then(|meta| meta.modified())
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+        entries.push(SessionSnapshotEntry {
+            id,
+            source: read_session_snapshot_source(&path),
+            path,
+            modified,
+        });
+    }
+    Ok(entries)
+}
+
+fn resolve_unique_session_snapshot(
+    sessions_dir: &Path,
+    query: &str,
+) -> Result<Option<SessionSnapshotEntry>, hermes_core::AgentError> {
+    let query = query.trim();
+    if query.is_empty() {
+        return Ok(None);
+    }
+    let entries = list_session_snapshot_entries(sessions_dir)?;
+    if let Some(exact) = entries
+        .iter()
+        .find(|entry| entry.id.eq_ignore_ascii_case(query))
+        .cloned()
+    {
+        return Ok(Some(exact));
+    }
+
+    let matches: Vec<_> = entries
+        .into_iter()
+        .filter(|entry| entry.id.starts_with(query))
+        .collect();
+    match matches.len() {
+        0 => Ok(None),
+        1 => Ok(matches.into_iter().next()),
+        _ => Err(hermes_core::AgentError::Config(format!(
+            "Session prefix '{}' is ambiguous ({} matches).",
+            query,
+            matches.len()
+        ))),
+    }
+}
+
+fn delete_session_snapshot_by_query(
+    sessions_dir: &Path,
+    query: &str,
+) -> Result<Option<String>, hermes_core::AgentError> {
+    let Some(entry) = resolve_unique_session_snapshot(sessions_dir, query)? else {
+        return Ok(None);
+    };
+    std::fs::remove_file(&entry.path).map_err(|e| {
+        hermes_core::AgentError::Io(format!(
+            "Failed to delete session snapshot {}: {}",
+            entry.path.display(),
+            e
+        ))
+    })?;
+    Ok(Some(entry.id))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SessionExportFormat {
+    Json,
+    Jsonl,
+    Markdown,
+    Html,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SessionExportOnly {
+    UserPrompts,
+}
+
+#[derive(Debug, Clone)]
+struct SessionExportSnapshot {
+    id: String,
+    data: serde_json::Value,
+}
+
+fn normalize_session_export_format(
+    format: Option<&str>,
+) -> Result<SessionExportFormat, hermes_core::AgentError> {
+    match format
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("json")
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "json" => Ok(SessionExportFormat::Json),
+        "jsonl" => Ok(SessionExportFormat::Jsonl),
+        "md" | "markdown" => Ok(SessionExportFormat::Markdown),
+        "html" => Ok(SessionExportFormat::Html),
+        other => Err(hermes_core::AgentError::Config(format!(
+            "Unsupported sessions export format '{}'. Expected json, jsonl, md, markdown, or html.",
+            other
+        ))),
+    }
+}
+
+fn normalize_session_export_only(
+    only: Option<&str>,
+) -> Result<Option<SessionExportOnly>, hermes_core::AgentError> {
+    let Some(value) = only.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(None);
+    };
+    match value.to_ascii_lowercase().as_str() {
+        "user" | "prompts" | "user-prompts" | "user_prompts" => {
+            Ok(Some(SessionExportOnly::UserPrompts))
+        }
+        other => Err(hermes_core::AgentError::Config(format!(
+            "Unsupported sessions export filter '{}'. Expected user-prompts.",
+            other
+        ))),
+    }
+}
+
+fn session_export_positional_looks_like_output(value: &str) -> bool {
+    let trimmed = value.trim();
+    trimmed == "-"
+        || trimmed.contains('/')
+        || trimmed.ends_with(".json")
+        || trimmed.ends_with(".jsonl")
+        || trimmed.ends_with(".md")
+        || trimmed.ends_with(".markdown")
+        || trimmed.ends_with(".html")
+        || trimmed.ends_with(".htm")
+}
+
+fn session_export_id_from_data(entry_id: &str, data: &serde_json::Value) -> String {
+    data.get("id")
+        .or_else(|| data.get("session_id"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(entry_id)
+        .to_string()
+}
+
+fn read_session_export_snapshot(
+    entry: &SessionSnapshotEntry,
+    redact: bool,
+) -> Result<SessionExportSnapshot, hermes_core::AgentError> {
+    let content = std::fs::read_to_string(&entry.path).map_err(|e| {
+        hermes_core::AgentError::Io(format!(
+            "Failed to read session snapshot {}: {}",
+            entry.path.display(),
+            e
+        ))
+    })?;
+    let mut data = serde_json::from_str::<serde_json::Value>(&content).map_err(|e| {
+        hermes_core::AgentError::Io(format!(
+            "Failed to parse session snapshot {}: {}",
+            entry.path.display(),
+            e
+        ))
+    })?;
+    if redact {
+        redact_session_export_value(&mut data, None);
+    }
+    let id = session_export_id_from_data(&entry.id, &data);
+    Ok(SessionExportSnapshot { id, data })
+}
+
+fn collect_session_export_snapshots(
+    sessions_dir: &Path,
+    subject: Option<&str>,
+    source: Option<&str>,
+    older_than_days: Option<u64>,
+    redact: bool,
+) -> Result<Vec<SessionExportSnapshot>, hermes_core::AgentError> {
+    let entries = if let Some(subject) = subject.map(str::trim).filter(|value| !value.is_empty()) {
+        match resolve_unique_session_snapshot(sessions_dir, subject)? {
+            Some(entry) => vec![entry],
+            None => return Ok(Vec::new()),
+        }
+    } else {
+        let mut entries = prune_session_snapshot_candidates(sessions_dir, source, older_than_days)?;
+        entries.sort_by(|a, b| b.modified.cmp(&a.modified).then_with(|| a.id.cmp(&b.id)));
+        entries
+    };
+    entries
+        .iter()
+        .map(|entry| read_session_export_snapshot(entry, redact))
+        .collect()
+}
+
+fn redact_session_export_value(value: &mut serde_json::Value, key: Option<&str>) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (child_key, child_value) in map.iter_mut() {
+                redact_session_export_value(child_value, Some(child_key));
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                redact_session_export_value(item, key);
+            }
+        }
+        serde_json::Value::String(text) => {
+            if key.is_some_and(session_export_key_is_secret) {
+                *text = "[REDACTED]".to_string();
+            } else {
+                *text = redact_session_export_text(text);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn session_export_key_is_secret(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    key.contains("api_key")
+        || key.contains("apikey")
+        || key.contains("authorization")
+        || key.contains("password")
+        || key.contains("secret")
+        || key.contains("token")
+        || key.ends_with("_key")
+}
+
+fn redact_session_export_text(text: &str) -> String {
+    let mut redacted = text.to_string();
+    for (pattern, replacement) in [
+        (r"sk-[A-Za-z0-9_-]{16,}", "sk-[REDACTED]"),
+        (r"Bearer\s+[A-Za-z0-9._~+/=-]{16,}", "Bearer [REDACTED]"),
+        (
+            r"(?i)(api[_-]?key|token|secret)\s*[:=]\s*[^\s,;]+",
+            "$1=[REDACTED]",
+        ),
+    ] {
+        if let Ok(regex) = Regex::new(pattern) {
+            redacted = regex.replace_all(&redacted, replacement).into_owned();
+        }
+    }
+    redacted
+}
+
+fn render_session_exports(
+    sessions: &[SessionExportSnapshot],
+    format: SessionExportFormat,
+    only: Option<SessionExportOnly>,
+) -> Result<String, hermes_core::AgentError> {
+    match (format, only) {
+        (SessionExportFormat::Json, None) => {
+            let result = if sessions.len() == 1 {
+                serde_json::to_string_pretty(&sessions[0].data)
+            } else {
+                serde_json::to_string_pretty(
+                    &sessions
+                        .iter()
+                        .map(|session| session.data.clone())
+                        .collect::<Vec<_>>(),
+                )
+            };
+            result
+                .map(|mut value| {
+                    value.push('\n');
+                    value
+                })
+                .map_err(|e| hermes_core::AgentError::Io(e.to_string()))
+        }
+        (SessionExportFormat::Jsonl, None) => render_sessions_jsonl(sessions, false),
+        (SessionExportFormat::Jsonl, Some(SessionExportOnly::UserPrompts)) => {
+            render_sessions_jsonl(sessions, true)
+        }
+        (SessionExportFormat::Markdown, None) => Ok(render_sessions_markdown(sessions, false)),
+        (SessionExportFormat::Markdown, Some(SessionExportOnly::UserPrompts)) => {
+            Ok(render_sessions_markdown(sessions, true))
+        }
+        (SessionExportFormat::Html, None) => Ok(render_sessions_html(sessions)),
+        (SessionExportFormat::Html, Some(SessionExportOnly::UserPrompts))
+        | (SessionExportFormat::Json, Some(SessionExportOnly::UserPrompts)) => {
+            Err(hermes_core::AgentError::Config(
+                "--only user-prompts supports --format jsonl or md.".into(),
+            ))
+        }
+    }
+}
+
+fn render_sessions_jsonl(
+    sessions: &[SessionExportSnapshot],
+    prompts_only: bool,
+) -> Result<String, hermes_core::AgentError> {
+    let mut lines = Vec::new();
+    if prompts_only {
+        for record in iter_user_prompt_records(sessions) {
+            lines.push(serde_json::to_string(&record).map_err(|e| {
+                hermes_core::AgentError::Io(format!("Failed to render prompt JSONL: {}", e))
+            })?);
+        }
+    } else {
+        for session in sessions {
+            lines.push(serde_json::to_string(&session.data).map_err(|e| {
+                hermes_core::AgentError::Io(format!("Failed to render session JSONL: {}", e))
+            })?);
+        }
+    }
+    Ok(if lines.is_empty() {
+        String::new()
+    } else {
+        format!("{}\n", lines.join("\n"))
+    })
+}
+
+fn iter_user_prompt_records(
+    sessions: &[SessionExportSnapshot],
+) -> Vec<serde_json::Map<String, serde_json::Value>> {
+    let mut records = Vec::new();
+    for session in sessions {
+        let mut index = 0usize;
+        for message in session_messages(&session.data) {
+            if message_role(message) != "user" {
+                continue;
+            }
+            index += 1;
+            let mut record = serde_json::Map::new();
+            record.insert("session_id".into(), serde_json::Value::String(session.id.clone()));
+            record.insert(
+                "index".into(),
+                serde_json::Value::Number(serde_json::Number::from(index as u64)),
+            );
+            record.insert("role".into(), serde_json::Value::String("user".into()));
+            record.insert(
+                "text".into(),
+                serde_json::Value::String(message_text(message.get("content"))),
+            );
+            if let Some(created_at) = message_timestamp(message) {
+                record.insert("created_at".into(), serde_json::Value::String(created_at));
+            }
+            if let Some(message_id) = message.get("id").cloned() {
+                record.insert("message_id".into(), message_id);
+            }
+            if let Some(event_id) = message
+                .get("platform_message_id")
+                .or_else(|| message.get("event_id"))
+                .and_then(serde_json::Value::as_str)
+                .filter(|value| !value.is_empty())
+            {
+                record.insert("event_id".into(), serde_json::Value::String(event_id.into()));
+            }
+            records.push(record);
+        }
+    }
+    records
+}
+
+fn render_sessions_markdown(sessions: &[SessionExportSnapshot], prompts_only: bool) -> String {
+    let mut lines = Vec::new();
+    if prompts_only {
+        if sessions.len() == 1 {
+            lines.push(format!("# User prompts for session {}", sessions[0].id));
+            append_session_metadata(&mut lines, &sessions[0]);
+            append_prompt_markdown(&mut lines, &sessions[0], 2);
+        } else {
+            lines.push("# User prompts export".into());
+            for session in sessions {
+                lines.push(String::new());
+                lines.push(format!("## Session {}", session.id));
+                append_session_metadata(&mut lines, session);
+                append_prompt_markdown(&mut lines, session, 3);
+            }
+        }
+    } else if sessions.len() == 1 {
+        lines.push(format!(
+            "# Session: {}",
+            markdown_heading_text(&session_title_or_id(&sessions[0]))
+        ));
+        append_session_metadata(&mut lines, &sessions[0]);
+        append_session_messages_markdown(&mut lines, &sessions[0], 2);
+    } else {
+        lines.push("# Hermes sessions export".into());
+        for session in sessions {
+            lines.push(String::new());
+            lines.push(format!(
+                "## Session: {}",
+                markdown_heading_text(&session_title_or_id(session))
+            ));
+            append_session_metadata(&mut lines, session);
+            append_session_messages_markdown(&mut lines, session, 3);
+        }
+    }
+    finish_session_markdown(lines)
+}
+
+fn append_session_metadata(lines: &mut Vec<String>, session: &SessionExportSnapshot) {
+    lines.push(format!("- Session ID: `{}`", session.id));
+    for key in ["source", "model", "title"] {
+        if let Some(value) = session
+            .data
+            .get(key)
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            lines.push(format!(
+                "- {}: {}",
+                title_case_ascii(key),
+                value.replace('\n', " ")
+            ));
+        }
+    }
+    if let Some(started) = session
+        .data
+        .get("started_at")
+        .or_else(|| session.data.get("created_at"))
+        .and_then(format_session_timestamp)
+    {
+        lines.push(format!("- Started: {}", started));
+    }
+    lines.push(String::new());
+}
+
+fn append_prompt_markdown(
+    lines: &mut Vec<String>,
+    session: &SessionExportSnapshot,
+    heading_level: usize,
+) {
+    let prompts = iter_user_prompt_records(std::slice::from_ref(session));
+    if prompts.is_empty() {
+        lines.push("_No user prompts found._".into());
+        return;
+    }
+    let marker = "#".repeat(heading_level);
+    for prompt in prompts {
+        let index = prompt
+            .get("index")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0);
+        let created_at = prompt
+            .get("created_at")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("timestamp unavailable");
+        lines.push(format!("{} {}. {}", marker, index, created_at));
+        if let Some(message_id) = prompt.get("message_id") {
+            lines.push(format!("Message ID: `{}`", json_scalar_text(message_id)));
+            lines.push(String::new());
+        }
+        lines.push(
+            prompt
+                .get("text")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("")
+                .to_string(),
+        );
+        lines.push(String::new());
+    }
+}
+
+fn append_session_messages_markdown(
+    lines: &mut Vec<String>,
+    session: &SessionExportSnapshot,
+    heading_level: usize,
+) {
+    let visible: Vec<_> = session_messages(&session.data)
+        .into_iter()
+        .filter(|message| message_role(message) != "system")
+        .collect();
+    if visible.is_empty() {
+        lines.push("_No messages found._".into());
+        return;
+    }
+    let marker = "#".repeat(heading_level);
+    for message in visible {
+        let role = message_role(message);
+        let label = match role.as_str() {
+            "user" => "User".to_string(),
+            "assistant" => "Assistant".to_string(),
+            "tool" => format!(
+                "Tool: {}",
+                message
+                    .get("tool_name")
+                    .or_else(|| message.get("name"))
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("tool")
+            ),
+            other => title_case_ascii(other),
+        };
+        let suffix = message_timestamp(message)
+            .map(|value| format!(" - {}", value))
+            .unwrap_or_default();
+        lines.push(format!("{} {}{}", marker, markdown_heading_text(&label), suffix));
+        lines.push(String::new());
+        if role == "tool" {
+            lines.push(fenced_session_text(&message_text(message.get("content"))));
+        } else {
+            lines.push(message_text(message.get("content")));
+        }
+        lines.push(String::new());
+    }
+}
+
+fn render_sessions_html(sessions: &[SessionExportSnapshot]) -> String {
+    let page_title = if sessions.len() == 1 {
+        format!("Hermes session {}", sessions[0].id)
+    } else {
+        format!("Hermes sessions export ({} sessions)", sessions.len())
+    };
+    let mut sidebar = String::new();
+    if sessions.len() > 1 {
+        sidebar.push_str("<nav class=\"sidebar\"><h2>Sessions</h2><ul>");
+        for session in sessions {
+            sidebar.push_str(&format!(
+                "<li><a href=\"#session-{id}\"><strong>{title}</strong><span>{id}</span></a></li>",
+                id = html_escape(&session.id),
+                title = html_escape(&session_title_or_id(session))
+            ));
+        }
+        sidebar.push_str("</ul></nav>");
+    }
+
+    let mut body = String::new();
+    for session in sessions {
+        body.push_str(&format!(
+            "<section class=\"session\" id=\"session-{id}\"><header><p class=\"eyebrow\">Hermes Ultra session export</p><h1>{title}</h1><p class=\"session-id\">{id}</p></header>",
+            id = html_escape(&session.id),
+            title = html_escape(&session_title_or_id(session))
+        ));
+        body.push_str("<div class=\"messages\">");
+        for message in session_messages(&session.data) {
+            let role = message_role(message);
+            if role == "session_meta" {
+                continue;
+            }
+            body.push_str(&format!(
+                "<article class=\"message message-{role}\"><div class=\"message-meta\"><span>{role}</span><time>{time}</time></div><pre>{content}</pre>",
+                role = html_escape(&role),
+                time = html_escape(
+                    &message_timestamp(message).unwrap_or_else(|| "timestamp unavailable".into())
+                ),
+                content = html_escape(&message_text(message.get("content"))),
+            ));
+            if let Some(tool_calls) = message
+                .get("tool_calls")
+                .and_then(serde_json::Value::as_array)
+            {
+                for tool_call in tool_calls {
+                    body.push_str("<details><summary>Tool call</summary><pre>");
+                    body.push_str(&html_escape(&json_scalar_text(tool_call)));
+                    body.push_str("</pre></details>");
+                }
+            }
+            if let Some(reasoning) = message
+                .get("reasoning")
+                .or_else(|| message.get("reasoning_content"))
+                .and_then(serde_json::Value::as_str)
+            {
+                body.push_str("<details><summary>Reasoning</summary><pre>");
+                body.push_str(&html_escape(reasoning));
+                body.push_str("</pre></details>");
+            }
+            body.push_str("</article>");
+        }
+        body.push_str("</div></section>");
+    }
+
+    format!(
+        r#"<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{}</title>
+<style>
+:root {{ color-scheme: light dark; --bg:#f8f4ec; --fg:#1d1912; --panel:#fffaf0; --muted:#756957; --border:#d9c6a3; --accent:#9a5a18; --tool:#ebf5ff; }}
+@media (prefers-color-scheme: dark) {{ :root {{ --bg:#11100d; --fg:#f7ecd7; --panel:#1e1a14; --muted:#c7bca7; --border:#5b4a31; --accent:#ffb84d; --tool:#132232; }} }}
+body {{ margin:0; background:radial-gradient(circle at top left, rgba(154,90,24,.18), transparent 36rem), var(--bg); color:var(--fg); font:16px/1.5 ui-serif, Georgia, serif; }}
+.layout {{ display:flex; min-height:100vh; }}
+.sidebar {{ width:18rem; padding:1.25rem; border-right:1px solid var(--border); background:color-mix(in srgb, var(--panel) 86%, transparent); position:sticky; top:0; height:100vh; overflow:auto; }}
+.sidebar ul {{ list-style:none; margin:0; padding:0; }}
+.sidebar a {{ color:var(--fg); display:block; padding:.7rem 0; text-decoration:none; border-bottom:1px solid var(--border); }}
+.sidebar span {{ color:var(--muted); display:block; font:12px ui-monospace, SFMono-Regular, Menlo, monospace; }}
+main {{ width:min(72rem, 100%); margin:0 auto; padding:3rem 1.25rem; }}
+.session {{ margin-bottom:4rem; }}
+.eyebrow {{ color:var(--accent); font:700 12px ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing:.1em; text-transform:uppercase; }}
+h1 {{ font-size:clamp(2rem, 5vw, 4rem); line-height:1; margin:.25rem 0; }}
+.session-id {{ color:var(--muted); font:13px ui-monospace, SFMono-Regular, Menlo, monospace; }}
+.message {{ background:var(--panel); border:1px solid var(--border); border-radius:18px; box-shadow:0 18px 50px rgba(0,0,0,.08); margin:1rem 0; padding:1rem; }}
+.message-user {{ border-left:5px solid var(--accent); }}
+.message-tool {{ background:var(--tool); }}
+.message-meta {{ display:flex; justify-content:space-between; gap:1rem; color:var(--muted); font:12px ui-monospace, SFMono-Regular, Menlo, monospace; text-transform:uppercase; }}
+pre {{ white-space:pre-wrap; word-break:break-word; font:13px/1.45 ui-monospace, SFMono-Regular, Menlo, monospace; }}
+details {{ margin-top:.75rem; }}
+@media (max-width: 860px) {{ .layout {{ display:block; }} .sidebar {{ position:relative; width:auto; height:auto; border-right:0; border-bottom:1px solid var(--border); }} main {{ padding-top:1.5rem; }} }}
+</style>
+</head>
+<body><div class="layout">{}<main>{}</main></div></body>
+</html>
+"#,
+        html_escape(&page_title),
+        sidebar,
+        body
+    )
+}
+
+fn session_messages(data: &serde_json::Value) -> Vec<&serde_json::Map<String, serde_json::Value>> {
+    data.get("messages")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(serde_json::Value::as_object)
+        .collect()
+}
+
+fn message_role(message: &serde_json::Map<String, serde_json::Value>) -> String {
+    message
+        .get("role")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("unknown")
+        .to_ascii_lowercase()
+}
+
+fn message_text(content: Option<&serde_json::Value>) -> String {
+    match content {
+        None | Some(serde_json::Value::Null) => String::new(),
+        Some(serde_json::Value::String(text)) => text.clone(),
+        Some(serde_json::Value::Array(items)) => items
+            .iter()
+            .map(|item| message_text(Some(item)))
+            .filter(|text| !text.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n"),
+        Some(serde_json::Value::Object(map)) => map
+            .get("text")
+            .or_else(|| map.get("content"))
+            .and_then(serde_json::Value::as_str)
+            .map(ToString::to_string)
+            .unwrap_or_else(|| content.map(json_scalar_text).unwrap_or_default()),
+        Some(other) => json_scalar_text(other),
+    }
+}
+
+fn message_timestamp(message: &serde_json::Map<String, serde_json::Value>) -> Option<String> {
+    message
+        .get("timestamp")
+        .or_else(|| message.get("created_at"))
+        .and_then(format_session_timestamp)
+}
+
+fn format_session_timestamp(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::Number(number) => number.as_f64().and_then(|secs| {
+            chrono::DateTime::<chrono::Utc>::from_timestamp(secs as i64, 0)
+                .map(|dt| dt.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
+        }),
+        serde_json::Value::String(text) => {
+            let text = text.trim();
+            (!text.is_empty()).then(|| text.to_string())
+        }
+        _ => None,
+    }
+}
+
+fn session_title_or_id(session: &SessionExportSnapshot) -> String {
+    session
+        .data
+        .get("title")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(&session.id)
+        .to_string()
+}
+
+fn title_case_ascii(value: &str) -> String {
+    let mut chars = value.chars();
+    match chars.next() {
+        Some(first) => first.to_ascii_uppercase().to_string() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
+fn markdown_heading_text(value: &str) -> String {
+    value
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn fenced_session_text(text: &str) -> String {
+    let mut fence = "```".to_string();
+    while text.contains(&fence) {
+        fence.push('`');
+    }
+    format!("{}text\n{}\n{}", fence, text, fence)
+}
+
+fn finish_session_markdown(mut lines: Vec<String>) -> String {
+    while matches!(lines.last(), Some(line) if line.is_empty()) {
+        lines.pop();
+    }
+    format!("{}\n", lines.join("\n"))
+}
+
+fn json_scalar_text(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(text) => text.clone(),
+        other => serde_json::to_string(other).unwrap_or_else(|_| String::new()),
+    }
+}
+
+fn html_escape(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+}
+
+fn write_session_export_output(
+    output: Option<&str>,
+    rendered: &str,
+) -> Result<(), hermes_core::AgentError> {
+    match output.map(str::trim).filter(|value| !value.is_empty()) {
+        None | Some("-") => {
+            print!("{}", rendered);
+            Ok(())
+        }
+        Some(path) => std::fs::write(path, rendered)
+            .map_err(|e| hermes_core::AgentError::Io(format!("Failed to write {}: {}", path, e))),
+    }
+}
+
+fn session_confirm_response_is_yes(input: Option<&str>) -> bool {
+    matches!(
+        input.map(|value| value.trim().to_ascii_lowercase()),
+        Some(value) if matches!(value.as_str(), "y" | "yes")
+    )
+}
+
+fn prompt_session_confirmation(prompt: &str, yes: bool) -> bool {
+    if yes {
+        return true;
+    }
+    print!("{} [y/N]: ", prompt);
+    let _ = std::io::stdout().flush();
+    let mut input = String::new();
+    match std::io::stdin().read_line(&mut input) {
+        Ok(0) | Err(_) => false,
+        Ok(_) => session_confirm_response_is_yes(Some(input.as_str())),
+    }
+}
+
+fn prune_cutoff_for_sessions(
+    source: Option<&str>,
+    older_than: Option<u64>,
+    legacy_days: Option<&str>,
+) -> Option<u64> {
+    let explicit = older_than.or_else(|| legacy_days.and_then(|value| value.parse::<u64>().ok()));
+    explicit.or_else(|| source.is_none().then_some(90))
+}
+
+fn prune_session_snapshot_candidates(
+    sessions_dir: &Path,
+    source: Option<&str>,
+    older_than_days: Option<u64>,
+) -> Result<Vec<SessionSnapshotEntry>, hermes_core::AgentError> {
+    let source = source.map(str::trim).filter(|value| !value.is_empty());
+    let cutoff = older_than_days.and_then(|days| {
+        SystemTime::now().checked_sub(Duration::from_secs(days.saturating_mul(86_400)))
+    });
+    let candidates = list_session_snapshot_entries(sessions_dir)?
+        .into_iter()
+        .filter(|entry| {
+            source.is_none_or(|expected| {
+                entry
+                    .source
+                    .as_deref()
+                    .is_some_and(|actual| actual.eq_ignore_ascii_case(expected))
+            })
+        })
+        .filter(|entry| cutoff.is_none_or(|cutoff| entry.modified < cutoff))
+        .collect();
+    Ok(candidates)
+}
+
+fn session_time_epoch_seconds(time: SystemTime) -> u64 {
+    time.duration_since(SystemTime::UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
+fn render_prune_preview(candidates: &[SessionSnapshotEntry]) -> String {
+    if candidates.is_empty() {
+        return "0 session(s) match.".to_string();
+    }
+    let oldest = candidates
+        .iter()
+        .map(|entry| entry.modified)
+        .min()
+        .unwrap_or(SystemTime::UNIX_EPOCH);
+    let newest = candidates
+        .iter()
+        .map(|entry| entry.modified)
+        .max()
+        .unwrap_or(SystemTime::UNIX_EPOCH);
+    format!(
+        "{} session(s) match (oldest {}, newest {}).",
+        candidates.len(),
+        session_time_epoch_seconds(oldest),
+        session_time_epoch_seconds(newest)
+    )
+}
+
 /// Handle `hermes sessions [action] [--id ...] [--name ...]`.
 pub async fn handle_cli_sessions(
-    action: Option<String>,
-    id: Option<String>,
-    name: Option<String>,
+    options: CliSessionsOptions,
 ) -> Result<(), hermes_core::AgentError> {
     let sessions_dir = hermes_config::hermes_home().join("sessions");
+    let CliSessionsOptions {
+        action,
+        session,
+        id,
+        session_id,
+        name,
+        format,
+        only,
+        output,
+        redact,
+        yes,
+        source,
+        older_than,
+    } = options;
 
     match action.as_deref().unwrap_or("list") {
         "list" => {
@@ -80,34 +967,99 @@ pub async fn handle_cli_sessions(
             }
         }
         "export" => {
-            let session_id = id.ok_or_else(|| {
-                hermes_core::AgentError::Config(
-                    "Missing session ID. Usage: hermes sessions export --id <id>".into(),
-                )
-            })?;
-            let path = sessions_dir.join(format!("{}.json", session_id));
-            if !path.exists() {
-                println!("Session '{}' not found.", session_id);
+            let export_format = normalize_session_export_format(format.as_deref())?;
+            let export_only = normalize_session_export_only(only.as_deref())?;
+            let explicit_subject = session_id.or(id);
+            let mut export_subject = explicit_subject;
+            let mut export_output = output;
+
+            if export_subject.is_none() {
+                if let Some(candidate) = session.clone().map(|value| value.trim().to_string()) {
+                    if candidate.is_empty() {
+                        export_subject = None;
+                    } else if resolve_unique_session_snapshot(&sessions_dir, &candidate)?.is_some() {
+                        export_subject = Some(candidate);
+                    } else if export_output.is_none()
+                        && session_export_positional_looks_like_output(&candidate)
+                    {
+                        export_output = Some(candidate);
+                    } else {
+                        export_subject = Some(candidate);
+                    }
+                }
+            }
+
+            if export_format == SessionExportFormat::Html
+                && export_output
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty() && *value != "-")
+                    .is_none()
+            {
+                return Err(hermes_core::AgentError::Config(
+                    "HTML export requires an output file path.".into(),
+                ));
+            }
+
+            let snapshots = collect_session_export_snapshots(
+                &sessions_dir,
+                export_subject.as_deref(),
+                source.as_deref(),
+                older_than,
+                redact,
+            )?;
+            if snapshots.is_empty() {
+                if let Some(subject) = export_subject {
+                    println!("Session '{}' not found.", subject);
+                } else {
+                    println!("No sessions found.");
+                }
                 return Ok(());
             }
-            let content = std::fs::read_to_string(&path)
-                .map_err(|e| hermes_core::AgentError::Io(e.to_string()))?;
-            println!("{}", content);
+
+            let rendered = render_session_exports(&snapshots, export_format, export_only)?;
+            write_session_export_output(export_output.as_deref(), &rendered)?;
+            if let Some(output) = export_output.as_deref().filter(|value| *value != "-") {
+                let count = if export_only == Some(SessionExportOnly::UserPrompts) {
+                    iter_user_prompt_records(&snapshots).len()
+                } else {
+                    snapshots.len()
+                };
+                let noun = if export_only == Some(SessionExportOnly::UserPrompts) {
+                    "prompt"
+                } else {
+                    "session"
+                };
+                println!(
+                    "Exported {} {}{} to {}",
+                    count,
+                    noun,
+                    if count == 1 { "" } else { "s" },
+                    output
+                );
+            }
         }
         "delete" => {
-            let session_id = id.ok_or_else(|| {
+            let session_id = session_subject(session.clone(), id.clone()).ok_or_else(|| {
                 hermes_core::AgentError::Config(
                     "Missing session ID. Usage: hermes sessions delete --id <id>".into(),
                 )
             })?;
-            let path = sessions_dir.join(format!("{}.json", session_id));
-            if path.exists() {
-                std::fs::remove_file(&path)
-                    .map_err(|e| hermes_core::AgentError::Io(e.to_string()))?;
-                println!("Session '{}' deleted.", session_id);
-            } else {
+            let Some(resolved) = resolve_unique_session_snapshot(&sessions_dir, &session_id)?
+            else {
                 println!("Session '{}' not found.", session_id);
+                return Ok(());
+            };
+            if !prompt_session_confirmation(
+                &format!("Delete session '{}'? This cannot be undone.", resolved.id),
+                yes,
+            ) {
+                println!("Cancelled.");
+                return Ok(());
             }
+            let deleted = delete_session_snapshot_by_query(&sessions_dir, &resolved.id)?
+                .unwrap_or_else(|| resolved.id.clone());
+            println!("Deleted session '{}'.", deleted);
         }
         "stats" => {
             if !sessions_dir.exists() {
@@ -137,33 +1089,30 @@ pub async fn handle_cli_sessions(
             println!("  Directory:      {}", sessions_dir.display());
         }
         "prune" => {
-            let max_age_days: u64 = name
-                .as_deref()
-                .and_then(|s| s.parse::<u64>().ok())
-                .unwrap_or(30);
-            println!("Pruning sessions older than {} days...", max_age_days);
             if !sessions_dir.exists() {
                 println!("No sessions directory.");
                 return Ok(());
             }
-            let cutoff = std::time::SystemTime::now()
-                .checked_sub(std::time::Duration::from_secs(max_age_days * 86400))
-                .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+            let max_age_days =
+                prune_cutoff_for_sessions(source.as_deref(), older_than, name.as_deref());
+            let candidates = prune_session_snapshot_candidates(
+                &sessions_dir,
+                source.as_deref(),
+                max_age_days,
+            )?;
+            println!("{}", render_prune_preview(&candidates));
+            if candidates.is_empty() {
+                return Ok(());
+            }
+            if !prompt_session_confirmation("Prune matching sessions?", yes) {
+                println!("Cancelled.");
+                return Ok(());
+            }
             let mut pruned = 0u32;
-            if let Ok(rd) = std::fs::read_dir(&sessions_dir) {
-                for entry in rd.filter_map(|e| e.ok()) {
-                    let path = entry.path();
-                    if !path.extension().map(|e| e == "json").unwrap_or(false) {
-                        continue;
-                    }
-                    if let Ok(meta) = std::fs::metadata(&path) {
-                        let modified = meta.modified().unwrap_or(std::time::SystemTime::UNIX_EPOCH);
-                        if modified < cutoff && std::fs::remove_file(&path).is_ok() {
-                            let name = path.file_stem().unwrap_or_default().to_string_lossy();
-                            println!("  Pruned: {}", name);
-                            pruned += 1;
-                        }
-                    }
+            for entry in candidates {
+                if std::fs::remove_file(&entry.path).is_ok() {
+                    println!("  Pruned: {}", entry.id);
+                    pruned += 1;
                 }
             }
             println!("Pruned {} session(s).", pruned);

--- a/crates/hermes-cli/src/commands/command_dispatch_model/model_capabilities.rs
+++ b/crates/hermes-cli/src/commands/command_dispatch_model/model_capabilities.rs
@@ -63,6 +63,69 @@ struct ResolvedModelCapabilities {
     context_window: u64,
 }
 
+const OPENAI_CODEX_OAUTH_CONTEXT_WINDOW: u64 = 272_000;
+
+fn model_context_override_for_config(
+    provider: &str,
+    model_id: &str,
+    config: &GatewayConfig,
+) -> Option<u64> {
+    let (_, provider_cfg) = crate::model_switch::configured_llm_provider(config, provider)?;
+    let model_id = model_id.trim();
+    let provider_model = format!("{}:{}", provider.trim(), model_id);
+    provider_cfg
+        .model_context_windows
+        .iter()
+        .find_map(|(key, value)| {
+            let key = key.trim();
+            if key.eq_ignore_ascii_case(model_id) || key.eq_ignore_ascii_case(&provider_model) {
+                Some((*value).max(1))
+            } else {
+                None
+            }
+        })
+}
+
+fn provider_is_openai_codex_oauth(provider: &str, config: Option<&GatewayConfig>) -> bool {
+    let canonical = canonical_provider_id(provider);
+    if canonical == "openai-codex" {
+        return true;
+    }
+    let Some(config) = config else {
+        return false;
+    };
+    crate::model_switch::configured_llm_provider(config, provider)
+        .and_then(|(_, provider_cfg)| provider_cfg.base_url.as_deref())
+        .map(|base_url| {
+            base_url
+                .trim()
+                .trim_end_matches('/')
+                .eq_ignore_ascii_case("https://chatgpt.com/backend-api/codex")
+        })
+        .unwrap_or(false)
+}
+
+fn resolve_display_context_window(
+    provider: &str,
+    model_id: &str,
+    config: Option<&GatewayConfig>,
+    models_dev_context_window: Option<u64>,
+) -> u64 {
+    if provider_is_openai_codex_oauth(provider, config) {
+        return OPENAI_CODEX_OAUTH_CONTEXT_WINDOW;
+    }
+    if let Some(config) = config {
+        if let Some(value) = model_context_override_for_config(provider, model_id, config) {
+            return value;
+        }
+    }
+    if let Some(value) = models_dev_context_window.filter(|value| *value > 0) {
+        return value;
+    }
+    let provider_model = format!("{}:{}", provider.trim(), model_id.trim());
+    get_model_context_length(&provider_model)
+}
+
 fn normalize_model_capability_name(value: &str) -> Option<&'static str> {
     match value.trim().to_ascii_lowercase().as_str() {
         "tools" | "tool" | "function-calling" | "function_calling" => Some("tools"),
@@ -181,32 +244,33 @@ fn resolve_model_capabilities(
     provider: &str,
     model_id: &str,
     client: &hermes_intelligence::models_dev::ModelsDevClient,
+    config: Option<&GatewayConfig>,
 ) -> ResolvedModelCapabilities {
-    if let Some(caps) = client.capabilities(provider, model_id) {
-        return ResolvedModelCapabilities {
-            supports_tools: caps.supports_tools,
-            supports_vision: caps.supports_vision,
-            supports_reasoning: caps.supports_reasoning,
-            context_window: caps.context_window.max(1),
-        };
-    }
-
     let provider_model = format!("{}:{}", provider.trim(), model_id.trim());
+    let models_dev_caps = client.capabilities(provider, model_id);
     let info = get_model_info(&provider_model).or_else(|| get_model_info(model_id));
     ResolvedModelCapabilities {
-        supports_tools: info
+        supports_tools: models_dev_caps
             .as_ref()
             .map(|entry| entry.supports_tools)
+            .or_else(|| info.as_ref().map(|entry| entry.supports_tools))
             .unwrap_or(true),
-        supports_vision: info
+        supports_vision: models_dev_caps
             .as_ref()
             .map(|entry| entry.supports_vision)
+            .or_else(|| info.as_ref().map(|entry| entry.supports_vision))
             .unwrap_or(false),
-        supports_reasoning: info
+        supports_reasoning: models_dev_caps
             .as_ref()
             .map(|entry| entry.supports_reasoning)
+            .or_else(|| info.as_ref().map(|entry| entry.supports_reasoning))
             .unwrap_or(false),
-        context_window: get_model_context_length(&provider_model),
+        context_window: resolve_display_context_window(
+            provider,
+            model_id,
+            config,
+            models_dev_caps.map(|entry| entry.context_window),
+        ),
     }
 }
 
@@ -283,7 +347,7 @@ async fn handle_model_explain_command(
     let (provider, model_id) = split_provider_model(&guarded);
     let client = default_client();
     client.fetch(false).await;
-    let capabilities = resolve_model_capabilities(provider, model_id, client);
+    let capabilities = resolve_model_capabilities(provider, model_id, client, Some(&app.config));
 
     let mut out = String::new();
     let _ = writeln!(out, "Model capability report");
@@ -319,7 +383,7 @@ async fn handle_model_explain_command(
                 .into_iter()
                 .filter(|candidate| {
                     model_meets_requirements(
-                        resolve_model_capabilities(provider, candidate, client),
+                    resolve_model_capabilities(provider, candidate, client, Some(&app.config)),
                         requirements,
                     )
                 })
@@ -583,7 +647,12 @@ async fn pick_model_for_provider(
             .iter()
             .filter(|model_id| {
                 model_meets_requirements(
-                    resolve_model_capabilities(&normalized_provider, model_id, client),
+                    resolve_model_capabilities(
+                        &normalized_provider,
+                        model_id,
+                        client,
+                        Some(&app.config),
+                    ),
                     requirements,
                 )
             })
@@ -740,4 +809,3 @@ fn handle_model_failover_command(
     }
     Ok(CommandResult::Handled)
 }
-

--- a/crates/hermes-cli/src/commands/command_dispatch_model/model_command.rs
+++ b/crates/hermes-cli/src/commands/command_dispatch_model/model_command.rs
@@ -46,7 +46,7 @@ async fn handle_model_command(app: &mut App, args: &[&str]) -> Result<CommandRes
                 let (provider, model_id) = split_provider_model(&guarded);
                 let client = default_client();
                 client.fetch(false).await;
-                let caps = resolve_model_capabilities(provider, model_id, client);
+                let caps = resolve_model_capabilities(provider, model_id, client, Some(&app.config));
                 if !model_meets_requirements(caps, requirements) {
                     return Err(AgentError::Config(format!(
                         "Requested model '{}' does not satisfy required capabilities: {}.",
@@ -108,4 +108,3 @@ async fn handle_model_command(app: &mut App, args: &[&str]) -> Result<CommandRes
     }
     Ok(CommandResult::Handled)
 }
-

--- a/crates/hermes-cli/src/commands/command_kanban_objective.rs
+++ b/crates/hermes-cli/src/commands/command_kanban_objective.rs
@@ -748,7 +748,7 @@ fn plan_capability_preflight(app: &App, task: &str) -> (Option<String>, bool) {
 
     let (provider, model_id) = split_provider_model(&app.current_model);
     let client = default_client();
-    let caps = resolve_model_capabilities(provider, model_id, client);
+    let caps = resolve_model_capabilities(provider, model_id, client, Some(&app.config));
     let unmet = unmet_model_requirements(caps, req);
     if unmet.is_empty() {
         return (

--- a/crates/hermes-cli/src/commands/command_tests.rs
+++ b/crates/hermes-cli/src/commands/command_tests.rs
@@ -406,7 +406,12 @@ mod tests {
         )
         .expect("write config");
 
-        let saved_path = setup_memory_provider_target("honcho", true).expect("setup honcho");
+        let saved_path = setup_memory_provider_target(
+            "honcho",
+            &MemorySetupCliOptions::yes_only(true),
+        )
+        .expect("setup honcho")
+        .config_path;
 
         assert_eq!(saved_path, path);
         let parsed: serde_json::Value =
@@ -490,7 +495,12 @@ mod tests {
         let _user = EnvVarGuard::remove("OPENVIKING_USER");
         let _agent = EnvVarGuard::remove("OPENVIKING_AGENT");
 
-        let path = setup_memory_provider_target("openviking", true).expect("setup openviking");
+        let path = setup_memory_provider_target(
+            "openviking",
+            &MemorySetupCliOptions::yes_only(true),
+        )
+        .expect("setup openviking")
+        .config_path;
 
         assert_eq!(path, tmp.path().join("openviking.json"));
         let parsed: serde_json::Value =
@@ -524,7 +534,12 @@ mod tests {
         let _base_url = EnvVarGuard::set("SUPERMEMORY_BASE_URL", "https://api.supermemory.ai");
         let _container = EnvVarGuard::set("SUPERMEMORY_CONTAINER_TAG", "hermes-tests");
 
-        let path = setup_memory_provider_target("supermemory", true).expect("setup supermemory");
+        let path = setup_memory_provider_target(
+            "supermemory",
+            &MemorySetupCliOptions::yes_only(true),
+        )
+        .expect("setup supermemory")
+        .config_path;
 
         assert_eq!(path, tmp.path().join("supermemory.json"));
         let parsed: serde_json::Value =
@@ -556,7 +571,12 @@ mod tests {
         let _home = TempHomeGuard::new(tmp.path());
         let _api_key = EnvVarGuard::set("BRV_API_KEY", "brv-test-key");
 
-        let path = setup_memory_provider_target("byterover", true).expect("setup byterover");
+        let path = setup_memory_provider_target(
+            "byterover",
+            &MemorySetupCliOptions::yes_only(true),
+        )
+        .expect("setup byterover")
+        .config_path;
 
         assert_eq!(path, tmp.path().join("byterover.json"));
         let parsed: serde_json::Value =

--- a/crates/hermes-cli/src/commands/tests/runtime_parity_ops.rs
+++ b/crates/hermes-cli/src/commands/tests/runtime_parity_ops.rs
@@ -1133,3 +1133,196 @@ fn parse_skill_tap_spec_parses_tree_url() {
     assert_eq!(parsed.repo, "anthropics/skills");
     assert_eq!(parsed.path, "skills");
 }
+
+#[test]
+fn cli_sessions_delete_resolves_unique_prefix_and_removes_snapshot() {
+    let tmp = tempdir().expect("tempdir");
+    let sessions_dir = tmp.path().join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+    let full_id = "20260315_092437_c9a6ff";
+    let path = sessions_dir.join(format!("{full_id}.json"));
+    std::fs::write(&path, r#"{"messages":[]}"#).expect("session snapshot");
+
+    let deleted =
+        delete_session_snapshot_by_query(&sessions_dir, "20260315_092437_c9a6").expect("delete");
+
+    assert_eq!(deleted.as_deref(), Some(full_id));
+    assert!(!path.exists());
+}
+
+#[test]
+fn cli_sessions_prune_uses_90_day_default_and_source_all_ages() {
+    assert_eq!(prune_cutoff_for_sessions(None, None, None), Some(90));
+    assert_eq!(prune_cutoff_for_sessions(Some("cron"), None, None), None);
+    assert_eq!(
+        prune_cutoff_for_sessions(Some("cron"), Some(30), None),
+        Some(30)
+    );
+}
+
+#[test]
+fn cli_sessions_prune_filters_source_and_renders_preview_bounds() {
+    let tmp = tempdir().expect("tempdir");
+    let sessions_dir = tmp.path().join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+    std::fs::write(
+        sessions_dir.join("cron-session.json"),
+        r#"{"source":"cron","messages":[]}"#,
+    )
+    .expect("cron session");
+    std::fs::write(
+        sessions_dir.join("cli-session.json"),
+        r#"{"source":"cli","messages":[]}"#,
+    )
+    .expect("cli session");
+
+    let candidates =
+        prune_session_snapshot_candidates(&sessions_dir, Some("cron"), None).expect("candidates");
+    let ids: Vec<_> = candidates.iter().map(|entry| entry.id.as_str()).collect();
+    assert_eq!(ids, vec!["cron-session"]);
+    let preview = render_prune_preview(&candidates);
+    assert!(preview.contains("1 session(s) match"));
+    assert!(preview.contains("oldest"));
+    assert!(preview.contains("newest"));
+}
+
+#[test]
+fn cli_sessions_confirmation_treats_eof_or_empty_input_as_cancelled() {
+    assert!(!session_confirm_response_is_yes(None));
+    assert!(!session_confirm_response_is_yes(Some("")));
+    assert!(!session_confirm_response_is_yes(Some("n")));
+    assert!(session_confirm_response_is_yes(Some("yes")));
+    assert!(session_confirm_response_is_yes(Some("Y")));
+}
+
+#[test]
+fn cli_sessions_export_renders_prompt_only_jsonl_and_markdown() {
+    let session = SessionExportSnapshot {
+        id: "session-a".to_string(),
+        data: serde_json::json!({
+            "id": "session-a",
+            "title": "Export <title>",
+            "source": "cli",
+            "messages": [
+                {"role": "system", "content": "internal"},
+                {"role": "user", "id": "u1", "timestamp": 1700000000, "content": "first prompt"},
+                {"role": "assistant", "content": "answer"},
+                {"role": "user", "content": [{"type": "text", "text": "second"}, {"text": "prompt"}]}
+            ]
+        }),
+    };
+
+    let jsonl = render_session_exports(
+        std::slice::from_ref(&session),
+        SessionExportFormat::Jsonl,
+        Some(SessionExportOnly::UserPrompts),
+    )
+    .expect("jsonl");
+    let rows: Vec<serde_json::Value> = jsonl
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("json row"))
+        .collect();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0]["session_id"], "session-a");
+    assert_eq!(rows[0]["text"], "first prompt");
+    assert_eq!(rows[1]["index"], 2);
+    assert_eq!(rows[1]["text"], "second\nprompt");
+
+    let markdown = render_session_exports(
+        &[session],
+        SessionExportFormat::Markdown,
+        Some(SessionExportOnly::UserPrompts),
+    )
+    .expect("markdown");
+    assert!(markdown.contains("# User prompts for session session-a"));
+    assert!(markdown.contains("## 1. 2023-11-14T22:13:20Z"));
+    assert!(markdown.contains("first prompt"));
+    assert!(!markdown.contains("internal"));
+}
+
+#[test]
+fn cli_sessions_export_html_is_self_contained_and_escaped() {
+    let sessions = vec![
+        SessionExportSnapshot {
+            id: "session-a".to_string(),
+            data: serde_json::json!({
+                "title": "One",
+                "messages": [
+                    {"role": "user", "content": "<script>alert(1)</script>"},
+                    {"role": "assistant", "reasoning": "private <reason>", "content": "done"}
+                ]
+            }),
+        },
+        SessionExportSnapshot {
+            id: "session-b".to_string(),
+            data: serde_json::json!({"title": "Two", "messages": []}),
+        },
+    ];
+
+    let html = render_session_exports(&sessions, SessionExportFormat::Html, None).expect("html");
+
+    assert!(html.starts_with("<!doctype html>"));
+    assert!(html.contains("<nav class=\"sidebar\">"));
+    assert!(html.contains("session-session-a"));
+    assert!(html.contains("&lt;script&gt;alert(1)&lt;/script&gt;"));
+    assert!(html.contains("private &lt;reason&gt;"));
+    assert!(!html.contains("<script>alert(1)</script>"));
+}
+
+#[test]
+fn cli_sessions_export_redacts_secret_fields_and_text_tokens() {
+    let mut value = serde_json::json!({
+        "api_key": "sk-live-secret-token",
+        "messages": [
+            {"role": "user", "content": "Bearer abcdefghijklmnopqrstuvwxyz token=abc123"}
+        ]
+    });
+
+    redact_session_export_value(&mut value, None);
+
+    assert_eq!(value["api_key"], "[REDACTED]");
+    let content = value["messages"][0]["content"].as_str().expect("content");
+    assert!(content.contains("Bearer [REDACTED]"));
+    assert!(content.contains("token=[REDACTED]"));
+}
+
+#[tokio::test]
+async fn cli_sessions_export_command_writes_html_file_with_session_id_alias() {
+    let _guard = env_test_lock();
+    let tmp = tempdir().expect("tempdir");
+    let _home_guard = TempHomeGuard::new(tmp.path());
+    let sessions_dir = hermes_config::hermes_home().join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+    std::fs::write(
+        sessions_dir.join("20260707_export_html.json"),
+        serde_json::json!({
+            "id": "20260707_export_html",
+            "title": "HTML export",
+            "messages": [{"role": "user", "content": "render this"}]
+        })
+        .to_string(),
+    )
+    .expect("session fixture");
+    let output = tmp.path().join("session-export.html");
+
+    handle_cli_sessions(CliSessionsOptions {
+        action: Some("export".to_string()),
+        session: None,
+        id: None,
+        session_id: Some("20260707_export".to_string()),
+        name: None,
+        format: Some("html".to_string()),
+        only: None,
+        output: Some(output.display().to_string()),
+        redact: false,
+        yes: false,
+        source: None,
+        older_than: None,
+    })
+    .await
+    .expect("export");
+
+    let html = std::fs::read_to_string(output).expect("html output");
+    assert!(html.contains("HTML export"));
+    assert!(html.contains("render this"));
+}

--- a/crates/hermes-cli/src/commands/tests/skill_model_policy.rs
+++ b/crates/hermes-cli/src/commands/tests/skill_model_policy.rs
@@ -607,6 +607,47 @@ llm_providers:
     }
 
     #[test]
+    fn resolve_model_capabilities_uses_codex_oauth_display_context_cap() {
+        let client = hermes_intelligence::models_dev::ModelsDevClient::new(
+            "http://127.0.0.1:9",
+            std::env::temp_dir().join("hermes-models-dev-codex-cap.json"),
+        );
+        let caps = resolve_model_capabilities("openai-codex", "gpt-5.5", &client, None);
+
+        assert_eq!(caps.context_window, OPENAI_CODEX_OAUTH_CONTEXT_WINDOW);
+    }
+
+    #[test]
+    fn resolve_model_capabilities_uses_custom_provider_context_override() {
+        let client = hermes_intelligence::models_dev::ModelsDevClient::new(
+            "http://127.0.0.1:9",
+            std::env::temp_dir().join("hermes-models-dev-custom-context.json"),
+        );
+        let mut config = GatewayConfig::default();
+        config.llm_providers.insert(
+            "my-custom-endpoint".to_string(),
+            hermes_config::LlmProviderConfig {
+                base_url: Some("https://example.invalid/v1".to_string()),
+                models: vec!["gpt-5.5".to_string()],
+                model_context_windows: std::collections::HashMap::from([(
+                    "gpt-5.5".to_string(),
+                    1_050_000,
+                )]),
+                ..hermes_config::LlmProviderConfig::default()
+            },
+        );
+
+        let caps = resolve_model_capabilities(
+            "my-custom-endpoint",
+            "gpt-5.5",
+            &client,
+            Some(&config),
+        );
+
+        assert_eq!(caps.context_window, 1_050_000);
+    }
+
+    #[test]
     fn parse_model_command_args_rejects_unknown_capability() {
         let err = parse_model_command_args(&["--cap", "telepathy"]).expect_err("expected error");
         let message = err.to_string().to_ascii_lowercase();

--- a/crates/hermes-cli/src/kanban.rs
+++ b/crates/hermes-cli/src/kanban.rs
@@ -1112,6 +1112,45 @@ mod tests {
     }
 
     #[test]
+    fn kanban_claim_completion_archive_is_idempotent_under_reclaim_like_replay() {
+        with_temp_home(|home| {
+            let path = kanban_store_path_in(home);
+            let mut store = load_store_from_path(&path).expect("load");
+            let board = ensure_board(&mut store, None);
+            let task = add_task(
+                board,
+                NewKanbanTaskInput {
+                    title: "Race-safe task".to_string(),
+                    lane: KanbanLane::Todo,
+                    priority: 1,
+                    assignee: None,
+                    description: None,
+                    depends_on: vec![],
+                    goal_mode: false,
+                    goal_max_turns: None,
+                },
+            );
+            assert_eq!(task.id, "K-0001");
+
+            let task = find_task_mut(board, "K-0001").expect("task");
+            claim_task(task, Some("worker-a".to_string()));
+            claim_task(task, Some("worker-a".to_string()));
+            move_task(task, KanbanLane::Done, Some("finished once".to_string()));
+
+            assert_eq!(archive_done(board), 1);
+            assert_eq!(archive_done(board), 0);
+            assert!(find_task_mut(board, "K-0001").is_none());
+            assert_eq!(board.archived.len(), 1);
+            assert_eq!(board.archived[0].id, "K-0001");
+            assert_eq!(
+                board.archived[0].run_summary.as_deref(),
+                Some("finished once")
+            );
+            save_store_to_path(&store, &path).expect("save");
+        });
+    }
+
+    #[test]
     fn contextlattice_checkpoint_disabled_path() {
         with_temp_home(|_home| {
             std::env::set_var("HERMES_KANBAN_CONTEXTLATTICE_SYNC", "0");

--- a/crates/hermes-cli/src/main/entrypoint.rs
+++ b/crates/hermes-cli/src/main/entrypoint.rs
@@ -438,7 +438,24 @@ async fn main() {
             action,
             target,
             yes,
-        } => hermes_cli::commands::handle_cli_memory(action, target, yes).await,
+            mode,
+            host,
+            api_key,
+            dry_run,
+        } => {
+            hermes_cli::commands::handle_cli_memory(
+                action,
+                target,
+                hermes_cli::commands::MemorySetupCliOptions {
+                    yes,
+                    mode,
+                    host,
+                    api_key,
+                    dry_run,
+                },
+            )
+            .await
+        }
         CliCommand::Mcp {
             action,
             name,
@@ -450,8 +467,35 @@ async fn main() {
             hermes_cli::commands::handle_cli_mcp(action, name, server, url, command, parallel_tools)
                 .await
         }
-        CliCommand::Sessions { action, id, name } => {
-            hermes_cli::commands::handle_cli_sessions(action, id, name).await
+        CliCommand::Sessions {
+            action,
+            session,
+            id,
+            session_id,
+            name,
+            format,
+            only,
+            output,
+            redact,
+            yes,
+            source,
+            older_than,
+        } => {
+            hermes_cli::commands::handle_cli_sessions(hermes_cli::commands::CliSessionsOptions {
+                action,
+                session,
+                id,
+                session_id,
+                name,
+                format,
+                only,
+                output,
+                redact,
+                yes,
+                source,
+                older_than,
+            })
+            .await
         }
         CliCommand::Resume { session_id } => run_resume(cli, session_id).await,
         CliCommand::Insights { days, source } => {

--- a/crates/hermes-cli/src/main/tools_config.rs
+++ b/crates/hermes-cli/src/main/tools_config.rs
@@ -568,8 +568,12 @@ async fn run_optional_setup_sections(
             }
             2 => {
                 println!("\nOpening memory setup...");
-                hermes_cli::commands::handle_cli_memory(Some("setup".to_string()), None, false)
-                    .await?;
+                hermes_cli::commands::handle_cli_memory(
+                    Some("setup".to_string()),
+                    None,
+                    hermes_cli::commands::MemorySetupCliOptions::yes_only(false),
+                )
+                .await?;
             }
             3 => {
                 println!("\nOpening sentrux MCP setup...");

--- a/crates/hermes-cli/src/model_switch.rs
+++ b/crates/hermes-cli/src/model_switch.rs
@@ -246,7 +246,7 @@ pub fn provider_curated_models(provider: &str) -> &'static [&'static str] {
     &[]
 }
 
-fn configured_llm_provider<'a>(
+pub(crate) fn configured_llm_provider<'a>(
     config: &'a GatewayConfig,
     provider: &str,
 ) -> Option<(&'a String, &'a LlmProviderConfig)> {

--- a/crates/hermes-config/src/config.rs
+++ b/crates/hermes-config/src/config.rs
@@ -851,6 +851,14 @@ pub struct LlmProviderConfig {
     )]
     pub models: Vec<String>,
 
+    /// Per-model provider-aware context windows for custom/named providers.
+    #[serde(
+        default,
+        alias = "model_context_lengths",
+        skip_serializing_if = "HashMap::is_empty"
+    )]
+    pub model_context_windows: HashMap<String, u64>,
+
     /// Whether model pickers should live-probe `/models` for this provider.
     #[serde(
         default = "default_true",
@@ -909,6 +917,7 @@ impl Default for LlmProviderConfig {
             args: Vec::new(),
             model: None,
             models: Vec::new(),
+            model_context_windows: HashMap::new(),
             discover_models: true,
             api_mode: None,
             max_tokens: None,

--- a/crates/hermes-config/src/config/tests.rs
+++ b/crates/hermes-config/src/config/tests.rs
@@ -129,6 +129,35 @@ llm_providers:
     }
 
     #[test]
+    fn repo_cli_config_example_parses_as_rust_gateway_config() {
+        let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let example_path = manifest_dir.join("../..").join("cli-config.yaml.example");
+
+        let cfg = crate::loader::load_from_yaml(&example_path).expect("example config parses");
+
+        assert_eq!(cfg.model.as_deref(), Some("openai-codex:dynamic"));
+        assert!(cfg.model_switch.persist_switch_by_default);
+        assert_eq!(
+            cfg.llm_providers
+                .get("openai-codex")
+                .and_then(|provider| provider.api_mode.as_deref()),
+            Some("codex_responses")
+        );
+        assert_eq!(
+            cfg.llm_providers
+                .get("openai-codex")
+                .and_then(|provider| provider.model_context_windows.get("dynamic")),
+            Some(&272_000)
+        );
+        assert_eq!(cfg.terminal.backend, TerminalBackendType::Local);
+        assert_eq!(cfg.terminal.workdir.as_deref(), Some("."));
+        assert_eq!(cfg.web.search_backend, "auto");
+        assert_eq!(cfg.web.extract_backend, "auto");
+        assert!(cfg.sessions.auto_prune);
+        assert!(cfg.smart_model_routing.enabled);
+    }
+
+    #[test]
     fn default_auxiliary_task_configs_match_upstream_shape() {
         let tasks = default_auxiliary_task_configs();
         for key in ["vision", "web_extract", "approval"] {

--- a/crates/hermes-core/src/traits.rs
+++ b/crates/hermes-core/src/traits.rs
@@ -247,6 +247,14 @@ pub trait PlatformAdapter: Send + Sync {
         Ok(false)
     }
 
+    /// Rename a platform-native thread/channel when supported.
+    ///
+    /// The default is a no-op so gateway session titles remain portable across
+    /// platforms without requiring every adapter to expose thread metadata.
+    async fn rename_thread(&self, _thread_id: &str, _title: &str) -> Result<bool, GatewayError> {
+        Ok(false)
+    }
+
     /// Add a reaction emoji to a message if the platform supports it.
     async fn add_reaction(
         &self,

--- a/crates/hermes-gateway/src/gateway/slash_command_methods.rs
+++ b/crates/hermes-gateway/src/gateway/slash_command_methods.rs
@@ -31,6 +31,35 @@ impl Gateway {
         }
     }
 
+    async fn mirror_session_title_to_platform_thread(
+        &self,
+        incoming: &IncomingMessage,
+        title: &str,
+    ) -> Option<String> {
+        if !incoming.platform.eq_ignore_ascii_case("discord") {
+            return None;
+        }
+        let thread_id = incoming
+            .thread_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())?;
+        let adapter = self.get_adapter(&incoming.platform).await?;
+        match adapter.rename_thread(thread_id, title).await {
+            Ok(_) => None,
+            Err(err) => {
+                warn!(
+                    platform = incoming.platform,
+                    chat_id = incoming.chat_id,
+                    thread_id,
+                    error = %err,
+                    "failed to mirror session title to platform thread"
+                );
+                Some(format!("⚠️ Discord thread title mirror failed: {err}"))
+            }
+        }
+    }
+
     fn format_session_list(&self, heading: &str, sessions: &[Session]) -> String {
         if sessions.is_empty() {
             return format!("📚 No {} found for your user.", heading.to_ascii_lowercase());
@@ -631,11 +660,20 @@ impl Gateway {
             }
             GatewayCommandResult::SetTitle { title, reply } => {
                 let stored = self.session_manager.set_title(session_key, &title).await;
-                let response = match &stored {
+                let mut response = match &stored {
                     Some(stored_title) if stored_title.as_str() == title => reply,
                     Some(stored_title) => format!("🏷 Session title set to: {}", stored_title),
                     None => "🏷 Session title cleared.".to_string(),
                 };
+                if let Some(stored_title) = stored.as_deref() {
+                    if let Some(warning) = self
+                        .mirror_session_title_to_platform_thread(incoming, stored_title)
+                        .await
+                    {
+                        response.push('\n');
+                        response.push_str(&warning);
+                    }
+                }
                 self.emit_hook_event(
                     "session:title",
                     serde_json::json!({

--- a/crates/hermes-gateway/src/gateway/tests/status_profiles.rs
+++ b/crates/hermes-gateway/src/gateway/tests/status_profiles.rs
@@ -1,3 +1,66 @@
+struct ThreadRenameAdapter {
+    messages: Arc<Mutex<Vec<(String, String)>>>,
+    renames: Arc<Mutex<Vec<(String, String)>>>,
+}
+
+#[async_trait::async_trait]
+impl PlatformAdapter for ThreadRenameAdapter {
+    async fn start(&self) -> Result<(), GatewayError> {
+        Ok(())
+    }
+
+    async fn stop(&self) -> Result<(), GatewayError> {
+        Ok(())
+    }
+
+    async fn send_message(
+        &self,
+        chat_id: &str,
+        text: &str,
+        _parse_mode: Option<ParseMode>,
+    ) -> Result<(), GatewayError> {
+        self.messages
+            .lock()
+            .unwrap()
+            .push((chat_id.to_string(), text.to_string()));
+        Ok(())
+    }
+
+    async fn edit_message(
+        &self,
+        _chat_id: &str,
+        _message_id: &str,
+        _text: &str,
+    ) -> Result<(), GatewayError> {
+        Ok(())
+    }
+
+    async fn send_file(
+        &self,
+        _chat_id: &str,
+        _file_path: &str,
+        _caption: Option<&str>,
+    ) -> Result<(), GatewayError> {
+        Ok(())
+    }
+
+    async fn rename_thread(&self, thread_id: &str, title: &str) -> Result<bool, GatewayError> {
+        self.renames
+            .lock()
+            .unwrap()
+            .push((thread_id.to_string(), title.to_string()));
+        Ok(true)
+    }
+
+    fn is_running(&self) -> bool {
+        true
+    }
+
+    fn platform_name(&self) -> &str {
+        "discord"
+    }
+}
+
 #[tokio::test]
 async fn gateway_status_updates_use_platform_status_api() {
     let updates = Arc::new(Mutex::new(Vec::new()));
@@ -1074,6 +1137,49 @@ async fn gateway_title_command_persists_and_surfaces_session_title() {
         title_event.1["title"],
         serde_json::json!("Release readiness")
     );
+}
+
+#[tokio::test]
+async fn gateway_title_command_mirrors_discord_thread_title() {
+    let sent = Arc::new(Mutex::new(Vec::new()));
+    let renames = Arc::new(Mutex::new(Vec::new()));
+    let adapter = Arc::new(ThreadRenameAdapter {
+        messages: sent.clone(),
+        renames: renames.clone(),
+    });
+
+    let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+    let mut dm_manager = DmManager::with_pair_behavior();
+    dm_manager.authorize_user("user1");
+    let gw = Gateway::new(session_mgr.clone(), dm_manager, GatewayConfig::default());
+    gw.register_adapter("discord", adapter).await;
+
+    let title = IncomingMessage {
+        platform: "discord".into(),
+        chat_id: "parent-channel".into(),
+        user_id: "user1".into(),
+        text: "/title Release readiness".into(),
+        message_id: Some("msg-1".into()),
+        thread_id: Some("thread-42".into()),
+        is_dm: false,
+    };
+
+    assert!(gw.route_message(&title).await.is_ok());
+
+    let session_key = session_mgr.compose_session_key("discord", "parent-channel", "user1");
+    assert_eq!(
+        session_mgr.get_title(&session_key).await.as_deref(),
+        Some("Release readiness")
+    );
+    assert_eq!(
+        *renames.lock().unwrap(),
+        vec![("thread-42".to_string(), "Release readiness".to_string())]
+    );
+    assert!(sent
+        .lock()
+        .unwrap()
+        .iter()
+        .any(|(_, text)| text == "🏷 Session title set to: Release readiness"));
 }
 
 #[tokio::test]

--- a/crates/hermes-gateway/src/platforms/discord.rs
+++ b/crates/hermes-gateway/src/platforms/discord.rs
@@ -156,6 +156,11 @@ impl PlatformAdapter for DiscordAdapter {
         Ok(())
     }
 
+    async fn rename_thread(&self, thread_id: &str, title: &str) -> Result<bool, GatewayError> {
+        self.rename_thread_channel(thread_id, title).await?;
+        Ok(true)
+    }
+
     async fn send_image_url(
         &self,
         chat_id: &str,

--- a/crates/hermes-gateway/src/platforms/discord/command_media.rs
+++ b/crates/hermes-gateway/src/platforms/discord/command_media.rs
@@ -133,14 +133,7 @@ pub fn discord_auto_thread_name(content: &str) -> String {
         candidate
     };
 
-    let mut name = candidate.chars().take(80).collect::<String>();
-    if candidate.chars().count() > 80 {
-        while name.chars().count() > 77 {
-            name.pop();
-        }
-        name.push_str("...");
-    }
-    name
+    truncate_discord_utf16_with_suffix(candidate, 80, "...")
 }
 
 pub fn discord_thread_create_success_message(thread_id: &str) -> String {
@@ -445,4 +438,3 @@ fn resolve_channel_skills_from_bindings(
         })
         .map(|binding| binding.skills.clone())
 }
-

--- a/crates/hermes-gateway/src/platforms/discord/core_config.rs
+++ b/crates/hermes-gateway/src/platforms/discord/core_config.rs
@@ -433,6 +433,40 @@ fn truncate_discord_content(content: &str, max_chars: usize) -> String {
     content.chars().take(max_chars).collect()
 }
 
+fn discord_utf16_len(content: &str) -> usize {
+    content.encode_utf16().count()
+}
+
+fn truncate_discord_utf16_units(content: &str, max_units: usize) -> String {
+    let mut out = String::new();
+    let mut used = 0usize;
+    for ch in content.chars() {
+        let width = ch.len_utf16();
+        if used + width > max_units {
+            break;
+        }
+        out.push(ch);
+        used += width;
+    }
+    out
+}
+
+fn truncate_discord_utf16_with_suffix(content: &str, max_units: usize, suffix: &str) -> String {
+    if discord_utf16_len(content) <= max_units {
+        return content.to_string();
+    }
+    let suffix_units = discord_utf16_len(suffix);
+    if suffix_units >= max_units {
+        return truncate_discord_utf16_units(suffix, max_units);
+    }
+    let mut out = truncate_discord_utf16_units(content, max_units - suffix_units);
+    while out.ends_with(char::is_whitespace) {
+        out.pop();
+    }
+    out.push_str(suffix);
+    out
+}
+
 fn discord_reply_reference_error_allows_retry(raw_error: &str) -> bool {
     let normalized = raw_error.to_ascii_lowercase();
     normalized.contains("cannot reply to a system message")
@@ -446,7 +480,7 @@ fn forum_thread_name(content: Option<&str>, file_name: Option<&str>) -> String {
         .or_else(|| file_name.map(str::trim).filter(|name| !name.is_empty()))
         .unwrap_or("Hermes");
 
-    candidate.chars().take(100).collect()
+    truncate_discord_utf16_units(candidate, 100)
 }
 
 fn forum_thread_message_body(content: &str) -> serde_json::Value {

--- a/crates/hermes-gateway/src/platforms/discord/gateway_state/adapter_io.rs
+++ b/crates/hermes-gateway/src/platforms/discord/gateway_state/adapter_io.rs
@@ -1,3 +1,6 @@
+const DISCORD_REST_JSON_BODY_LIMIT_BYTES: usize = 1024 * 1024;
+const DISCORD_REST_ERROR_BODY_LIMIT_BYTES: usize = 8 * 1024;
+
 impl DiscordAdapter {
     /// Create a new Discord adapter with the given configuration.
     pub fn new(config: DiscordConfig) -> Result<Self, GatewayError> {
@@ -215,7 +218,7 @@ impl DiscordAdapter {
                 .map_err(|e| GatewayError::SendFailed(format!("Discord send failed: {}", e)))?;
 
             if !resp.status().is_success() {
-                let text = resp.text().await.unwrap_or_default();
+                let text = discord_response_text_limited(resp).await;
                 if include_reply_reference && discord_reply_reference_error_allows_retry(&text) {
                     suppress_reply_references = true;
                     let retry_body =
@@ -233,16 +236,14 @@ impl DiscordAdapter {
                         })?;
 
                     if !retry_resp.status().is_success() {
-                        let retry_text = retry_resp.text().await.unwrap_or_default();
+                        let retry_text = discord_response_text_limited(retry_resp).await;
                         return Err(GatewayError::SendFailed(format!(
                             "Discord API error: {}",
                             retry_text
                         )));
                     }
 
-                    let msg: DiscordMessage = retry_resp.json().await.map_err(|e| {
-                        GatewayError::SendFailed(format!("Failed to parse Discord response: {}", e))
-                    })?;
+                    let msg: DiscordMessage = discord_response_json_limited(retry_resp).await?;
 
                     message_ids.push(msg.id);
                     continue;
@@ -254,9 +255,7 @@ impl DiscordAdapter {
                 )));
             }
 
-            let msg: DiscordMessage = resp.json().await.map_err(|e| {
-                GatewayError::SendFailed(format!("Failed to parse Discord response: {}", e))
-            })?;
+            let msg: DiscordMessage = discord_response_json_limited(resp).await?;
 
             message_ids.push(msg.id);
         }
@@ -301,16 +300,14 @@ impl DiscordAdapter {
             .map_err(|e| GatewayError::SendFailed(format!("Discord forum post failed: {}", e)))?;
 
         if !resp.status().is_success() {
-            let text = resp.text().await.unwrap_or_default();
+            let text = discord_response_text_limited(resp).await;
             return Err(GatewayError::SendFailed(format!(
                 "Discord forum post API error: {}",
                 text
             )));
         }
 
-        let thread: DiscordForumThread = resp.json().await.map_err(|e| {
-            GatewayError::SendFailed(format!("Failed to parse forum thread response: {}", e))
-        })?;
+        let thread: DiscordForumThread = discord_response_json_limited(resp).await?;
         let message_id = thread
             .message
             .as_ref()
@@ -361,7 +358,7 @@ impl DiscordAdapter {
             .map_err(|e| GatewayError::SendFailed(format!("Discord edit failed: {}", e)))?;
 
         if !resp.status().is_success() {
-            let text = resp.text().await.unwrap_or_default();
+            let text = discord_response_text_limited(resp).await;
             return Err(GatewayError::SendFailed(format!(
                 "Discord edit API error: {}",
                 text
@@ -414,16 +411,14 @@ impl DiscordAdapter {
             .map_err(|e| GatewayError::SendFailed(format!("Discord embed send failed: {}", e)))?;
 
         if !resp.status().is_success() {
-            let text = resp.text().await.unwrap_or_default();
+            let text = discord_response_text_limited(resp).await;
             return Err(GatewayError::SendFailed(format!(
                 "Discord embed API error: {}",
                 text
             )));
         }
 
-        let msg: DiscordMessage = resp.json().await.map_err(|e| {
-            GatewayError::SendFailed(format!("Failed to parse Discord response: {}", e))
-        })?;
+        let msg: DiscordMessage = discord_response_json_limited(resp).await?;
 
         if metadata_marks_non_conversational(metadata) {
             self.mark_non_conversational_messages([msg.id.as_str()]);
@@ -489,16 +484,14 @@ impl DiscordAdapter {
             .map_err(|e| GatewayError::SendFailed(format!("Discord file upload failed: {}", e)))?;
 
         if !resp.status().is_success() {
-            let text = resp.text().await.unwrap_or_default();
+            let text = discord_response_text_limited(resp).await;
             return Err(GatewayError::SendFailed(format!(
                 "Discord file upload API error: {}",
                 text
             )));
         }
 
-        let msg: DiscordMessage = resp.json().await.map_err(|e| {
-            GatewayError::SendFailed(format!("Failed to parse Discord response: {}", e))
-        })?;
+        let msg: DiscordMessage = discord_response_json_limited(resp).await?;
 
         if metadata_marks_non_conversational(metadata) {
             self.mark_non_conversational_messages([msg.id.as_str()]);
@@ -589,7 +582,7 @@ impl DiscordAdapter {
             .map_err(|e| GatewayError::SendFailed(format!("Discord add_reaction failed: {}", e)))?;
 
         if !resp.status().is_success() {
-            let text = resp.text().await.unwrap_or_default();
+            let text = discord_response_text_limited(resp).await;
             return Err(GatewayError::SendFailed(format!(
                 "Discord add_reaction API error: {}",
                 text
@@ -623,7 +616,7 @@ impl DiscordAdapter {
             })?;
 
         if !resp.status().is_success() {
-            let text = resp.text().await.unwrap_or_default();
+            let text = discord_response_text_limited(resp).await;
             return Err(GatewayError::SendFailed(format!(
                 "Discord remove_reaction API error: {}",
                 text
@@ -669,18 +662,58 @@ impl DiscordAdapter {
             })?;
 
         if !resp.status().is_success() {
-            let text = resp.text().await.unwrap_or_default();
+            let text = discord_response_text_limited(resp).await;
             return Err(GatewayError::SendFailed(format!(
                 "Discord create_thread API error: {}",
                 text
             )));
         }
 
-        let thread: DiscordThread = resp.json().await.map_err(|e| {
-            GatewayError::SendFailed(format!("Failed to parse thread response: {}", e))
-        })?;
+        let thread: DiscordThread = discord_response_json_limited(resp).await?;
 
         Ok(thread)
+    }
+
+    /// Rename an existing Discord thread/channel.
+    pub async fn rename_thread_channel(
+        &self,
+        thread_id: &str,
+        title: &str,
+    ) -> Result<(), GatewayError> {
+        self.ensure_liveness_healthy()?;
+        let thread_id = thread_id.trim();
+        if thread_id.is_empty() {
+            return Err(GatewayError::SendFailed(
+                "Discord thread rename requires a thread id".into(),
+            ));
+        }
+        let title = title.trim();
+        let title = if title.is_empty() { "Hermes" } else { title };
+        let name = truncate_discord_utf16_with_suffix(title, 100, "...");
+        let url = self.api_url(&format!("channels/{thread_id}"));
+        let body = serde_json::json!({ "name": name });
+
+        let resp = self
+            .client
+            .patch(&url)
+            .header("Authorization", self.auth_header())
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| {
+                GatewayError::SendFailed(format!("Discord rename_thread failed: {}", e))
+            })?;
+
+        if !resp.status().is_success() {
+            let text = discord_response_text_limited(resp).await;
+            return Err(GatewayError::SendFailed(format!(
+                "Discord rename_thread API error: {}",
+                text
+            )));
+        }
+
+        Ok(())
     }
 
     // -----------------------------------------------------------------------
@@ -715,7 +748,7 @@ impl DiscordAdapter {
             })?;
 
         if !resp.status().is_success() {
-            let text = resp.text().await.unwrap_or_default();
+            let text = discord_response_text_limited(resp).await;
             return Err(GatewayError::SendFailed(format!(
                 "Discord register_commands API error: {}",
                 text
@@ -756,7 +789,7 @@ impl DiscordAdapter {
             })?;
 
         if !resp.status().is_success() {
-            let text = resp.text().await.unwrap_or_default();
+            let text = discord_response_text_limited(resp).await;
             return Err(GatewayError::SendFailed(format!(
                 "Discord register_guild_commands API error: {}",
                 text
@@ -806,7 +839,7 @@ impl DiscordAdapter {
             })?;
 
         if !resp.status().is_success() {
-            let text = resp.text().await.unwrap_or_default();
+            let text = discord_response_text_limited(resp).await;
             return Err(GatewayError::SendFailed(format!(
                 "Discord interaction response API error: {}",
                 text
@@ -845,7 +878,7 @@ impl DiscordAdapter {
             })?;
 
         if !resp.status().is_success() {
-            let text = resp.text().await.unwrap_or_default();
+            let text = discord_response_text_limited(resp).await;
             return Err(GatewayError::SendFailed(format!(
                 "Discord defer interaction API error: {}",
                 text
@@ -944,6 +977,55 @@ async fn run_discord_liveness_probe_loop(
     }
 }
 
+async fn discord_response_bytes_limited(
+    mut resp: reqwest::Response,
+    limit_bytes: usize,
+) -> Result<(Vec<u8>, bool), GatewayError> {
+    let mut body = Vec::new();
+    while let Some(chunk) = resp
+        .chunk()
+        .await
+        .map_err(|err| GatewayError::SendFailed(format!("Discord response read failed: {err}")))?
+    {
+        if body.len() + chunk.len() > limit_bytes {
+            let remaining = limit_bytes.saturating_sub(body.len());
+            body.extend_from_slice(&chunk[..remaining]);
+            return Ok((body, true));
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok((body, false))
+}
+
+async fn discord_response_text_limited(resp: reqwest::Response) -> String {
+    let Ok((body, truncated)) =
+        discord_response_bytes_limited(resp, DISCORD_REST_ERROR_BODY_LIMIT_BYTES).await
+    else {
+        return String::new();
+    };
+    let mut text = String::from_utf8_lossy(&body).to_string();
+    if truncated {
+        text.push_str("... [truncated]");
+    }
+    text
+}
+
+async fn discord_response_json_limited<T>(resp: reqwest::Response) -> Result<T, GatewayError>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let (body, truncated) =
+        discord_response_bytes_limited(resp, DISCORD_REST_JSON_BODY_LIMIT_BYTES).await?;
+    if truncated {
+        return Err(GatewayError::SendFailed(format!(
+            "Discord API JSON response exceeds {} bytes",
+            DISCORD_REST_JSON_BODY_LIMIT_BYTES
+        )));
+    }
+    serde_json::from_slice(&body)
+        .map_err(|err| GatewayError::SendFailed(format!("Failed to parse Discord response: {err}")))
+}
+
 async fn probe_discord_rest_liveness(
     client: &Client,
     token: &str,
@@ -962,7 +1044,7 @@ async fn probe_discord_rest_liveness(
         return Ok(());
     }
     let status = resp.status();
-    let text = resp.text().await.unwrap_or_default();
+    let text = discord_response_text_limited(resp).await;
     Err(GatewayError::ConnectionFailed(format!(
         "Discord liveness REST status {status}: {text}"
     )))

--- a/crates/hermes-gateway/src/platforms/discord/history_context.rs
+++ b/crates/hermes-gateway/src/platforms/discord/history_context.rs
@@ -74,15 +74,16 @@ pub fn discord_normalize_clarify_choices(
 
 pub fn discord_clarify_button_label(index: usize, choice: &str) -> String {
     let prefix = format!("{}. ", index + 1);
-    let budget = 80usize.saturating_sub(prefix.chars().count()).max(1);
-    let choice_len = choice.chars().count();
+    let budget = 80usize.saturating_sub(discord_utf16_len(&prefix)).max(1);
+    let choice_len = discord_utf16_len(choice);
+    let ellipsis = "…";
     let label_body = if choice_len <= budget {
         choice.to_string()
     } else {
-        let mut chars = choice
-            .chars()
-            .take(budget.saturating_sub(1))
-            .collect::<String>();
+        let mut chars = truncate_discord_utf16_units(
+            choice,
+            budget.saturating_sub(discord_utf16_len(ellipsis)),
+        );
         while chars.chars().last().is_some_and(char::is_whitespace) {
             chars.pop();
         }
@@ -109,7 +110,7 @@ pub fn discord_clarify_button_label(index: usize, choice: &str) -> String {
         while chars.chars().last().is_some_and(char::is_whitespace) {
             chars.pop();
         }
-        format!("{chars}…")
+        format!("{chars}{ellipsis}")
     };
     format!("{prefix}{label_body}")
 }
@@ -330,4 +331,3 @@ pub fn discord_reactions_enabled_from_raw(raw: Option<&str>) -> bool {
         None => true,
     }
 }
-

--- a/crates/hermes-gateway/src/platforms/discord/tests/commands_and_channels.rs
+++ b/crates/hermes-gateway/src/platforms/discord/tests/commands_and_channels.rs
@@ -264,6 +264,9 @@ fn discord_auto_thread_names_and_feedback_match_slash_contract() {
     let long_name = discord_auto_thread_name(&"a".repeat(200));
     assert_eq!(long_name.len(), 80);
     assert!(long_name.ends_with("..."));
+    let emoji_name = discord_auto_thread_name(&"😀".repeat(80));
+    assert!(discord_utf16_len(&emoji_name) <= 80);
+    assert!(emoji_name.ends_with("..."));
     assert!(discord_thread_create_success_message("555").contains("<#555>"));
     assert!(discord_thread_create_failure_message("nope").contains("Failed to create thread"));
 }

--- a/crates/hermes-gateway/src/platforms/discord/tests/gateway_protocol.rs
+++ b/crates/hermes-gateway/src/platforms/discord/tests/gateway_protocol.rs
@@ -1,5 +1,5 @@
 use tokio::time::{sleep, Duration, Instant};
-use wiremock::matchers::{header, method, path};
+use wiremock::matchers::{body_json, header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[test]
@@ -94,6 +94,84 @@ async fn discord_liveness_probe_disabled_by_zero_knob() {
         .expect("liveness lock")
         .is_none());
     adapter.stop().await.expect("stop");
+}
+
+#[tokio::test]
+async fn discord_error_response_text_is_bounded() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/too-large-error"))
+        .respond_with(
+            ResponseTemplate::new(500)
+                .set_body_string("x".repeat(DISCORD_REST_ERROR_BODY_LIMIT_BYTES + 64)),
+        )
+        .mount(&server)
+        .await;
+
+    let resp = reqwest::Client::new()
+        .get(format!("{}/too-large-error", server.uri()))
+        .send()
+        .await
+        .expect("response");
+
+    let text = discord_response_text_limited(resp).await;
+
+    assert!(text.ends_with("... [truncated]"));
+    assert!(text.len() <= DISCORD_REST_ERROR_BODY_LIMIT_BYTES + "... [truncated]".len());
+}
+
+#[tokio::test]
+async fn discord_json_response_rejects_oversized_body() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/too-large-json"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(format!(
+            "{{\"id\":\"{}\"}}",
+            "x".repeat(DISCORD_REST_JSON_BODY_LIMIT_BYTES + 64)
+        )))
+        .mount(&server)
+        .await;
+
+    let resp = reqwest::Client::new()
+        .get(format!("{}/too-large-json", server.uri()))
+        .send()
+        .await
+        .expect("response");
+
+    let err = discord_response_json_limited::<DiscordMessage>(resp)
+        .await
+        .expect_err("oversized JSON should fail closed");
+
+    assert!(err.to_string().contains("Discord API JSON response exceeds"));
+}
+
+#[tokio::test]
+async fn discord_rename_thread_uses_bounded_utf16_title() {
+    let server = MockServer::start().await;
+    let title = "😀".repeat(90);
+    let expected = truncate_discord_utf16_with_suffix(&title, 100, "...");
+    assert!(discord_utf16_len(&expected) <= 100);
+
+    Mock::given(method("PATCH"))
+        .and(path("/channels/thread-1"))
+        .and(header("Authorization", "Bot test-token"))
+        .and(body_json(serde_json::json!({ "name": expected })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "thread-1",
+            "name": "renamed"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let mut cfg = test_config();
+    cfg.api_base_url = Some(server.uri());
+    let adapter = DiscordAdapter::new(cfg).expect("adapter");
+
+    adapter
+        .rename_thread_channel("thread-1", &title)
+        .await
+        .expect("thread rename should succeed");
 }
 
 #[test]

--- a/crates/hermes-gateway/src/platforms/discord/tests/policy_and_history.rs
+++ b/crates/hermes-gateway/src/platforms/discord/tests/policy_and_history.rs
@@ -113,7 +113,7 @@ fn clarify_button_labels_fit_discord_cap_and_cut_at_boundaries() {
     let label = discord_clarify_button_label(0, wordy);
     assert!(label.starts_with("1. "));
     assert!(label.ends_with('…'));
-    assert!(label.chars().count() <= 80);
+    assert!(discord_utf16_len(&label) <= 80);
     assert!(!label.trim_end_matches('…').ends_with('('));
 
     let no_space = format!(
@@ -125,7 +125,7 @@ fn clarify_button_labels_fit_discord_cap_and_cut_at_boundaries() {
     );
     let label = discord_clarify_button_label(0, &no_space);
     assert!(label.ends_with('…'));
-    assert!(label.chars().count() <= 80);
+    assert!(discord_utf16_len(&label) <= 80);
     let body = label
         .strip_prefix("1. ")
         .expect("prefix")
@@ -134,6 +134,15 @@ fn clarify_button_labels_fit_discord_cap_and_cut_at_boundaries() {
         body.chars().last(),
         Some('-' | ',' | '.' | ')' | ' ')
     ));
+}
+
+#[test]
+fn clarify_button_labels_fit_discord_utf16_cap_for_emoji() {
+    let label = discord_clarify_button_label(0, &"😀".repeat(80));
+
+    assert!(label.starts_with("1. "));
+    assert!(label.ends_with('…'));
+    assert!(discord_utf16_len(&label) <= 80);
 }
 
 #[test]
@@ -232,6 +241,7 @@ fn forum_parent_and_payload_contract_matches_python_send_path() {
     );
     assert_eq!(forum_thread_name(Some(""), Some("voice.ogg")), "voice.ogg");
     assert_eq!(forum_thread_name(None, None), "Hermes");
+    assert!(discord_utf16_len(&forum_thread_name(Some(&"😀".repeat(90)), None)) <= 100);
 
     let payload = forum_thread_payload("Hello forum!", None, Some(60));
     assert_eq!(payload["name"], "Hello forum!");

--- a/crates/hermes-tools/src/backends/web.rs
+++ b/crates/hermes-tools/src/backends/web.rs
@@ -108,6 +108,7 @@ impl WebCrawlBackend for FallbackCrawlBackend {
 // ---------------------------------------------------------------------------
 
 const MAX_EXTRACT_BYTES: usize = 512_000; // 500 KB
+const EXA_BASE_URL_DEFAULT: &str = "https://api.exa.ai";
 const TAVILY_BASE_URL_DEFAULT: &str = "https://api.tavily.com";
 const SEARXNG_SEARCH_PATH: &str = "/search";
 const BRAVE_SEARCH_URL_DEFAULT: &str = "https://api.search.brave.com/res/v1/web/search";
@@ -565,13 +566,25 @@ fn strip_html_tags(html: &str) -> String {
 pub struct ExaSearchBackend {
     client: Client,
     api_key: String,
+    base_url: String,
 }
 
 impl ExaSearchBackend {
     pub fn new(api_key: String) -> Self {
+        Self::with_base_url(api_key, EXA_BASE_URL_DEFAULT.to_string())
+    }
+
+    pub fn with_base_url(api_key: String, base_url: String) -> Self {
+        let normalized_base = base_url.trim().trim_end_matches('/').to_string();
+        let base_url = if normalized_base.is_empty() {
+            EXA_BASE_URL_DEFAULT.to_string()
+        } else {
+            normalized_base
+        };
         Self {
             client: Client::new(),
             api_key,
+            base_url,
         }
     }
 
@@ -586,7 +599,13 @@ impl ExaSearchBackend {
                 "EXA_API_KEY environment variable is empty".into(),
             ));
         }
-        Ok(Self::new(api_key.to_string()))
+        let base_url =
+            std::env::var("EXA_BASE_URL").unwrap_or_else(|_| EXA_BASE_URL_DEFAULT.to_string());
+        Ok(Self::with_base_url(api_key.to_string(), base_url))
+    }
+
+    pub fn base_url(&self) -> &str {
+        &self.base_url
     }
 }
 
@@ -613,7 +632,7 @@ impl WebSearchBackend for ExaSearchBackend {
 
         let resp = self
             .client
-            .post("https://api.exa.ai/search")
+            .post(format!("{}/search", self.base_url))
             .header("x-api-key", &self.api_key)
             .header("Content-Type", "application/json")
             .json(&body)
@@ -665,6 +684,168 @@ impl WebSearchBackend for ExaSearchBackend {
         }))
         .map_err(|e| ToolError::ExecutionFailed(format!("Failed to serialize results: {}", e)))
     }
+}
+
+/// Real Exa API content extraction backend.
+pub struct ExaExtractBackend {
+    client: Client,
+    api_key: String,
+    base_url: String,
+}
+
+impl ExaExtractBackend {
+    pub fn new(api_key: String) -> Self {
+        Self::with_base_url(api_key, EXA_BASE_URL_DEFAULT.to_string())
+    }
+
+    pub fn with_base_url(api_key: String, base_url: String) -> Self {
+        let normalized_base = base_url.trim().trim_end_matches('/').to_string();
+        let base_url = if normalized_base.is_empty() {
+            EXA_BASE_URL_DEFAULT.to_string()
+        } else {
+            normalized_base
+        };
+        Self {
+            client: Client::new(),
+            api_key,
+            base_url,
+        }
+    }
+
+    pub fn from_env() -> Result<Self, ToolError> {
+        let api_key = std::env::var("EXA_API_KEY").map_err(|_| {
+            ToolError::ExecutionFailed("EXA_API_KEY environment variable not set".into())
+        })?;
+        let api_key = api_key.trim();
+        if api_key.is_empty() {
+            return Err(ToolError::ExecutionFailed(
+                "EXA_API_KEY environment variable is empty".into(),
+            ));
+        }
+        let base_url =
+            std::env::var("EXA_BASE_URL").unwrap_or_else(|_| EXA_BASE_URL_DEFAULT.to_string());
+        Ok(Self::with_base_url(api_key.to_string(), base_url))
+    }
+
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+}
+
+#[async_trait]
+impl WebExtractBackend for ExaExtractBackend {
+    async fn extract(&self, url: &str, _include_links: bool) -> Result<String, ToolError> {
+        validate_url_does_not_exfiltrate_secret(url)?;
+        let body = json!({
+            "ids": [url],
+            "text": true,
+        });
+
+        let resp = self
+            .client
+            .post(format!("{}/contents", self.base_url))
+            .header("x-api-key", &self.api_key)
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(format!("Exa extract request failed: {e}")))?;
+
+        let status = resp.status();
+        let text = resp.text().await.map_err(|e| {
+            ToolError::ExecutionFailed(format!("Failed to read Exa extract response: {e}"))
+        })?;
+
+        if !status.is_success() {
+            return Err(ToolError::ExecutionFailed(format!(
+                "Exa extract API error ({status}): {text}"
+            )));
+        }
+
+        let data: Value = serde_json::from_str(&text).map_err(|e| {
+            ToolError::ExecutionFailed(format!("Failed to parse Exa extract response: {e}"))
+        })?;
+        let documents = normalize_exa_documents(&data, &[url]);
+        let first_content = documents
+            .first()
+            .and_then(|d| d.get("content"))
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        let source_summary = source_quality_summary(&documents);
+        serde_json::to_string_pretty(&json!({
+            "url": url,
+            "content": first_content,
+            "results": documents,
+            "provider": "exa",
+            "source_quality_summary": source_summary,
+        }))
+        .map_err(|e| ToolError::ExecutionFailed(format!("Failed to serialize result: {e}")))
+    }
+}
+
+fn normalize_exa_documents(response: &Value, requested_urls: &[&str]) -> Vec<Value> {
+    let mut documents = Vec::new();
+    if let Some(results) = response.get("results").and_then(Value::as_array) {
+        for result in results {
+            let url = result.get("url").and_then(Value::as_str).unwrap_or("");
+            let title = result.get("title").and_then(Value::as_str).unwrap_or("");
+            let content = result
+                .get("text")
+                .or_else(|| result.get("content"))
+                .or_else(|| result.get("raw_content"))
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            let quality = source_quality_for_url(url);
+            documents.push(json!({
+                "url": url,
+                "title": title,
+                "content": content,
+                "raw_content": content,
+                "source_quality": quality.label,
+                "source_quality_score": quality.score,
+                "source_quality_reason": quality.reason,
+                "metadata": {"sourceURL": url, "title": title},
+            }));
+        }
+    }
+    if let Some(errors) = response.get("errors").and_then(Value::as_array) {
+        for error in errors {
+            let url = error.get("url").and_then(Value::as_str).unwrap_or("");
+            let message = error
+                .get("message")
+                .or_else(|| error.get("error"))
+                .and_then(Value::as_str)
+                .unwrap_or("extraction failed");
+            let quality = source_quality_for_url(url);
+            documents.push(json!({
+                "url": url,
+                "title": "",
+                "content": "",
+                "error": message,
+                "source_quality": quality.label,
+                "source_quality_score": quality.score,
+                "source_quality_reason": quality.reason,
+                "metadata": {"sourceURL": url},
+            }));
+        }
+    }
+    if documents.is_empty() {
+        for url in requested_urls {
+            let quality = source_quality_for_url(url);
+            documents.push(json!({
+                "url": url,
+                "title": "",
+                "content": "",
+                "error": "extraction failed (no content returned)",
+                "source_quality": quality.label,
+                "source_quality_score": quality.score,
+                "source_quality_reason": quality.reason,
+                "metadata": {"sourceURL": url},
+            }));
+        }
+    }
+    documents
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/hermes-tools/src/backends/web/parallel_xai_firecrawl.rs
+++ b/crates/hermes-tools/src/backends/web/parallel_xai_firecrawl.rs
@@ -387,13 +387,17 @@ fn normalize_search_backend_choice(choice: &str) -> Option<&'static str> {
 ///
 /// Priority:
 /// 1. Explicit `HERMES_WEB_EXTRACT_BACKEND` override, then legacy `HERMES_WEB_BACKEND`
-///    (`parallel`, `firecrawl`, `tavily`, `simple`; search-only backends return a clear error)
+///    (`exa`, `parallel`, `firecrawl`, `tavily`, `simple`; search-only backends return a clear error)
 /// 2. Firecrawl direct/self-hosted/managed when configured
-/// 3. Tavily when configured
-/// 4. Parallel REST when `PARALLEL_API_KEY` is configured
-/// 5. Simple local extractor fallback
+/// 3. Exa when configured
+/// 4. Tavily when configured
+/// 5. Parallel REST when `PARALLEL_API_KEY` is configured
+/// 6. Simple local extractor fallback
 pub fn extract_backend_from_env_or_fallback() -> Box<dyn WebExtractBackend> {
     match extract_backend_choice_from_env() {
+        "exa" => ExaExtractBackend::from_env()
+            .map(|b| Box::new(b) as Box<dyn WebExtractBackend>)
+            .unwrap_or_else(|_| Box::new(SimpleExtractBackend::new())),
         "parallel" => Box::new(ParallelWebBackend::from_env()),
         "firecrawl" => FirecrawlExtractBackend::from_env_or_managed()
             .map(|b| Box::new(b) as Box<dyn WebExtractBackend>)
@@ -413,6 +417,7 @@ pub fn extract_backend_from_env_or_fallback() -> Box<dyn WebExtractBackend> {
 fn extract_backend_choice_from_env() -> &'static str {
     if let Ok(choice) = std::env::var("HERMES_WEB_EXTRACT_BACKEND") {
         match choice.trim().to_ascii_lowercase().as_str() {
+            "exa" => return "exa",
             "parallel" => return "parallel",
             "firecrawl" => return "firecrawl",
             "tavily" => return "tavily",
@@ -424,13 +429,13 @@ fn extract_backend_choice_from_env() -> &'static str {
         .and_then(|choice| normalize_search_backend_choice(&choice).map(str::to_string))
     {
         match choice.as_str() {
+            "exa" => return "exa",
             "parallel" => return "parallel",
             "firecrawl" => return "firecrawl",
             "tavily" => return "tavily",
             "brave-free" => return "search-only:brave-free",
             "ddgs" => return "search-only:ddgs",
             "searxng" => return "search-only:searxng",
-            "exa" => return "search-only:exa",
             "xai" => return "search-only:xai",
             _ => {}
         }
@@ -438,6 +443,8 @@ fn extract_backend_choice_from_env() -> &'static str {
 
     if firecrawl_direct_config_present() || firecrawl_managed_config_present() {
         "firecrawl"
+    } else if env_present_nonempty("EXA_API_KEY") {
+        "exa"
     } else if env_present_nonempty("TAVILY_API_KEY") {
         "tavily"
     } else if env_present_nonempty("PARALLEL_API_KEY") {

--- a/crates/hermes-tools/src/backends/web/web_search_env_tests.rs
+++ b/crates/hermes-tools/src/backends/web/web_search_env_tests.rs
@@ -13,6 +13,7 @@ mod web_search_env_tests {
             let g = test_lock::lock();
             let keys = [
                 "EXA_API_KEY",
+                "EXA_BASE_URL",
                 "TAVILY_API_KEY",
                 "TAVILY_BASE_URL",
                 "FIRECRAWL_API_KEY",
@@ -122,6 +123,17 @@ mod web_search_env_tests {
         std::env::set_var("EXA_API_KEY", "exa-key");
         std::env::set_var("TAVILY_API_KEY", "tavily-key");
         assert_eq!(search_backend_choice_from_env(), "exa");
+    }
+
+    #[test]
+    fn exa_from_env_honors_base_url_for_search_and_extract() {
+        let _scope = EnvScope::new();
+        std::env::set_var("EXA_API_KEY", "exa-key");
+        std::env::set_var("EXA_BASE_URL", "https://proxy.example.com/exa/");
+        let search = ExaSearchBackend::from_env().expect("exa search backend");
+        let extract = ExaExtractBackend::from_env().expect("exa extract backend");
+        assert_eq!(search.base_url(), "https://proxy.example.com/exa");
+        assert_eq!(extract.base_url(), "https://proxy.example.com/exa");
     }
 
     #[test]
@@ -356,6 +368,13 @@ mod web_search_env_tests {
     }
 
     #[test]
+    fn extract_backend_choice_uses_exa_key_when_present() {
+        let _scope = EnvScope::new();
+        std::env::set_var("EXA_API_KEY", "exa-key");
+        assert_eq!(extract_backend_choice_from_env(), "exa");
+    }
+
+    #[test]
     fn extract_backend_choice_uses_parallel_key_when_present() {
         let _scope = EnvScope::new();
         std::env::set_var("PARALLEL_API_KEY", "parallel-key");
@@ -363,12 +382,14 @@ mod web_search_env_tests {
     }
 
     #[test]
-    fn extract_backend_choice_accepts_explicit_simple_and_parallel() {
+    fn extract_backend_choice_accepts_explicit_simple_parallel_and_exa() {
         let _scope = EnvScope::new();
         std::env::set_var("HERMES_WEB_EXTRACT_BACKEND", "simple");
         assert_eq!(extract_backend_choice_from_env(), "simple");
         std::env::set_var("HERMES_WEB_EXTRACT_BACKEND", "parallel");
         assert_eq!(extract_backend_choice_from_env(), "parallel");
+        std::env::set_var("HERMES_WEB_EXTRACT_BACKEND", "exa");
+        assert_eq!(extract_backend_choice_from_env(), "exa");
     }
 
     #[test]
@@ -376,6 +397,13 @@ mod web_search_env_tests {
         let _scope = EnvScope::new();
         std::env::set_var("HERMES_WEB_BACKEND", "ddgs");
         assert_eq!(extract_backend_choice_from_env(), "search-only:ddgs");
+    }
+
+    #[test]
+    fn extract_backend_choice_honors_generic_exa_backend() {
+        let _scope = EnvScope::new();
+        std::env::set_var("HERMES_WEB_BACKEND", "exa");
+        assert_eq!(extract_backend_choice_from_env(), "exa");
     }
 
     #[test]
@@ -520,6 +548,63 @@ mod web_search_env_tests {
         assert_eq!(docs.len(), 2);
         assert_eq!(docs[0]["content"], "body");
         assert_eq!(docs[1]["error"], "blocked");
+    }
+
+    #[test]
+    fn normalize_exa_documents_maps_results_errors_and_empty_fallback() {
+        let docs = normalize_exa_documents(
+            &json!({
+                "results": [{"url": "https://docs.example.com/page", "title": "Docs", "text": "body"}],
+                "errors": [{"url": "https://bad.example", "message": "blocked"}]
+            }),
+            &["https://docs.example.com/page"],
+        );
+        assert_eq!(docs.len(), 2);
+        assert_eq!(docs[0]["content"], "body");
+        assert_eq!(docs[0]["raw_content"], "body");
+        assert_eq!(docs[1]["error"], "blocked");
+
+        let fallback = normalize_exa_documents(&json!({}), &["https://missing.example"]);
+        assert_eq!(fallback.len(), 1);
+        assert_eq!(
+            fallback[0]["error"],
+            "extraction failed (no content returned)"
+        );
+    }
+
+    #[tokio::test]
+    async fn exa_keyed_extract_posts_contents_payload() {
+        use wiremock::matchers::{body_partial_json, header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/contents"))
+            .and(header("x-api-key", "exa-key"))
+            .and(body_partial_json(json!({
+                "ids": ["https://docs.example.com/page"],
+                "text": true,
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "results": [{
+                    "url": "https://docs.example.com/page",
+                    "title": "Docs",
+                    "text": "official content"
+                }]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let backend = ExaExtractBackend::with_base_url("exa-key".to_string(), server.uri());
+        let out = backend
+            .extract("https://docs.example.com/page", false)
+            .await
+            .expect("exa extract");
+        let json: Value = serde_json::from_str(&out).expect("json output");
+        assert_eq!(json["provider"], "exa");
+        assert_eq!(json["content"], "official content");
+        assert_eq!(json["results"][0]["title"], "Docs");
     }
 
     #[tokio::test]

--- a/crates/hermes-tools/src/lib.rs
+++ b/crates/hermes-tools/src/lib.rs
@@ -156,7 +156,7 @@ pub use backends::video_gen::{
 pub use backends::vision::OpenAiVisionBackend;
 pub use backends::web::{
     crawl_backend_from_env_or_fallback, extract_backend_from_env_or_fallback,
-    search_backend_from_env_or_fallback, ExaSearchBackend, FallbackCrawlBackend,
+    search_backend_from_env_or_fallback, ExaExtractBackend, ExaSearchBackend, FallbackCrawlBackend,
     FallbackSearchBackend, FirecrawlExtractBackend, FirecrawlSearchBackend, SimpleExtractBackend,
     TavilyCrawlBackend, TavilyExtractBackend, TavilySearchBackend, XaiWebSearchBackend,
 };

--- a/docs/parity/adapter-feature-matrix.json
+++ b/docs/parity/adapter-feature-matrix.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-07-04T06:47:43.270955+00:00",
+  "generated_at_utc": "2026-07-07T21:51:23.676108+00:00",
   "items": [
     {
       "category": "memory_plugin",

--- a/docs/parity/adapter-feature-matrix.md
+++ b/docs/parity/adapter-feature-matrix.md
@@ -1,6 +1,6 @@
 # Adapter Feature Matrix
 
-Generated: `2026-07-04T06:47:43.270955+00:00`
+Generated: `2026-07-07T21:51:23.676108+00:00`
 
 | Category | Name | Feature Flag | Status |
 | --- | --- | --- | --- |

--- a/docs/parity/divergence-validation.json
+++ b/docs/parity/divergence-validation.json
@@ -1,6 +1,6 @@
 {
   "divergence_file": "/Volumes/wd_black/hermes-agent-ultra/repo/docs/parity/intentional-divergence.json",
-  "generated_at_utc": "2026-07-04T06:47:44.366771+00:00",
+  "generated_at_utc": "2026-07-07T21:51:24.786179+00:00",
   "items": [
     {
       "errors": [],
@@ -217,7 +217,7 @@
       "errors": [],
       "id": "rust-cli-tui-primary-ux-surface",
       "last_reviewed": "2026-07-02",
-      "matched_files": 1273,
+      "matched_files": 1278,
       "matched_sample": [
         "ui-tui/.gitignore",
         "ui-tui/.prettierrc",
@@ -297,10 +297,10 @@
   "summary": {
     "errors": 0,
     "items": 13,
-    "local_paths": 4064,
+    "local_paths": 4072,
     "review_overdue": 0,
     "unowned": 0,
-    "upstream_paths": 6057,
+    "upstream_paths": 6159,
     "warnings": 1
   }
 }

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -58,7 +58,7 @@
         "status": "pass"
       },
       {
-        "actual": 3319.0,
+        "actual": 3422.0,
         "limit": 2600,
         "metric": "max_files_only_upstream",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-07-04T06:47:45.918725+00:00",
+  "generated_at_utc": "2026-07-07T21:51:26.217875+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -273,7 +273,7 @@
     "max_deep_problem_solving_regressions": 0.0,
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
-    "max_files_only_upstream": 3319.0,
+    "max_files_only_upstream": 3422.0,
     "max_queue_pending_commits": 0.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
@@ -298,7 +298,7 @@
   },
   "queue_summary": {
     "by_disposition": {
-      "superseded": 1
+      "ported": 1
     },
     "by_target_ticket": {
       "20": 1
@@ -508,22 +508,22 @@
       "pass": true
     },
     "summary": {
-      "coverage_manifest_entries": 460,
-      "coverage_manifest_entries_with_valid_rust_tests": 460,
-      "covered_behavior_rows": 470,
+      "coverage_manifest_entries": 467,
+      "coverage_manifest_entries_with_valid_rust_tests": 467,
+      "covered_behavior_rows": 477,
       "divergence_errors": 0,
       "divergence_review_overdue": 0,
       "divergence_unowned": 0,
       "missing_rust_test_refs": 0,
       "queue_pending": 0,
       "queue_total": 1,
-      "rust_test_files": 418,
-      "rust_test_functions": 7270,
+      "rust_test_files": 422,
+      "rust_test_functions": 7391,
       "test_intent_mapping_ratio": 1.0,
       "test_intents_mapped": 10,
       "test_intents_total": 10,
       "tracked_behavior_coverage_ratio": 1.0,
-      "tracked_behavior_rows": 470
+      "tracked_behavior_rows": 477
     }
   },
   "ws_legacy_states": {

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-07-04T06:47:45.918725+00:00`
+Generated: `2026-07-07T21:51:26.217875+00:00`
 
 ## Gate Status
 
@@ -15,7 +15,7 @@ Generated: `2026-07-04T06:47:45.918725+00:00`
 | --- | ---: |
 | `max_commits_behind` | 1.0 |
 | `max_upstream_patch_missing` | 1.0 |
-| `max_files_only_upstream` | 3319.0 |
+| `max_files_only_upstream` | 3422.0 |
 | `max_unowned_divergences` | 0.0 |
 | `max_divergence_review_overdue` | 0.0 |
 | `min_test_intent_mapping_ratio` | 1.0 |

--- a/docs/parity/hermes-cli-test-coverage.json
+++ b/docs/parity/hermes-cli-test-coverage.json
@@ -2222,6 +2222,29 @@
     {
       "coverage_kind": "rust_contract_or_documented_divergence",
       "coverage_tags": [
+        "model/provider/context_display"
+      ],
+      "path": "tests/hermes_cli/test_model_switch_context_display.py",
+      "rationale": "Upstream Python hermes_cli test intent is covered by the listed Rust unit/contract tests for the equivalent Rust-first CLI, config, provider, gateway, or tool surface.",
+      "rust_tests": [
+        {
+          "file": "crates/hermes-cli/src/commands/command_tests.rs",
+          "name": "resolve_model_capabilities_uses_codex_oauth_display_context_cap"
+        },
+        {
+          "file": "crates/hermes-cli/src/commands/command_tests.rs",
+          "name": "resolve_model_capabilities_uses_custom_provider_context_override"
+        },
+        {
+          "file": "crates/hermes-cli/src/commands/command_tests.rs",
+          "name": "model_meets_requirements_checks_tools_vision_reasoning_and_context"
+        }
+      ],
+      "status": "covered_by_rust_contracts"
+    },
+    {
+      "coverage_kind": "rust_contract_or_documented_divergence",
+      "coverage_tags": [
         "model/provider/models_dev"
       ],
       "path": "tests/hermes_cli/test_model_switch_custom_providers.py",
@@ -3040,6 +3063,33 @@
         {
           "file": "crates/hermes-cli/src/app.rs",
           "name": "test_persist_session_snapshot_prunes_old_files_by_count_limit"
+        }
+      ],
+      "status": "covered_by_rust_contracts"
+    },
+    {
+      "coverage_kind": "rust_contract_or_documented_divergence",
+      "coverage_tags": [
+        "session/delete/prune"
+      ],
+      "path": "tests/hermes_cli/test_sessions_delete.py",
+      "rationale": "Upstream Python hermes_cli test intent is covered by the listed Rust unit/contract tests for the equivalent Rust-first CLI, config, provider, gateway, or tool surface.",
+      "rust_tests": [
+        {
+          "file": "crates/hermes-cli/src/commands/command_tests.rs",
+          "name": "cli_sessions_delete_resolves_unique_prefix_and_removes_snapshot"
+        },
+        {
+          "file": "crates/hermes-cli/src/commands/command_tests.rs",
+          "name": "cli_sessions_prune_uses_90_day_default_and_source_all_ages"
+        },
+        {
+          "file": "crates/hermes-cli/src/commands/command_tests.rs",
+          "name": "cli_sessions_prune_filters_source_and_renders_preview_bounds"
+        },
+        {
+          "file": "crates/hermes-cli/src/commands/command_tests.rs",
+          "name": "cli_sessions_confirmation_treats_eof_or_empty_input_as_cancelled"
         }
       ],
       "status": "covered_by_rust_contracts"
@@ -4436,7 +4486,7 @@
   "schema_version": 1,
   "source_backlog": "docs/parity/shared-diff-backlog.json",
   "summary": {
-    "covered_paths": 124,
+    "covered_paths": 126,
     "guard_test": "crates/hermes-source-parity-tests/tests/hermes_cli_test_coverage_contract.rs",
     "provider_api_mode_bridge_added": true,
     "required_backlog_classification_path": "tests/hermes_cli"

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,30 +1,30 @@
 {
-  "generated_at_utc": "2026-07-04T06:47:41.384014+00:00",
+  "generated_at_utc": "2026-07-07T21:51:21.663142+00:00",
   "refs": {
     "local_ref": "HEAD",
-    "local_sha": "c905df14be39b3f43623d2ec17f98c587ea97a83",
+    "local_sha": "8c58db72e5e53c349a77cd59efe3e5b86b001adf",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "5445e42b87b9918d5b1bfa9f4eadd8e4bb10ff37",
+    "upstream_sha": "5e51b123f32b7f6a51fbd5759e89ba5146ce4003",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 1,
-    "commits_ahead": 1326,
+    "commits_ahead": 1334,
     "upstream_patch_missing": 1,
     "upstream_patch_represented": 0,
-    "local_patch_unique": 1063,
-    "files_only_upstream": 3319,
-    "files_only_local": 1326,
-    "files_shared_identical": 1470,
-    "files_shared_different": 1268,
-    "tree_files_changed": 5811,
-    "tree_insertions": 1317915,
-    "tree_deletions": 596164
+    "local_patch_unique": 1068,
+    "files_only_upstream": 3422,
+    "files_only_local": 1335,
+    "files_shared_identical": 1458,
+    "files_shared_different": 1279,
+    "tree_files_changed": 5934,
+    "tree_insertions": 1360345,
+    "tree_deletions": 602812
   },
   "top_upstream_only": [
     {
       "path": "apps/desktop",
-      "count": 829
+      "count": 833
     },
     {
       "path": "website/i18n",
@@ -32,23 +32,23 @@
     },
     {
       "path": "tests/hermes_cli",
-      "count": 217
+      "count": 227
     },
     {
       "path": "tests/gateway",
-      "count": 200
+      "count": 221
     },
     {
       "path": "tests/agent",
-      "count": 144
+      "count": 152
     },
     {
       "path": "web/src",
-      "count": 109
+      "count": 110
     },
     {
       "path": "tests/tools",
-      "count": 88
+      "count": 101
     },
     {
       "path": "optional-skills/creative",
@@ -60,11 +60,11 @@
     },
     {
       "path": "website/docs",
-      "count": 57
+      "count": 61
     },
     {
       "path": "tests/plugins",
-      "count": 56
+      "count": 59
     },
     {
       "path": "ui-tui/src",
@@ -72,7 +72,7 @@
     },
     {
       "path": "tests/run_agent",
-      "count": 45
+      "count": 48
     },
     {
       "path": "plugins/platforms",
@@ -88,7 +88,7 @@
     },
     {
       "path": "tests/cli",
-      "count": 32
+      "count": 33
     },
     {
       "path": "gateway/platforms",
@@ -100,7 +100,7 @@
     },
     {
       "path": "tests/tui_gateway",
-      "count": 17
+      "count": 18
     },
     {
       "path": ".github/workflows",
@@ -108,7 +108,7 @@
     },
     {
       "path": "tests/cron",
-      "count": 13
+      "count": 14
     },
     {
       "path": "website/static",
@@ -116,6 +116,10 @@
     },
     {
       "path": "hermes_cli/dashboard_auth",
+      "count": 12
+    },
+    {
+      "path": "scripts/whatsapp-bridge",
       "count": 12
     },
     {
@@ -147,10 +151,6 @@
       "count": 11
     },
     {
-      "path": "scripts/whatsapp-bridge",
-      "count": 10
-    },
-    {
       "path": "docker/s6-rc.d",
       "count": 9
     },
@@ -167,6 +167,10 @@
       "count": 7
     },
     {
+      "path": "agent/secret_sources",
+      "count": 6
+    },
+    {
       "path": "gateway/relay",
       "count": 6
     },
@@ -177,10 +181,6 @@
     {
       "path": "apps/shared",
       "count": 5
-    },
-    {
-      "path": "plugins/cron_providers",
-      "count": 5
     }
   ],
   "top_shared_different": [
@@ -190,15 +190,15 @@
     },
     {
       "path": "website/docs",
-      "count": 183
+      "count": 182
     },
     {
       "path": "tests/tools",
-      "count": 165
+      "count": 166
     },
     {
       "path": "tests/hermes_cli",
-      "count": 142
+      "count": 144
     },
     {
       "path": "ui-tui/src",
@@ -206,7 +206,7 @@
     },
     {
       "path": "tests/agent",
-      "count": 67
+      "count": 68
     },
     {
       "path": "tests/run_agent",
@@ -222,7 +222,7 @@
     },
     {
       "path": "plugins/memory",
-      "count": 21
+      "count": 22
     },
     {
       "path": "plugins/platforms",
@@ -249,12 +249,12 @@
       "count": 9
     },
     {
-      "path": "tests/acp",
+      "path": "plugins/web",
       "count": 9
     },
     {
-      "path": "plugins/web",
-      "count": 6
+      "path": "tests/acp",
+      "count": 9
     },
     {
       "path": "skills/productivity",
@@ -265,7 +265,15 @@
       "count": 6
     },
     {
+      "path": "tests/integration",
+      "count": 6
+    },
+    {
       "path": "tests/skills",
+      "count": 6
+    },
+    {
+      "path": "tests/stress",
       "count": 6
     },
     {
@@ -274,10 +282,6 @@
     },
     {
       "path": "tests/honcho_plugin",
-      "count": 5
-    },
-    {
-      "path": "tests/stress",
       "count": 5
     },
     {
@@ -290,10 +294,6 @@
     },
     {
       "path": "plugins/image_gen",
-      "count": 4
-    },
-    {
-      "path": "tests/integration",
       "count": 4
     },
     {
@@ -356,7 +356,7 @@
     },
     {
       "path": "crates/hermes-tools",
-      "count": 121
+      "count": 123
     },
     {
       "path": "crates/hermes-gateway",
@@ -384,7 +384,7 @@
     },
     {
       "path": "website/docs",
-      "count": 25
+      "count": 26
     },
     {
       "path": "crates/hermes-acp",
@@ -510,7 +510,7 @@
   "top_missing_from_local": [
     {
       "path": "apps/desktop",
-      "count": 829
+      "count": 833
     },
     {
       "path": "website/i18n",
@@ -518,23 +518,23 @@
     },
     {
       "path": "tests/hermes_cli",
-      "count": 217
+      "count": 227
     },
     {
       "path": "tests/gateway",
-      "count": 200
+      "count": 221
     },
     {
       "path": "tests/agent",
-      "count": 144
+      "count": 152
     },
     {
       "path": "web/src",
-      "count": 109
+      "count": 110
     },
     {
       "path": "tests/tools",
-      "count": 88
+      "count": 101
     },
     {
       "path": "optional-skills/creative",
@@ -546,11 +546,11 @@
     },
     {
       "path": "website/docs",
-      "count": 57
+      "count": 61
     },
     {
       "path": "tests/plugins",
-      "count": 56
+      "count": 59
     },
     {
       "path": "ui-tui/src",
@@ -558,7 +558,7 @@
     },
     {
       "path": "tests/run_agent",
-      "count": 45
+      "count": 48
     },
     {
       "path": "plugins/platforms",
@@ -574,7 +574,7 @@
     },
     {
       "path": "tests/cli",
-      "count": 32
+      "count": 33
     },
     {
       "path": "gateway/platforms",
@@ -586,7 +586,7 @@
     },
     {
       "path": "tests/tui_gateway",
-      "count": 17
+      "count": 18
     },
     {
       "path": ".github/workflows",
@@ -594,7 +594,7 @@
     },
     {
       "path": "tests/cron",
-      "count": 13
+      "count": 14
     },
     {
       "path": "website/static",
@@ -602,6 +602,10 @@
     },
     {
       "path": "hermes_cli/dashboard_auth",
+      "count": 12
+    },
+    {
+      "path": "scripts/whatsapp-bridge",
       "count": 12
     },
     {
@@ -633,10 +637,6 @@
       "count": 11
     },
     {
-      "path": "scripts/whatsapp-bridge",
-      "count": 10
-    },
-    {
       "path": "docker/s6-rc.d",
       "count": 9
     },
@@ -653,6 +653,10 @@
       "count": 7
     },
     {
+      "path": "agent/secret_sources",
+      "count": 6
+    },
+    {
       "path": "gateway/relay",
       "count": 6
     },
@@ -662,10 +666,6 @@
     },
     {
       "path": "apps/shared",
-      "count": 5
-    },
-    {
-      "path": "plugins/cron_providers",
       "count": 5
     }
   ],
@@ -680,7 +680,7 @@
     },
     {
       "path": "crates/hermes-tools",
-      "count": 121
+      "count": 123
     },
     {
       "path": "crates/hermes-gateway",
@@ -708,7 +708,7 @@
     },
     {
       "path": "website/docs",
-      "count": 25
+      "count": 26
     },
     {
       "path": "crates/hermes-acp",
@@ -836,9 +836,9 @@
       "workstream": "WS6",
       "issue": 10,
       "name": "Tests and CI parity",
-      "upstream_only": 928,
-      "shared_different": 791,
-      "local_only": 42,
+      "upstream_only": 1004,
+      "shared_different": 798,
+      "local_only": 43,
       "risk": "critical",
       "effort": "XL"
     },
@@ -846,9 +846,9 @@
       "workstream": "WS8",
       "issue": 12,
       "name": "Compatibility and divergence policy",
-      "upstream_only": 1404,
+      "upstream_only": 1421,
       "shared_different": 12,
-      "local_only": 452,
+      "local_only": 454,
       "risk": "critical",
       "effort": "XL"
     },
@@ -856,9 +856,9 @@
       "workstream": "WS5",
       "issue": 9,
       "name": "UX parity",
-      "upstream_only": 582,
-      "shared_different": 329,
-      "local_only": 133,
+      "upstream_only": 587,
+      "shared_different": 328,
+      "local_only": 137,
       "risk": "high",
       "effort": "XL"
     },
@@ -866,9 +866,9 @@
       "workstream": "WS3",
       "issue": 7,
       "name": "Tools and adapters parity",
-      "upstream_only": 178,
-      "shared_different": 98,
-      "local_only": 159,
+      "upstream_only": 180,
+      "shared_different": 102,
+      "local_only": 161,
       "risk": "high",
       "effort": "L"
     },
@@ -877,7 +877,7 @@
       "issue": 8,
       "name": "Skills parity",
       "upstream_only": 157,
-      "shared_different": 38,
+      "shared_different": 39,
       "local_only": 123,
       "risk": "medium",
       "effort": "L"
@@ -886,7 +886,7 @@
       "workstream": "WS2",
       "issue": 6,
       "name": "Core runtime parity",
-      "upstream_only": 70,
+      "upstream_only": 73,
       "shared_different": 0,
       "local_only": 412,
       "risk": "critical",
@@ -906,10 +906,10 @@
   "commit_mapping": {
     "upstream_patch_missing": 1,
     "upstream_patch_represented": 0,
-    "local_patch_unique": 1063,
+    "local_patch_unique": 1068,
     "local_patch_equivalent_to_upstream": 0,
     "upstream_patch_missing_sample": [
-      "5445e42b87b9918d5b1bfa9f4eadd8e4bb10ff37"
+      "5e51b123f32b7f6a51fbd5759e89ba5146ce4003"
     ],
     "upstream_patch_represented_sample": [],
     "local_patch_unique_sample": [
@@ -936,7 +936,7 @@
     ],
     "local_patch_equivalent_sample": [],
     "intentional_divergence_items": 13,
-    "intentional_divergence_covered_files": 1338
+    "intentional_divergence_covered_files": 1344
   },
   "intentional_divergence": [
     {
@@ -981,7 +981,7 @@
       "status": "approved",
       "workstream": "WS4",
       "summary": "Track upstream skills and optional-skills catalogs via parity audits while keeping Rust runtime skill loading externalized (no direct Python skill-tree vendoring).",
-      "matched_files": 318,
+      "matched_files": 319,
       "matched_sample": [
         "optional-skills/autonomous-ai-agents/honcho/SKILL.md",
         "optional-skills/creative/DESCRIPTION.md",
@@ -1103,7 +1103,7 @@
       "status": "approved",
       "workstream": "WS5",
       "summary": "Treat Rust CLI/TUI and gateway as primary UX surface; upstream web/ui-tui trees are tracked as intentional divergence unless explicitly ported.",
-      "matched_files": 933,
+      "matched_files": 938,
       "matched_sample": [
         "ui-tui/README.md",
         "ui-tui/babel.compiler.config.cjs",

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,11 +1,11 @@
 # Parity Matrix
 
-Generated: `2026-07-04T06:47:41.384014+00:00`
+Generated: `2026-07-07T21:51:21.663142+00:00`
 
 ## Scope
 
-- Local ref: `HEAD` (`c905df14be39b3f43623d2ec17f98c587ea97a83`)
-- Upstream ref: `upstream/main` (`5445e42b87b9918d5b1bfa9f4eadd8e4bb10ff37`)
+- Local ref: `HEAD` (`8c58db72e5e53c349a77cd59efe3e5b86b001adf`)
+- Upstream ref: `upstream/main` (`5e51b123f32b7f6a51fbd5759e89ba5146ce4003`)
 - Merge base: `none (history divergence)`
 
 ## Summary
@@ -13,46 +13,47 @@ Generated: `2026-07-04T06:47:41.384014+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 1 |
-| Commits ahead local (`local` ancestry only) | 1326 |
+| Commits ahead local (`local` ancestry only) | 1334 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 1 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 0 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 1063 |
-| Files only in upstream tree | 3319 |
-| Files only in local tree | 1326 |
-| Shared files identical content | 1470 |
-| Shared files different content | 1268 |
-| Total files changed (`local` vs `upstream`) | 5811 |
-| Insertions (`local` vs `upstream`) | 1317915 |
-| Deletions (`local` vs `upstream`) | 596164 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 1068 |
+| Files only in upstream tree | 3422 |
+| Files only in local tree | 1335 |
+| Shared files identical content | 1458 |
+| Shared files different content | 1279 |
+| Total files changed (`local` vs `upstream`) | 5934 |
+| Insertions (`local` vs `upstream`) | 1360345 |
+| Deletions (`local` vs `upstream`) | 602812 |
 
 ## Top 40 upstream-only buckets
 
 | Bucket | Files |
 | --- | ---: |
-| `apps/desktop` | 829 |
+| `apps/desktop` | 833 |
 | `website/i18n` | 313 |
-| `tests/hermes_cli` | 217 |
-| `tests/gateway` | 200 |
-| `tests/agent` | 144 |
-| `web/src` | 109 |
-| `tests/tools` | 88 |
+| `tests/hermes_cli` | 227 |
+| `tests/gateway` | 221 |
+| `tests/agent` | 152 |
+| `web/src` | 110 |
+| `tests/tools` | 101 |
 | `optional-skills/creative` | 70 |
 | `optional-skills/security` | 65 |
-| `website/docs` | 57 |
-| `tests/plugins` | 56 |
+| `website/docs` | 61 |
+| `tests/plugins` | 59 |
 | `ui-tui/src` | 55 |
-| `tests/run_agent` | 45 |
+| `tests/run_agent` | 48 |
 | `plugins/platforms` | 41 |
 | `apps/bootstrap-installer` | 40 |
 | `hermes_cli/subcommands` | 40 |
-| `tests/cli` | 32 |
+| `tests/cli` | 33 |
 | `gateway/platforms` | 27 |
 | `tests/docker` | 26 |
-| `tests/tui_gateway` | 17 |
+| `tests/tui_gateway` | 18 |
 | `.github/workflows` | 14 |
-| `tests/cron` | 13 |
+| `tests/cron` | 14 |
 | `website/static` | 13 |
 | `hermes_cli/dashboard_auth` | 12 |
+| `scripts/whatsapp-bridge` | 12 |
 | `ui-tui/packages` | 12 |
 | `agent/lsp` | 11 |
 | `agent/pet` | 11 |
@@ -60,48 +61,47 @@ Generated: `2026-07-04T06:47:41.384014+00:00`
 | `optional-skills/mlops` | 11 |
 | `tools/environments` | 11 |
 | `web/public` | 11 |
-| `scripts/whatsapp-bridge` | 10 |
 | `docker/s6-rc.d` | 9 |
 | `tools/computer_use` | 8 |
 | `.github/pr-screenshots` | 7 |
 | `hermes_cli/proxy` | 7 |
+| `agent/secret_sources` | 6 |
 | `gateway/relay` | 6 |
 | `plugins/security-guidance` | 6 |
 | `apps/shared` | 5 |
-| `plugins/cron_providers` | 5 |
 
 ## Top 40 shared-different buckets
 
 | Bucket | Files |
 | --- | ---: |
 | `tests/gateway` | 206 |
-| `website/docs` | 183 |
-| `tests/tools` | 165 |
-| `tests/hermes_cli` | 142 |
+| `website/docs` | 182 |
+| `tests/tools` | 166 |
+| `tests/hermes_cli` | 144 |
 | `ui-tui/src` | 90 |
-| `tests/agent` | 67 |
+| `tests/agent` | 68 |
 | `tests/run_agent` | 64 |
 | `tests/cli` | 32 |
 | `ui-tui/packages` | 26 |
-| `plugins/memory` | 21 |
+| `plugins/memory` | 22 |
 | `plugins/platforms` | 20 |
 | `plugins/model-providers` | 16 |
 | `tests/plugins` | 16 |
 | `tests/cron` | 11 |
 | `plugins/google_meet` | 10 |
 | `optional-skills/creative` | 9 |
+| `plugins/web` | 9 |
 | `tests/acp` | 9 |
-| `plugins/web` | 6 |
 | `skills/productivity` | 6 |
 | `skills/software-development` | 6 |
+| `tests/integration` | 6 |
 | `tests/skills` | 6 |
+| `tests/stress` | 6 |
 | `plugins/teams_pipeline` | 5 |
 | `tests/honcho_plugin` | 5 |
-| `tests/stress` | 5 |
 | `tests/tui_gateway` | 5 |
 | `website/src` | 5 |
 | `plugins/image_gen` | 4 |
-| `tests/integration` | 4 |
 | `tests/providers` | 4 |
 | `website/scripts` | 4 |
 | `optional-skills/research` | 3 |
@@ -121,14 +121,14 @@ Generated: `2026-07-04T06:47:41.384014+00:00`
 | --- | ---: |
 | `third_party/rustsec-patches` | 190 |
 | `crates/hermes-cli` | 182 |
-| `crates/hermes-tools` | 121 |
+| `crates/hermes-tools` | 123 |
 | `crates/hermes-gateway` | 111 |
 | `crates/hermes-agent` | 107 |
 | `skills/creative` | 70 |
 | `docs/parity` | 56 |
 | `crates/hermes-intelligence` | 40 |
 | `crates/hermes-config` | 30 |
-| `website/docs` | 25 |
+| `website/docs` | 26 |
 | `crates/hermes-acp` | 22 |
 | `crates/hermes-core` | 18 |
 | `crates/hermes-eval` | 16 |
@@ -164,20 +164,20 @@ Generated: `2026-07-04T06:47:41.384014+00:00`
 
 | Workstream | Issue | Name | Upstream-only | Shared-different | Risk | Effort |
 | --- | ---: | --- | ---: | ---: | --- | --- |
-| `WS6` | #10 | Tests and CI parity | 928 | 791 | critical | XL |
-| `WS8` | #12 | Compatibility and divergence policy | 1404 | 12 | critical | XL |
-| `WS5` | #9 | UX parity | 582 | 329 | high | XL |
-| `WS3` | #7 | Tools and adapters parity | 178 | 98 | high | L |
-| `WS4` | #8 | Skills parity | 157 | 38 | medium | L |
-| `WS2` | #6 | Core runtime parity | 70 | 0 | critical | M |
+| `WS6` | #10 | Tests and CI parity | 1004 | 798 | critical | XL |
+| `WS8` | #12 | Compatibility and divergence policy | 1421 | 12 | critical | XL |
+| `WS5` | #9 | UX parity | 587 | 328 | high | XL |
+| `WS3` | #7 | Tools and adapters parity | 180 | 102 | high | L |
+| `WS4` | #8 | Skills parity | 157 | 39 | medium | L |
+| `WS2` | #6 | Core runtime parity | 73 | 0 | critical | M |
 | `WS7` | #11 | Security/secrets/store/webhook parity | 0 | 0 | critical | S |
 
 ## Commit Mapping
 
 - Upstream missing by patch-id: `1`
 - Upstream represented by patch-id: `0`
-- Local unique by patch-id: `1063`
-- Intentional divergence tracked items: `13` (covered files: `1338`)
+- Local unique by patch-id: `1068`
+- Intentional divergence tracked items: `13` (covered files: `1344`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 
 ## Intentional Divergence Registry
@@ -187,14 +187,14 @@ Generated: `2026-07-04T06:47:41.384014+00:00`
 | `ultra-contextlattice-memory-plugin` | approved | WS3 | 2 | Keep ContextLattice native memory plugin and provider discovery in the Rust agent runtime. |
 | `ultra-webhook-queue-backends` | approved | WS7 | 4 | Preserve webhook-driven sync queue worker architecture with sqlite, SQS, and Kafka support. |
 | `ultra-launchd-webhook-lifecycle` | approved | WS7 | 4 | Preserve launchd-based interactive dev lifecycle management for webhook listener and worker. |
-| `rust-skills-catalog-governance` | approved | WS4 | 318 | Track upstream skills and optional-skills catalogs via parity audits while keeping Rust runtime skill loading externalized (no direct Python skill-tree vendoring). |
+| `rust-skills-catalog-governance` | approved | WS4 | 319 | Track upstream skills and optional-skills catalogs via parity audits while keeping Rust runtime skill loading externalized (no direct Python skill-tree vendoring). |
 | `rust-gateway-platform-plugin-parity` | approved | WS3 | 40 | Keep platform adapter parity in the Rust gateway instead of vendoring upstream Python platform-plugin trees. |
 | `rust-chronos-managed-cron-provider` | approved | WS3 | 5 | Own Chronos managed-cron behavior in the Rust cron scheduler and API server instead of vendoring the upstream Python cron plugin. |
 | `rust-runtime-no-raft-platform-plugin` | temporary | WS3 | 3 | Track the upstream Raft Python platform plugin as non-runtime until a Rust-native Raft adapter is scoped. |
 | `upstream-python-plugin-backend-drift-20260527` | temporary | WS3 | 10 | Track upstream Python backend plugin trees that are not yet closed as Rust-native runtime surfaces. |
 | `upstream-s6-plan-doc-archive` | approved | WS7 | 0 | Do not import upstream implementation-plan archive documents unless they change local runtime or release behavior. |
 | `rust-vertex-provider-plugin-parity` | approved | WS3 | 2 | Keep upstream Vertex Python provider plugin files out of the Rust runtime while tracking equivalent Rust provider surfaces. |
-| `rust-cli-tui-primary-ux-surface` | approved | WS5 | 933 | Treat Rust CLI/TUI and gateway as primary UX surface; upstream web/ui-tui trees are tracked as intentional divergence unless explicitly ported. |
+| `rust-cli-tui-primary-ux-surface` | approved | WS5 | 938 | Treat Rust CLI/TUI and gateway as primary UX surface; upstream web/ui-tui trees are tracked as intentional divergence unless explicitly ported. |
 | `rust-memory-provider-plugin-parity` | approved | WS3 | 13 | Keep Honcho and Mem0 memory provider behavior in Rust-native memory/provider surfaces instead of vendoring Python plugin trees. |
 | `rust-image-provider-plugin-parity` | approved | WS5 | 4 | Keep OpenRouter and Krea image generation provider behavior in the Rust image backend instead of vendoring upstream Python plugin trees. |
 

--- a/docs/parity/python-test-suite-coverage.json
+++ b/docs/parity/python-test-suite-coverage.json
@@ -2,7 +2,7 @@
   "generated_at_utc": "2026-07-02T18:14:12Z",
   "source_backlog": "docs/parity/shared-diff-backlog.json",
   "summary": {
-    "covered_paths": 214,
+    "covered_paths": 219,
     "required_backlog_classification_paths": [
       "tests",
       "tests/agent",
@@ -210,6 +210,38 @@
           "name": "test_openrouter_parse_response_with_reasoning"
         }
       ]
+    },
+    {
+      "path": "tests/agent/test_credential_pool_routing.py",
+      "classification_path": "tests/agent",
+      "coverage_tags": [
+        "credential_pool",
+        "rate_limit_recovery",
+        "python_test_suite",
+        "rust_contracts",
+        "tests_agent"
+      ],
+      "rust_tests": [
+        {
+          "file": "crates/hermes-agent/src/agent_loop.rs",
+          "name": "non_cloudcode_multi_key_pool_retries_primary_before_fallback"
+        },
+        {
+          "file": "crates/hermes-agent/src/agent_loop.rs",
+          "name": "single_entry_pool_rate_limit_uses_fallback_without_retry"
+        },
+        {
+          "file": "crates/hermes-agent/src/agent_loop.rs",
+          "name": "cloudcode_rate_limit_uses_fallback_without_pool_retry"
+        },
+        {
+          "file": "crates/hermes-intelligence/src/credential_pool.rs",
+          "name": "test_exhaustion_and_rotation"
+        }
+      ],
+      "status": "covered_by_rust_test_suite_contracts",
+      "coverage_kind": "rust_contract_or_documented_divergence",
+      "rationale": "Upstream Python test intent is covered by the listed Rust unit, integration, or contract tests for the equivalent Rust-first runtime surface; the Python file remains reference-only and is not vendored into runtime."
     },
     {
       "path": "tests/agent/test_crossloop_client_cache.py",
@@ -4200,6 +4232,38 @@
       ]
     },
     {
+      "path": "tests/integration/test_batch_runner.py",
+      "classification_path": "tests/integration",
+      "coverage_tags": [
+        "batch_runner",
+        "checkpoint",
+        "python_test_suite",
+        "rust_contracts",
+        "tests_integration"
+      ],
+      "rust_tests": [
+        {
+          "file": "crates/hermes-intelligence/src/rl.rs",
+          "name": "batch_runner_generates_style_tagged_baseline_responses"
+        },
+        {
+          "file": "crates/hermes-intelligence/src/rl.rs",
+          "name": "batch_dataset_runner_updates_checkpoint_and_resumes_by_index_and_prompt"
+        },
+        {
+          "file": "crates/hermes-intelligence/src/rl.rs",
+          "name": "batch_dataset_runner_persists_atomic_checkpoint_per_batch_and_resumes_from_file"
+        },
+        {
+          "file": "crates/hermes-intelligence/src/rl.rs",
+          "name": "batch_dataset_runner_checkpoint_path_starts_fresh_on_corrupt_or_mismatched_checkpoint"
+        }
+      ],
+      "status": "covered_by_rust_test_suite_contracts",
+      "coverage_kind": "rust_contract_or_documented_divergence",
+      "rationale": "Upstream Python test intent is covered by the listed Rust unit, integration, or contract tests for the equivalent Rust-first runtime surface; the Python file remains reference-only and is not vendored into runtime."
+    },
+    {
       "path": "tests/integration/test_checkpoint_resumption.py",
       "classification_path": "tests/integration",
       "status": "covered_by_rust_test_suite_contracts",
@@ -4324,6 +4388,34 @@
           "name": "contract_reconnect_watcher_restarts_offline_primary_adapter"
         }
       ]
+    },
+    {
+      "path": "tests/integration/test_modal_terminal.py",
+      "classification_path": "tests/integration",
+      "coverage_tags": [
+        "terminal",
+        "modal",
+        "python_test_suite",
+        "rust_contracts",
+        "tests_integration"
+      ],
+      "rust_tests": [
+        {
+          "file": "crates/hermes-tools/src/terminal_requirements.rs",
+          "name": "modal_managed_mode_requires_managed_gateway"
+        },
+        {
+          "file": "crates/hermes-tools/src/terminal_requirements.rs",
+          "name": "modal_direct_mode_requires_direct_credentials"
+        },
+        {
+          "file": "crates/hermes-tools/src/register_builtins.rs",
+          "name": "builtin_registry_registers_terminal_tools_for_managed_modal_surface"
+        }
+      ],
+      "status": "covered_by_rust_test_suite_contracts",
+      "coverage_kind": "rust_contract_or_documented_divergence",
+      "rationale": "Upstream Python test intent is covered by the listed Rust unit, integration, or contract tests for the equivalent Rust-first runtime surface; the Python file remains reference-only and is not vendored into runtime."
     },
     {
       "path": "tests/integration/test_voice_channel_flow.py",
@@ -6340,6 +6432,39 @@
           "name": "gateway_emits_agent_start_and_end_hooks"
         }
       ]
+    },
+    {
+      "path": "tests/stress/test_concurrency_reclaim_race.py",
+      "classification_path": "tests/stress",
+      "coverage_tags": [
+        "kanban",
+        "concurrency",
+        "claim_replay",
+        "python_test_suite",
+        "rust_contracts",
+        "tests_stress"
+      ],
+      "rust_tests": [
+        {
+          "file": "crates/hermes-cli/src/kanban.rs",
+          "name": "add_move_and_archive_flow_works"
+        },
+        {
+          "file": "crates/hermes-cli/src/kanban.rs",
+          "name": "kanban_claim_completion_archive_is_idempotent_under_reclaim_like_replay"
+        },
+        {
+          "file": "crates/hermes-agent/src/sub_agent_orchestrator.rs",
+          "name": "background_request_dispatches_handle_and_emits_completion_callback"
+        },
+        {
+          "file": "crates/hermes-agent/src/sub_agent_orchestrator.rs",
+          "name": "cancel_path_reports_cancelled"
+        }
+      ],
+      "status": "covered_by_rust_test_suite_contracts",
+      "coverage_kind": "rust_contract_or_documented_divergence",
+      "rationale": "Upstream Python test intent is covered by the listed Rust unit, integration, or contract tests for the equivalent Rust-first runtime surface; the Python file remains reference-only and is not vendored into runtime."
     },
     {
       "path": "tests/stress/test_property_fuzzing.py",
@@ -11126,6 +11251,39 @@
           "name": "registry_contract_lists_dispatches_and_wraps_errors_as_json"
         }
       ]
+    },
+    {
+      "path": "tests/tools/test_mcp_dynamic_discovery.py",
+      "classification_path": "tests/tools",
+      "coverage_tags": [
+        "mcp",
+        "dynamic_discovery",
+        "tool_registry",
+        "python_test_suite",
+        "rust_contracts",
+        "tests_tools"
+      ],
+      "rust_tests": [
+        {
+          "file": "crates/hermes-mcp/src/client/tests.rs",
+          "name": "manager_registers_discovered_mcp_tools_as_callable_registry_tools"
+        },
+        {
+          "file": "crates/hermes-tools/src/registry.rs",
+          "name": "test_register_and_dispatch"
+        },
+        {
+          "file": "crates/hermes-tools/src/toolset.rs",
+          "name": "test_default_toolsets_registered"
+        },
+        {
+          "file": "crates/hermes-tools/tests/upstream_core_tool_contracts.rs",
+          "name": "registry_contract_lists_dispatches_and_wraps_errors_as_json"
+        }
+      ],
+      "status": "covered_by_rust_test_suite_contracts",
+      "coverage_kind": "rust_contract_or_documented_divergence",
+      "rationale": "Upstream Python test intent is covered by the listed Rust unit, integration, or contract tests for the equivalent Rust-first runtime surface; the Python file remains reference-only and is not vendored into runtime."
     },
     {
       "path": "tests/tools/test_mcp_empty_error_message.py",

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -1,9 +1,19 @@
 {
   "sha": {
+    "00694b935fb360bf5a93b1d3034a115ec09f08cd": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "00779800f650c8b875f0f9ab6f08fa33531e6494": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
+    },
+    "009b42d008b81c18af39414dded9ecdf06082d93": {
+      "disposition": "superseded",
+      "notes": "Upstream patch mirrors Python interactive prompt payload siblings into Discord content. Rust gateway prompt/approval flows do not depend on discord.py component-only payloads.",
+      "owner": "rust-runtime"
     },
     "00c045b43f30": {
       "disposition": "ported",
@@ -32,10 +42,25 @@
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
+    "018009bc382de86f864e3fa8af3982c2f0aa7bfb": {
+      "disposition": "superseded",
+      "notes": "Upstream Python runtime delta is superseded by Hermes Ultra Rust-native agent/provider/tool architecture and existing deterministic Rust tests; the Python module path is not shipped in the Rust runtime.",
+      "owner": "rust-runtime"
+    },
+    "0198713c3364f7a16603fa684e78671b1392941d": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
+    },
+    "019950560d43f1058d0966b95480d73ed8daf034": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Codex image backend: local/data source images use a Codex-specific raster allowlist; SVG/non-raster inputs are rejected before request.",
+      "owner": "rust-runtime"
+    },
     "02050859f316": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Already ported by Rust session-resume parity work: SessionPersistence resolves compression continuation tips and ACP/session handlers preserve the active session id across load/resume rather than replacing it with a stale compressed parent."
+      "notes": "Already ported by Rust session-resume parity work: SessionPersistence resolves compression continuation tips and ACP/session handlers preserve the active session id across load/resume rather than replacing it with a stale compressed parent.",
+      "owner": "rust-runtime"
     },
     "020ef76cf16b": {
       "disposition": "superseded",
@@ -51,18 +76,18 @@
     },
     "0223ea5f590a": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported on the Rust CLI primary surface: hermes computer-use doctor calls cua-driver health_report and renders permission/preflight checks without requiring the absent Electron desktop panel."
+      "notes": "Ported on the Rust CLI primary surface: hermes computer-use doctor calls cua-driver health_report and renders permission/preflight checks without requiring the absent Electron desktop panel.",
+      "owner": "rust-runtime"
     },
     "0229246ab879b9968c9fcc384d8d5d0add939771": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "027cb649ef80": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust memory fan-out and OpenViking validation: AgentLoop only mirrors built-in memory writes to external providers when the memory tool returns structured JSON with success=true and staged!=true, failing closed for unclear/non-object/non-JSON tool results. OpenViking viking_forget now treats only .abstract.md and .overview.md as generated summaries, so concrete user memory files such as .full.md remain deletable while non-.md sidecars are rejected by the exact-file guard. Focused Rust tests cover the fail-closed gate and URI validation."
+      "notes": "Ported in Rust memory fan-out and OpenViking validation: AgentLoop only mirrors built-in memory writes to external providers when the memory tool returns structured JSON with success=true and staged!=true, failing closed for unclear/non-object/non-JSON tool results. OpenViking viking_forget now treats only .abstract.md and .overview.md as generated summaries, so concrete user memory files such as .full.md remain deletable while non-.md sidecars are rejected by the exact-file guard. Focused Rust tests cover the fail-closed gate and URI validation.",
+      "owner": "rust-runtime"
     },
     "02aad08acf46": {
       "disposition": "superseded",
@@ -80,9 +105,24 @@
       "disposition": "ported",
       "notes": "Rust Telegram status updates already use send_or_update_status with edit-in-place fallback, and gateway tool progress remains quiet for Telegram by default while /verbose can explicitly raise it. Progress/status docs now describe the Rust-native behavior instead of Python heartbeat binding state."
     },
+    "03311abe498da34ab4dbd2402935cf641fce1431": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
+    "03406ae2553e802f11399129c3f376a096bbec4f": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "039fbb41fc2d": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "03bbd37dd7fbef796d2f9d9e8c54ee190d2ccc57": {
+      "disposition": "superseded",
+      "notes": "Upstream Python runtime delta is superseded by Hermes Ultra Rust-native agent/provider/tool architecture and existing deterministic Rust tests; the Python module path is not shipped in the Rust runtime.",
+      "owner": "rust-runtime"
     },
     "03d9a95a74b2": {
       "disposition": "ported",
@@ -101,6 +141,11 @@
     "0441b7f19feb": {
       "disposition": "superseded",
       "notes": "Upstream desktop remote-profile REST routing is superseded by Rust gateway/profile/auth surfaces; Electron connection-config and Python web_server endpoints are not the primary runtime.",
+      "owner": "rust-runtime"
+    },
+    "04639adace67c7765eb14a32c78ae4fb62da7fe6": {
+      "disposition": "superseded",
+      "notes": "Upstream already-installed theme picker flags are confined to the absent Electron desktop app under apps/desktop. Hermes Agent Ultra does not ship that theme marketplace/install picker surface; Rust CLI/gateway/TUI UX is the shipped product boundary, so no Rust runtime port applies.",
       "owner": "rust-runtime"
     },
     "04730f32e7e8": {
@@ -128,6 +173,11 @@
       "disposition": "superseded",
       "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
     },
+    "05ac16778bda321bd4726c17bd7061b110255582": {
+      "disposition": "ported",
+      "notes": "Ported in Rust platform config: PlatformConfig exposes a first-class typing_indicator flag defaulting true, merge/deserialization preserve explicit false, Python-style root platform blocks lift the key under platforms, and tests cover default, explicit-disable, compatibility lift, and JSON/YAML roundtrip behavior. Rust has no generic Python-style keep-typing loop to spawn, so this is the applicable runtime gate contract.",
+      "owner": "rust-runtime"
+    },
     "05b9c84ca4b1": {
       "disposition": "ported",
       "notes": "Ported in Rust Telegram adapter: crates/hermes-gateway/src/platforms/telegram.rs now supports opt-in Bot API 10.1 sendRichMessage with raw rich_message.markdown payloads, legacy fallback, link_preview_options, and feature-gated tests telegram_rich_message_uses_bot_api_10_1_payload_shape / telegram_rich_message_bad_request_falls_back_to_legacy_send.",
@@ -135,8 +185,13 @@
     },
     "05c896cf524991f95c34ce73d2cbe985b5e0558f": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream CI/workflow-only delta is superseded by Hermes Agent Ultra's local Rust-first deterministic gates and PR verification workflow; it does not add or change a shipped Rust runtime behavior. Runtime/install/docker changes remain pending for separate evidence."
+      "notes": "Upstream CI/workflow-only delta is superseded by Hermes Agent Ultra's local Rust-first deterministic gates and PR verification workflow; it does not add or change a shipped Rust runtime behavior. Runtime/install/docker changes remain pending for separate evidence.",
+      "owner": "rust-runtime"
+    },
+    "05ed553c538092904e5e1d61dc9753ac5ea911e4": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
     },
     "061a18300837": {
       "disposition": "superseded",
@@ -148,8 +203,8 @@
     },
     "069011dd0c8f": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream test covers Electron runtime-to-stored notification id resolution, which is absent from the Rust CLI/TUI/gateway session model."
+      "notes": "Upstream test covers Electron runtime-to-stored notification id resolution, which is absent from the Rust CLI/TUI/gateway session model.",
+      "owner": "rust-runtime"
     },
     "069ab40c5f3f": {
       "disposition": "superseded",
@@ -162,8 +217,8 @@
     },
     "06cbc3bae985": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by absent Rust Photon sidecar/runtime: upstream recovers degraded Python Photon streams and sidecar state, but Hermes Ultra has no Photon adapter or sidecar process to patch."
+      "notes": "Superseded by absent Rust Photon sidecar/runtime: upstream recovers degraded Python Photon streams and sidecar state, but Hermes Ultra has no Photon adapter or sidecar process to patch.",
+      "owner": "rust-runtime"
     },
     "06ecc5535c47": {
       "disposition": "superseded",
@@ -171,8 +226,8 @@
     },
     "0768ed3b33e43df7de05c59017c997bb5e2960f5": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Documentation-only upstream delta is superseded by local Rust-first docs/parity/release surfaces; it does not add or change a shipped Rust runtime behavior. Skills/docs/config-mixed items remain pending for separate evidence."
+      "notes": "Documentation-only upstream delta is superseded by local Rust-first docs/parity/release surfaces; it does not add or change a shipped Rust runtime behavior. Skills/docs/config-mixed items remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "0776d1b19cb3": {
       "disposition": "superseded",
@@ -186,9 +241,24 @@
       "disposition": "ported",
       "notes": "Rust OpenAI audio key resolution now consistently uses VOICE_TOOLS_OPENAI_KEY first for transcription and gateway voice STT/TTS, then HERMES_OPENAI_API_KEY, then OPENAI_API_KEY; focused tests cover precedence and schema/error visibility."
     },
+    "086343854dbf723acfc529d2580c260cc3713d0b": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "08b1c44a5330": {
       "disposition": "superseded",
       "notes": "Upstream extends discord.py _bot_task cancellation to generic connect exceptions. The Rust Discord adapter has no Python asyncio bot task to cancel and no discord.py reconnect loop; failed sends surface as typed GatewayError values."
+    },
+    "08be8e5ef7a07e1bce9910b379b6a5fe48f40763": {
+      "disposition": "superseded",
+      "notes": "Upstream Python/Electron /journey timeline UI is superseded by Hermes Ultra Rust SOTA workflow replay and ContextLattice-backed memory/skills evidence surfaces; no Python journey module or desktop star-map runtime is shipped.",
+      "owner": "rust-runtime"
+    },
+    "08c83d055509a8d61bef0b8648df39d136b3e60b": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
     },
     "08d89e7aba14": {
       "disposition": "superseded",
@@ -196,13 +266,13 @@
     },
     "0952acbf4de8": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by absent Rust Photon sidecar: upstream labels Photon CatchUpEvents failures in JavaScript sidecar code that is not present or invoked by Hermes Ultra's Rust gateway."
+      "notes": "Superseded by absent Rust Photon sidecar: upstream labels Photon CatchUpEvents failures in JavaScript sidecar code that is not present or invoked by Hermes Ultra's Rust gateway.",
+      "owner": "rust-runtime"
     },
     "09623b4527351b46c326c998b603d078ee87eb6c": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "09a6a2ddd71d": {
       "disposition": "superseded",
@@ -210,8 +280,8 @@
     },
     "09abbf8a63f8faada154850fd716b23a6dae9ee8": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "09bcf5a9370e": {
       "disposition": "superseded",
@@ -220,6 +290,11 @@
     "09d66037f8f7": {
       "disposition": "ported",
       "notes": "Rust Hindsight append retains send only the pending-turn delta and use the stable session document only when the API advertises append support."
+    },
+    "09dbe76955dd65b102827bdbed48a3d08394e856": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
     },
     "0a2ee71cccbf": {
       "disposition": "ported",
@@ -252,8 +327,8 @@
     },
     "0aea0c365444": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust config writers: atomic_yaml_write and save_config_yaml share YAML sequence-indent normalization so mapping child lists and siblings round-trip consistently. Focused hermes-config tests cover atomic writes and indexed list updates."
+      "notes": "Ported in Rust config writers: atomic_yaml_write and save_config_yaml share YAML sequence-indent normalization so mapping child lists and siblings round-trip consistently. Focused hermes-config tests cover atomic writes and indexed list updates.",
+      "owner": "rust-runtime"
     },
     "0b54a33a3467": {
       "disposition": "ported",
@@ -278,8 +353,8 @@
     },
     "0c190083cd": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Lazy embed renderers/fenced diagrams/alerts are Electron assistant-ui renderer components. Ultra has no apps/desktop renderer surface."
+      "notes": "Lazy embed renderers/fenced diagrams/alerts are Electron assistant-ui renderer components. Ultra has no apps/desktop renderer surface.",
+      "owner": "rust-runtime"
     },
     "0c29cfd1a614": {
       "disposition": "superseded",
@@ -315,8 +390,13 @@
     },
     "0d4cecb35270": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by Rust cron architecture: upstream renames Python plugins/cron to plugins/cron_providers to avoid provider package shadowing. Hermes Ultra cron is crates/hermes-cron plus Rust gateway/api-server integrations and has no Python plugins/cron import path."
+      "notes": "Superseded by Rust cron architecture: upstream renames Python plugins/cron to plugins/cron_providers to avoid provider package shadowing. Hermes Ultra cron is crates/hermes-cron plus Rust gateway/api-server integrations and has no Python plugins/cron import path.",
+      "owner": "rust-runtime"
+    },
+    "0d9ed9214d3682f4d274b8d8e2455261217ebce5": {
+      "disposition": "ported",
+      "notes": "Rust gateway has durable session titles surfaced by /title, /status, /sessions, hooks, and now mirrors Discord thread titles through a PlatformAdapter rename_thread hook when a native thread id is present.",
+      "owner": "rust-runtime"
     },
     "0dc677f0718b": {
       "disposition": "ported",
@@ -328,8 +408,8 @@
     },
     "0e2a5a3206d3543294abd132a8dcf914a5257759": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "0e2e69a71dda": {
       "disposition": "ported",
@@ -337,8 +417,8 @@
     },
     "0e47f68a479aa4de70f588b6bf40f3f5ac3470e0": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust ACP: session.title/session-title RPC updates the live in-memory SessionState title via SessionManager, persists through the existing callback path, emits session_info_update, and makes session/list prefer explicit titles over history-derived titles. This covers runtime-only branched/new sessions before any stored DB row exists."
+      "notes": "Ported in Rust ACP: session.title/session-title RPC updates the live in-memory SessionState title via SessionManager, persists through the existing callback path, emits session_info_update, and makes session/list prefer explicit titles over history-derived titles. This covers runtime-only branched/new sessions before any stored DB row exists.",
+      "owner": "rust-runtime"
     },
     "0e81d2fb71c1": {
       "disposition": "superseded",
@@ -402,6 +482,11 @@
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
+    "11b0be8d15fc18f6a6741317cbb3f197ac7df989": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Matrix sync: pending invite rooms are scheduled as detached, deduped auto-join tasks with a timeout instead of blocking sync_once/gateway readiness. Wiremock test proves sync_once returns before a delayed join finishes and duplicate pending joins only issue one join request.",
+      "owner": "rust-runtime"
+    },
     "11e6dd3c606e": {
       "disposition": "superseded",
       "notes": "Upstream Python release AUTHOR_MAP maintenance is not part of the Rust release pipeline in hermes-agent-ultra."
@@ -423,6 +508,11 @@
       "disposition": "ported",
       "notes": "Rust HindsightConfig accepts both apiKey and snake_case api_key from config.json, with regression coverage for the snake_case path."
     },
+    "1289f12812a9c6a3f3e6fbdf39e39ed7e1b7bd50": {
+      "disposition": "superseded",
+      "notes": "Superseded by Rust-native memory providers: Mem0 and Supermemory use direct reqwest HTTP clients and compiled Rust code, not optional Python SDK imports. There is no runtime SDK lazy-install step to add; Supermemory setup/config activation was strengthened separately in Rust.",
+      "owner": "rust-runtime"
+    },
     "12bbca95ecf4": {
       "disposition": "superseded",
       "notes": "The vendored tinker-atropos Python submodule path is superseded by Rust-native RL environment descriptors for tinker, atropos-compatible, and custom environments plus local run-manager control; no Python submodule is required for runtime registration."
@@ -430,6 +520,11 @@
     "13038dc747aa": {
       "disposition": "ported",
       "notes": "Google Workspace setup parity is represented by skills/productivity/google-workspace/scripts/setup.py with Python 3.9-compatible syntax and local dependency handling documented in the skill body."
+    },
+    "1324add563ca0a90fd4dd8ba07e3a0dd9cf365c6": {
+      "disposition": "ported",
+      "notes": "Ported in Rust image_gen: OpenRouter/Nous model resolution falls back to top-level image_gen.model when provider-scoped model and env are absent.",
+      "owner": "rust-runtime"
     },
     "134643a2fa80": {
       "disposition": "superseded",
@@ -449,13 +544,13 @@
     },
     "13ce8119067ead38cde7ec262f265af6f1c1551f": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "13d4b5fe2f45": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream aligns the Python hindsight-client package version. Rust Hindsight does not import or pin hindsight-client; native HTTP request code implements retain/recall/reflect behavior directly, so there is no Rust dependency version to align."
+      "notes": "Upstream aligns the Python hindsight-client package version. Rust Hindsight does not import or pin hindsight-client; native HTTP request code implements retain/recall/reflect behavior directly, so there is no Rust dependency version to align.",
+      "owner": "rust-runtime"
     },
     "14275d7baa1a": {
       "disposition": "ported",
@@ -469,6 +564,11 @@
     "146e77684b71": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "14baeefe1d0b80e67429ffb47934acc4cd399fd1": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Matrix invite handling: direct invite metadata from invite_state is carried into the detached join request, and successful direct invite joins persist m.direct account data for the inviter/room so future identity classification can use direct-room account state. Focused test covers m.direct append/write behavior.",
+      "owner": "rust-runtime"
     },
     "14fee4f11265": {
       "disposition": "superseded",
@@ -507,6 +607,16 @@
       "disposition": "superseded",
       "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
     },
+    "163cb24d45d83e551d65da74678c191ceabecd5c": {
+      "disposition": "ported",
+      "notes": "Ported in Rust: MoA/quorum fan-out emits structured moa_reference stream events with index/count/model/text for successful reference voters, TUI consumes them as visible reference activity/thinking, and the mixture_of_agents tool returns reference_responses with model labels and content for downstream renderers. Covered by TUI stream-event and MoA tool mock HTTP tests.",
+      "owner": "rust-runtime"
+    },
+    "16414418377ba7ca32fae372726966f81fa9c7ca": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "165b2e481afa": {
       "disposition": "ported",
       "notes": "Rust config/runtime now exposes agent.api_max_retries with apiMaxRetries alias, config patch/display support, HERMES_AGENT_API_MAX_RETRIES env override, and build_agent_config propagation into RetryConfig.max_retries with focused hermes-config/hermes-cli regression coverage."
@@ -527,8 +637,8 @@
     },
     "16aeba17078d5470f21eedb504142554169e748c": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "16beab421f05": {
       "disposition": "superseded",
@@ -553,8 +663,8 @@
     },
     "17dfc6bec4a8b7fd840d479c33e9a7b2449f805d": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "182092c5fdd5": {
       "disposition": "superseded",
@@ -563,6 +673,11 @@
     "183d86b3e04e": {
       "disposition": "ported",
       "notes": "Rust provider profile and model-switch code maps reasoning_effort into provider-specific Gemini/OpenRouter reasoning controls, with regression tests for Gemini thinking levels and OpenRouter reasoning objects."
+    },
+    "184c10cf97002c95b233830d62d6fb355a82708a": {
+      "disposition": "ported",
+      "notes": "Ported in Rust SlackAdapter: startup auth.test health audit warns once when Slack returns user_id without bot_id, preserving the existing group-DM scope audit in a single auth.test call. Unit and wiremock tests cover user-token detection, bot-token suppression, once-only warning, and combined auth.test warning behavior.",
+      "owner": "rust-runtime"
     },
     "187951ec6b88": {
       "disposition": "ported",
@@ -581,9 +696,19 @@
       "notes": "Ported in skills/media/youtube-content: SKILL.md and scripts/fetch_transcript.py already use uv run / uv pip for youtube-transcript-api, matching the upstream helper execution contract.",
       "owner": "skills"
     },
+    "18a9467fca1a750e83c7579ee0cd422c082fd77d": {
+      "disposition": "superseded",
+      "notes": "Upstream Python runtime delta is superseded by Hermes Ultra Rust-native agent/provider/tool architecture and existing deterministic Rust tests; the Python module path is not shipped in the Rust runtime.",
+      "owner": "rust-runtime"
+    },
     "18beb69b4996": {
       "disposition": "superseded",
       "notes": "The embedded Hindsight async-client close fix is Python-only; Rust Hindsight does not start hindsight-embed and uses bounded reqwest clients for HTTP operations."
+    },
+    "18d54bf0fd307e02f1ca3f877bcd8a26651297fc": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
     },
     "18d61bd06e06": {
       "disposition": "ported",
@@ -591,8 +716,8 @@
     },
     "18f7ad49ab25f8f27cc56f9bd80e3e4caeaa1455": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Python/Electron CI or Docker-test orchestration delta is superseded by Hermes Agent Ultra's Rust-first CI surface: the local workflows build/test the Rust workspace, run parity gates, and use the distinct Rust Docker image/entrypoint contracts rather than upstream uv/s6/Electron docker jobs."
+      "notes": "Upstream Python/Electron CI or Docker-test orchestration delta is superseded by Hermes Agent Ultra's Rust-first CI surface: the local workflows build/test the Rust workspace, run parity gates, and use the distinct Rust Docker image/entrypoint contracts rather than upstream uv/s6/Electron docker jobs.",
+      "owner": "rust-runtime"
     },
     "1927ff217e6b": {
       "disposition": "superseded",
@@ -604,8 +729,8 @@
     },
     "19bae1b9e0d32f9ba05830e44ba8c1cdbdb246c8": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "19c07c40379b": {
       "disposition": "ported",
@@ -613,22 +738,27 @@
     },
     "19ca295a846a8a032a01ba5da3d74c827e2e26d4": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "19d4174454624a1ca91bc47b8f2a7ae8c3b4b5d3": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust gateway: /sessions search and /sessions find now route to user-scoped SessionManager search over session title, UUID id, and canonical gateway key with punctuation-normalized matching; missing-query usage and cross-user non-leakage are covered by gateway parser/runtime tests."
+      "notes": "Ported in Rust gateway: /sessions search and /sessions find now route to user-scoped SessionManager search over session title, UUID id, and canonical gateway key with punctuation-normalized matching; missing-query usage and cross-user non-leakage are covered by gateway parser/runtime tests.",
+      "owner": "rust-runtime"
     },
     "19db9cd0760e05dafcd1ae637db946cdd65322ce": {
       "disposition": "ported",
       "notes": "Rust ACP SessionManager now exposes a public lock-protected update_session_meta API with COALESCE-style optional model preservation, merges cwd/provider/api_mode/base_url/config options, routes existing update_cwd/update_model through it, and tests missing-session no-op plus single persist callback behavior."
     },
+    "1a0c5768135c0565712140eba76e1e7d566bedf6": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
+    },
     "1a1e00f37e0f4558dc930b7b0147f01411e02e76": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "1a3cd3d436a1": {
       "disposition": "superseded",
@@ -655,15 +785,25 @@
       "notes": "Upstream desktop OAuth account-removal UI is superseded by Rust provider/auth config surfaces; Electron onboarding/settings UI is outside the Rust-only shipped runtime.",
       "owner": "rust-runtime"
     },
+    "1b3768558e02071b629d1014941ed7b2a0024c34": {
+      "disposition": "ported",
+      "notes": "Ported in Rust image_gen tests/config contract: OpenRouter/Nous model precedence is enforced by provider_config_payloads and covered by focused tests.",
+      "owner": "rust-runtime"
+    },
     "1b70a9184498cd03bb1e2274b3eac4b2635f7835": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Documentation/infographic-only upstream delta is superseded by Hermes Agent Ultra's Rust-first docs/parity/release surfaces for this batch; it does not add or change a shipped Rust runtime behavior. Runtime, provider, platform, and install changes remain pending for separate evidence."
+      "notes": "Documentation/infographic-only upstream delta is superseded by Hermes Agent Ultra's Rust-first docs/parity/release surfaces for this batch; it does not add or change a shipped Rust runtime behavior. Runtime, provider, platform, and install changes remain pending for separate evidence.",
+      "owner": "rust-runtime"
+    },
+    "1b75b3fd90d32e9111607c6331ace49fdc47287a": {
+      "disposition": "ported",
+      "notes": "Ported with a higher-quality Rust Supermemory setup surface: setup now supports hermes memory setup supermemory, persists owner-only supermemory.json, exposes the app.supermemory.ai integration URL plus auto_recall/auto_capture schema knobs, prints a deterministic setup summary, and initialize now actually loads api_key from supermemory.json instead of only env.",
+      "owner": "rust-runtime"
     },
     "1b7b4d138a67": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Slash exec dispatch payload handling targets desktop renderer command dispatch. Rust slash execution is handled directly by CLI/TUI command routing."
+      "notes": "Slash exec dispatch payload handling targets desktop renderer command dispatch. Rust slash execution is handled directly by CLI/TUI command routing.",
+      "owner": "rust-runtime"
     },
     "1b89715e153f": {
       "disposition": "superseded",
@@ -684,8 +824,8 @@
     },
     "1bff85cf664e18579965d1a205e13b5b54679dc5": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "1c0437dfc5bb": {
       "disposition": "superseded",
@@ -693,8 +833,8 @@
     },
     "1c0fa12edb1c33b8c72ff860b6a0276262394cd7": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "1c2189839d0b": {
       "disposition": "superseded",
@@ -702,8 +842,8 @@
     },
     "1c8594b634": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Remote backend update-count display is Electron desktop UI plus Python banner/update tests. Ultra Rust docs now avoid the upstream native desktop installer/update surface."
+      "notes": "Remote backend update-count display is Electron desktop UI plus Python banner/update tests. Ultra Rust docs now avoid the upstream native desktop installer/update surface.",
+      "owner": "rust-runtime"
     },
     "1c909e75e1a0": {
       "disposition": "ported",
@@ -740,10 +880,15 @@
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
+    "1deeaf71abcf84d9f5d4d8255abfd5654a0ed2e1": {
+      "disposition": "ported",
+      "notes": "Discord auto-thread/forum/session title paths now truncate by UTF-16 units, including emoji tests for thread names and native Discord thread-title mirroring.",
+      "owner": "rust-runtime"
+    },
     "1dfcda4e3c19": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust approval guard includes env/config overwrite detection for redirection, tee, and copy/move/install paths; test_sensitive_write_patterns_require_confirmation covers the guard."
+      "notes": "Rust approval guard includes env/config overwrite detection for redirection, tee, and copy/move/install paths; test_sensitive_write_patterns_require_confirmation covers the guard.",
+      "owner": "rust-runtime"
     },
     "1e1ab31ad6c8": {
       "disposition": "superseded",
@@ -766,14 +911,29 @@
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
+    "1f1d346ceda2b133f9bb4f5758e31b6190a211fe": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
+    },
     "1f950e189ce7e68696298dc14ccbcf15a44eb213": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
+    },
+    "1fe013ee16f19f6390f2efce39397447e7ec2f67": {
+      "disposition": "ported",
+      "notes": "Ported/superseded in Rust: /hatch and /generate-pet are first-class slash commands that capture a petdex hatch request, enable the Rust TUI pet, infer known species/mood from the description, persist pet settings, and queue a next-turn companion design brief instead of shipping upstream Electron/Python hatch UI internals. Covered by command tests for species/mood persistence and queued design brief.",
+      "owner": "rust-runtime"
     },
     "1febb0824000": {
       "disposition": "ported",
       "notes": "Rust Anthropic/OpenRouter request shaping covers modern thinking controls and strips unsupported fast-model controls in provider_profiles and provider.rs tests, including test_anthropic_strips_sampling_and_unsupported_fast_controls."
+    },
+    "1ffa01f35fb8bc0bf8825117788092ff0e08421f": {
+      "disposition": "ported",
+      "notes": "Ported with Rust source-contract coverage in crates/hermes-source-parity-tests/tests/windows_subprocess_no_window_contract.rs, proving the std/tokio helper chokepoints exist and key backend subprocess surfaces opt into them.",
+      "owner": "rust-runtime"
     },
     "2057977102da26cbf0fa9e699fa4432dbf017566": {
       "disposition": "ported",
@@ -793,13 +953,18 @@
     },
     "211ba9c7d31d": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust one-shot helper now renders commit-message templates, strips wrapping code fences, runs through the auxiliary client without session mutation, and exposes llm.oneshot over HTTP JSON-RPC with deterministic validation errors. Focused agent and HTTP tests cover template rendering, client usage, and missing-prompt failure."
+      "notes": "Rust one-shot helper now renders commit-message templates, strips wrapping code fences, runs through the auxiliary client without session mutation, and exposes llm.oneshot over HTTP JSON-RPC with deterministic validation errors. Focused agent and HTTP tests cover template rendering, client usage, and missing-prompt failure.",
+      "owner": "rust-runtime"
     },
     "216ace4bf3ce88d142057813970554fff91a8e6a": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
+    },
+    "217b3c283a8277ab8a78bd3bfc52a53f6ddeadf4": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
     },
     "218452b05019": {
       "disposition": "ported",
@@ -820,8 +985,8 @@
     },
     "221cd60242ae": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Already ported in Rust provider controls: ollama-cloud is a known provider and the /reasoning set path applies provider extra_body reasoning effort configuration generically, with tests covering reasoning.effort normalization and clearing without introducing legacy model defaults."
+      "notes": "Already ported in Rust provider controls: ollama-cloud is a known provider and the /reasoning set path applies provider extra_body reasoning effort configuration generically, with tests covering reasoning.effort normalization and clearing without introducing legacy model defaults.",
+      "owner": "rust-runtime"
     },
     "22afa066f838": {
       "disposition": "superseded",
@@ -833,8 +998,8 @@
     },
     "233ef98afe2f156dd916c8f4e7f98d16676de4ee": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream hardens docker/stage2-hook.sh symlink chown behavior. This Rust checkout does not ship docker/stage2-hook.sh, so there is no local stage2 recursive chown surface to port."
+      "notes": "Upstream hardens docker/stage2-hook.sh symlink chown behavior. This Rust checkout does not ship docker/stage2-hook.sh, so there is no local stage2 recursive chown surface to port.",
+      "owner": "rust-runtime"
     },
     "235bfb192b91": {
       "disposition": "superseded",
@@ -846,8 +1011,8 @@
     },
     "236f0597e562": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Floating composer pop-out is Electron desktop UI. Rust TUI composer remains the shipped terminal surface."
+      "notes": "Floating composer pop-out is Electron desktop UI. Rust TUI composer remains the shipped terminal surface.",
+      "owner": "rust-runtime"
     },
     "23c0578bd75d": {
       "disposition": "superseded",
@@ -855,8 +1020,8 @@
     },
     "242962e1f5a0d2a29db7683c01de907369eb2145": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "vLLM/Qwen reasoning guidance is ported to the local provider docs; the upstream cli-config.yaml.example hunk is non-applicable because this Rust repo does not ship that example file."
+      "notes": "vLLM/Qwen reasoning guidance is ported to the local provider docs; the upstream cli-config.yaml.example hunk is non-applicable because this Rust repo does not ship that example file.",
+      "owner": "rust-runtime"
     },
     "242da9db965c": {
       "disposition": "superseded",
@@ -870,10 +1035,20 @@
       "disposition": "ported",
       "notes": "Rust TUI consumes App pending prefill after /rewind or /undo, restoring the rewound prompt into the composer without auto-submitting while App soft-rewinds active session rows."
     },
+    "244a6f2ceb7f58c16b3cb2186584c39524e37874": {
+      "disposition": "superseded",
+      "notes": "Superseded by local Rust-first product shape: upstream fixes an Electron desktop Open setup guide button plus Python web_server route, but this repo has no apps/desktop or shipped Python web_server runtime. Rust CLI/TUI/gateway docs and setup surfaces own plugin setup guidance.",
+      "owner": "rust-runtime"
+    },
+    "249c69b9586567d54dc7bcdeadd221f49aa2d304": {
+      "disposition": "ported",
+      "notes": "Rust gateway DM/pairing authorization is platform-scoped: DmManager keys pending/rate-limited pairing by platform+user, platform allowlists do not cross-authorize, and Discord component auth has approved-pairing fallback tests.",
+      "owner": "rust-runtime"
+    },
     "24a4df9cd11598ec41c0bbb1f85369ff06d234e5": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported by Rust-native table rendering surfaces: Telegram rich-text table detection lives in adapter_impl/rich_text.rs with pipe-table tests, while Discord now has an outbound table-to-bullet formatter with focused tests; no Python helpers.py sharing layer is used in the Rust runtime."
+      "notes": "Ported by Rust-native table rendering surfaces: Telegram rich-text table detection lives in adapter_impl/rich_text.rs with pipe-table tests, while Discord now has an outbound table-to-bullet formatter with focused tests; no Python helpers.py sharing layer is used in the Rust runtime.",
+      "owner": "rust-runtime"
     },
     "24d48ffb8294": {
       "disposition": "superseded",
@@ -881,8 +1056,8 @@
     },
     "24f139e16a6f": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust MCP schema handling normalizes draft-07 definitions to $defs and rewrites #/definitions refs at client intake and server export, with core/client/server tests."
+      "notes": "Rust MCP schema handling normalizes draft-07 definitions to $defs and rewrites #/definitions refs at client intake and server export, with core/client/server tests.",
+      "owner": "rust-runtime"
     },
     "24f74eb88853": {
       "disposition": "superseded",
@@ -900,20 +1075,30 @@
       "disposition": "superseded",
       "notes": "Desktop thinking-disclosure pending state is React rendering state; Rust reasoning capture/display is handled in provider parsing and gateway/TUI status paths."
     },
+    "259e6b87a73911eca0e71a33a81381801364868a": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Teams pipeline: dot-only and separator-only recording names fall back to recording.mp4, with regression coverage.",
+      "owner": "rust-runtime"
+    },
     "25c31cab624e6556af09f8fe693c535578c5e8e5": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
+    },
+    "25c7900fb58239552c530fd6cf8be28e5efbcec4": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
     },
     "25d35cce18cd51f903b8800dcda31950d6190a16": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Documentation/infographic-only upstream delta is superseded by Hermes Agent Ultra's Rust-first docs/parity/release surfaces for this batch; it does not add or change a shipped Rust runtime behavior. Runtime, provider, platform, and install changes remain pending for separate evidence."
+      "notes": "Documentation/infographic-only upstream delta is superseded by Hermes Agent Ultra's Rust-first docs/parity/release surfaces for this batch; it does not add or change a shipped Rust runtime behavior. Runtime, provider, platform, and install changes remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "2609bcccca30": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Spanish README/security/locales translation delta is documentation/i18n only. Ultra does not carry upstream locales/es.yaml, and Rust runtime parity is unaffected."
+      "notes": "Spanish README/security/locales translation delta is documentation/i18n only. Ultra does not carry upstream locales/es.yaml, and Rust runtime parity is unaffected.",
+      "owner": "rust-runtime"
     },
     "263e008d6beb": {
       "disposition": "ported",
@@ -941,6 +1126,11 @@
       "notes": "Superseded by Rust-first Honcho docs/tests surface; no real Telegram UID or named user example is required by the Rust Honcho setup path.",
       "owner": "rust-runtime"
     },
+    "275e293f5431fcac4118d1fcd03bb65f6dd7953e": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
+    },
     "27936ee02dfc": {
       "disposition": "superseded",
       "notes": "Python TUI queued-title retry over auto-title DB state is superseded by Rust gateway user title storage on Session.title, which is not delayed behind DB materialization."
@@ -960,18 +1150,18 @@
     },
     "281a439ad483e6f130c2305a5e932c652778cb3b": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "281b333cc5f048cc37e7b2075bde9c353b9a0496": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "284be6cc247c46aa6e2bf2b1b271a5e7fafb5558": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "288f7026e332": {
       "disposition": "superseded",
@@ -987,6 +1177,11 @@
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
+    "290fa7fd2baaa842856000143bc5028dcedd4185": {
+      "disposition": "ported",
+      "notes": "Ported in Rust DeliveryRouter: confirmed-dead platform targets are persisted under HERMES_HOME/gateway/dead_targets.json after whole-chat Forbidden or chat-level NotFound send failures, skipped on later deliveries to avoid flood-control burn, and thread/topic/message not-found plus transient errors are not marked dead. Focused tests cover persistence, corrupt-store fallback, marking, skipping, and non-dead errors.",
+      "owner": "rust-runtime"
+    },
     "29147afd637d": {
       "disposition": "superseded",
       "notes": "Desktop remote attachment toast copy is React desktop UX only. Rust gateway media limits and send errors are handled in platform adapters."
@@ -1001,18 +1196,23 @@
     },
     "2977e7454377bdb9cb101e4d387e1df7720af8a7": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream CI/workflow-only delta is superseded by Hermes Agent Ultra's local Rust-first deterministic gates and PR verification workflow; it does not add or change a shipped Rust runtime behavior. Runtime/install/docker changes remain pending for separate evidence."
+      "notes": "Upstream CI/workflow-only delta is superseded by Hermes Agent Ultra's local Rust-first deterministic gates and PR verification workflow; it does not add or change a shipped Rust runtime behavior. Runtime/install/docker changes remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "29e5e127c6f1c35fcc67abf0281c50c237e2929f": {
       "disposition": "ported",
       "notes": "Ported in Rust Telegram adapter: TelegramMessage now deserializes Bot API rich_message echoes and parse_update flattens native rich blocks into text when Telegram omits text/caption, with focused rich-reply coverage.",
       "owner": "rust-runtime"
     },
+    "2a14205ff43b81be569427c58dc4191ea33fab52": {
+      "disposition": "ported",
+      "notes": "Rust Mem0 backend/setup now supports self-hosted base URLs without cloud API keys, cloud/self-hosted prompt labels, configurable rerank default false, and focused tests.",
+      "owner": "rust-runtime"
+    },
     "2a4542333ee1": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by absent Rust Photon adapter: upstream modifies the Python Photon plugin sidecar retry/cooldown behavior. Hermes Ultra does not register a Photon platform module; CLI parsing of arbitrary --platform values is not an advertised Photon runtime surface."
+      "notes": "Superseded by absent Rust Photon adapter: upstream modifies the Python Photon plugin sidecar retry/cooldown behavior. Hermes Ultra does not register a Photon platform module; CLI parsing of arbitrary --platform values is not an advertised Photon runtime surface.",
+      "owner": "rust-runtime"
     },
     "2a5d51c16e94": {
       "disposition": "ported",
@@ -1025,13 +1225,23 @@
     },
     "2a75c4a8cb4aaa1f08c0a4fda9a192e52e89cec2": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
+    },
+    "2a84bcb1499005d36f028d430225b2aca1554ac3": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
+    "2acbdd1848b7d48e1471ce39fc296f12300824d4": {
+      "disposition": "superseded",
+      "notes": "Upstream patch mirrors Discord exec approval command into Python interactive message content. Rust approvals are not discord.py view prompts; command display/redaction is handled by hermes-tools approval contracts.",
+      "owner": "rust-runtime"
     },
     "2b08a4295a650d27fc354573ef2dde87dd211103": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Documentation-only upstream delta is superseded by local Rust-first docs/parity/release surfaces; it does not add or change a shipped Rust runtime behavior. Skills/docs/config-mixed items remain pending for separate evidence."
+      "notes": "Documentation-only upstream delta is superseded by local Rust-first docs/parity/release surfaces; it does not add or change a shipped Rust runtime behavior. Skills/docs/config-mixed items remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "2b6345cee302": {
       "disposition": "ported",
@@ -1048,18 +1258,18 @@
     },
     "2bd17221b73190f87f1a4ae09c45515b9637bfb1": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Python/Electron CI or Docker-test orchestration delta is superseded by Hermes Agent Ultra's Rust-first CI surface: the local workflows build/test the Rust workspace, run parity gates, and use the distinct Rust Docker image/entrypoint contracts rather than upstream uv/s6/Electron docker jobs."
+      "notes": "Upstream Python/Electron CI or Docker-test orchestration delta is superseded by Hermes Agent Ultra's Rust-first CI surface: the local workflows build/test the Rust workspace, run parity gates, and use the distinct Rust Docker image/entrypoint contracts rather than upstream uv/s6/Electron docker jobs.",
+      "owner": "rust-runtime"
     },
     "2bd1977d8fad185c9b4be47884f7e87f1add0ce3": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Python v0.17.0 release metadata is superseded by Hermes Agent Ultra Rust release train: workspace version is 0.21.0 and docs/releases/v0.17.0, v0.18.0, v0.18.1, v0.19.0, v0.20.0, and v0.21.0 record the local Rust release lineage."
+      "notes": "Upstream Python v0.17.0 release metadata is superseded by Hermes Agent Ultra Rust release train: workspace version is 0.21.0 and docs/releases/v0.17.0, v0.18.0, v0.18.1, v0.19.0, v0.20.0, and v0.21.0 record the local Rust release lineage.",
+      "owner": "rust-runtime"
     },
     "2c02583c2b19f72b3904481c9d219e325b35ef10": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Krea payload construction: image_url/reference_image_urls are deduplicated, capped at 10, and converted to Krea image_style_references objects with {url, strength: 0.6} instead of invalid bare URL strings; regression tests assert the exact request shape."
+      "notes": "Ported in Rust Krea payload construction: image_url/reference_image_urls are deduplicated, capped at 10, and converted to Krea image_style_references objects with {url, strength: 0.6} instead of invalid bare URL strings; regression tests assert the exact request shape.",
+      "owner": "rust-runtime"
     },
     "2c19208224de": {
       "disposition": "superseded",
@@ -1074,10 +1284,15 @@
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
+    "2d206a3a42429465f6bb99c9425e3f7316273782": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop Electron bundling/native-deps delta is superseded by the local Rust-first distribution: apps/desktop and nix desktop packaging are absent, while Rust installer/Docker/CLI paths own shipped runtime startup.",
+      "owner": "rust-runtime"
+    },
     "2d206a3a4242f2d909f3dd71f0f782032bbab578": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/desktop/dashboard-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, web, or Electron desktop runtime tree, while Rust CLI/TUI/gateway/install paths own the applicable behavior. Mixed Rust/runtime/provider/platform commits remain pending for separate evidence."
+      "notes": "Upstream Electron/desktop/dashboard-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, web, or Electron desktop runtime tree, while Rust CLI/TUI/gateway/install paths own the applicable behavior. Mixed Rust/runtime/provider/platform commits remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "2d232c999115": {
       "disposition": "ported",
@@ -1091,8 +1306,8 @@
     },
     "2d55ff8fcaf3d0f3ac80938437e99af7a9f067ab": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "2d587c56622f": {
       "disposition": "ported",
@@ -1109,8 +1324,8 @@
     },
     "2de7549fe0fe06954dd7b72528ca37953d62ada1": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "2dfcc8087a8e": {
       "disposition": "ported",
@@ -1118,18 +1333,23 @@
     },
     "2dfcead68367": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported on the Rust CLI primary surface: the computer-use doctor path passes include/skip filters through to cua-driver health_report and is platform-neutral for macOS/Windows/Linux."
+      "notes": "Ported on the Rust CLI primary surface: the computer-use doctor path passes include/skip filters through to cua-driver health_report and is platform-neutral for macOS/Windows/Linux.",
+      "owner": "rust-runtime"
     },
     "2e0c9083db84": {
       "disposition": "ported",
       "notes": "Rust PluginManager now exposes tool_request and tool_execution middleware primitives, AgentLoop applies request rewrites before guards/hooks and wraps real tool handler execution with a single-use next_call-equivalent chain. Unit and agent-loop tests cover argument adaptation, execution wrapping, and real autonomous tool execution.",
       "owner": "rust-runtime"
     },
+    "2e12401ed436309b59e813bf9444c8323ef05171": {
+      "disposition": "superseded",
+      "notes": "Upstream Python runtime delta is superseded by Hermes Ultra Rust-native agent/provider/tool architecture and existing deterministic Rust tests; the Python module path is not shipped in the Rust runtime.",
+      "owner": "rust-runtime"
+    },
     "2e322466b1": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Dashboard-auth drain shared bearer plugin is a Python provider plugin without the deferred handler/channel in Ultra. Adding a no-op Rust route would be misleading; no advertised Rust drain surface exists."
+      "notes": "Dashboard-auth drain shared bearer plugin is a Python provider plugin without the deferred handler/channel in Ultra. Adding a no-op Rust route would be misleading; no advertised Rust drain surface exists.",
+      "owner": "rust-runtime"
     },
     "2e3c6627ceac": {
       "disposition": "ported",
@@ -1137,13 +1357,13 @@
     },
     "2e3efce66ebd0a144a0733333e1c0d31d9f65c5d": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "2e779d11a03d": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported the first-class Rust runtime surface for Mem0 v3/self-hosted management: schemas now expose mem0_list, mem0_add, mem0_update, and mem0_delete; legacy mem0_profile/mem0_conclude calls remain accepted; search/list include IDs for management; update/delete validate exact memory IDs and issue PATCH/DELETE requests with fallback endpoint shapes; self-hosted host/base_url mode is supported without empty auth headers. Python OSS setup subprocess and local vector-store provisioning are intentionally not copied into the Rust runtime."
+      "notes": "Ported the first-class Rust runtime surface for Mem0 v3/self-hosted management: schemas now expose mem0_list, mem0_add, mem0_update, and mem0_delete; legacy mem0_profile/mem0_conclude calls remain accepted; search/list include IDs for management; update/delete validate exact memory IDs and issue PATCH/DELETE requests with fallback endpoint shapes; self-hosted host/base_url mode is supported without empty auth headers. Python OSS setup subprocess and local vector-store provisioning are intentionally not copied into the Rust runtime.",
+      "owner": "rust-runtime"
     },
     "2e874ef87926": {
       "disposition": "superseded",
@@ -1151,8 +1371,8 @@
     },
     "2ea94c6c45814862e9ebacf80d8051b58da980f7": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "2ea957fc41f4": {
       "disposition": "ported",
@@ -1161,6 +1381,16 @@
     "2ec8d2b42ffe": {
       "disposition": "superseded",
       "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "2ecb6f7fe60f6a240d632bbd51bcbb25ad22c161": {
+      "disposition": "superseded",
+      "notes": "Superseded by Rust direct Bot API polling: there is no PTB _send_path_degraded flag or deferred heartbeat gate. Successful getUpdates clears Rust backoff/error counters immediately, while sustained polling failures or 409 conflicts mark the adapter unhealthy for the gateway watcher.",
+      "owner": "rust-runtime"
+    },
+    "2ecca1e7d3e7c387b4d350f99dc699e2f43f73c5": {
+      "disposition": "ported",
+      "notes": "Ported as a real Rust chokepoint rather than relying on stdout/stderr capture: helper processes explicitly call suppress_windows_console before spawn/output/status, and source parity tests require the no-window helper on the primary backend subprocess surfaces.",
+      "owner": "rust-runtime"
     },
     "2ed96372ade3": {
       "disposition": "ported",
@@ -1179,10 +1409,20 @@
       "disposition": "superseded",
       "notes": "upstream python CI/release workflow delta superseded by local rust-first parity gates and release pipeline"
     },
+    "2f46fde3f51db2db1cb0854ce1bd2b5c07c16a0d": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "2f48c58b85b8": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust gateway now normalizes iOS/mobile Unicode dash variants at the slash-argument boundary for quick, builtin, and skill slash routing; existing /model parser Unicode-dash coverage remains green."
+      "notes": "Rust gateway now normalizes iOS/mobile Unicode dash variants at the slash-argument boundary for quick, builtin, and skill slash routing; existing /model parser Unicode-dash coverage remains green.",
+      "owner": "rust-runtime"
+    },
+    "2f7b6cf298a3b64b39b0c9e5a102707e018eacbd": {
+      "disposition": "superseded",
+      "notes": "Upstream Python/Electron /journey timeline UI is superseded by Hermes Ultra Rust SOTA workflow replay and ContextLattice-backed memory/skills evidence surfaces; no Python journey module or desktop star-map runtime is shipped.",
+      "owner": "rust-runtime"
     },
     "2f7c4858a764": {
       "disposition": "ported",
@@ -1195,8 +1435,8 @@
     },
     "2fa66950e8ba06ed8d587aad4bfc1766f06dee5b": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Python/Electron CI or Docker-test orchestration delta is superseded by Hermes Agent Ultra's Rust-first CI surface: the local workflows build/test the Rust workspace, run parity gates, and use the distinct Rust Docker image/entrypoint contracts rather than upstream uv/s6/Electron docker jobs."
+      "notes": "Upstream Python/Electron CI or Docker-test orchestration delta is superseded by Hermes Agent Ultra's Rust-first CI surface: the local workflows build/test the Rust workspace, run parity gates, and use the distinct Rust Docker image/entrypoint contracts rather than upstream uv/s6/Electron docker jobs.",
+      "owner": "rust-runtime"
     },
     "30340eae2f6e": {
       "disposition": "ported",
@@ -1221,8 +1461,8 @@
     },
     "304f0650c4071951cbdc067a47e87eb3c0d01fe3": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "3078053795e838e47797ede02b44e6dead731aac": {
       "disposition": "ported",
@@ -1235,6 +1475,11 @@
     "30b391ab366e": {
       "disposition": "ported",
       "notes": "Rust Honcho avoids runtime peer collisions by hashing runtime IDs when generating prefixed peer names, with regression coverage."
+    },
+    "30cd39dc5609a91d5eeee85f78495ffdbecdd157": {
+      "disposition": "superseded",
+      "notes": "Upstream stroll-direction coin refactor only changes the absent Electron desktop pet roam implementation. Hermes Agent Ultra has no apps/desktop pet surface, so the Rust product boundary supersedes this non-shipped GUI-only delta.",
+      "owner": "rust-runtime"
     },
     "311900842e88": {
       "disposition": "superseded",
@@ -1251,8 +1496,8 @@
     },
     "317b94871be6d90383078f07bf4975e2efc38217": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "31bdb60013c98d033dac3c0475be6e24773b5bf9": {
       "disposition": "ported",
@@ -1272,6 +1517,11 @@
       "disposition": "superseded",
       "notes": "upstream SimpleX websocket reconnect delta is Python plugin-only in this fork; no Rust SimpleX platform adapter exists under crates, so there is no Rust runtime surface to port under the Rust-only parity policy."
     },
+    "322138df51c3d965e52d4be7477e596332195479": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "324567c93662": {
       "disposition": "superseded",
       "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
@@ -1284,6 +1534,11 @@
       "disposition": "ported",
       "notes": "Rust Honcho only treats pinUserPeer/pinPeerName as enabled when the JSON value is a strict boolean true, avoiding truthy-string or mock-style coercion."
     },
+    "3362bdb4e5c9d01521feb3f8d6b4390ee8e95dd5": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
+    },
     "338c07433699": {
       "disposition": "ported",
       "notes": "Rust ntfy sends now distinguish explicit tool/router targets from configured publish-topic replies: gateway-backed messaging marks caller recipients explicit, DeliveryTarget routing preserves is_explicit/thread hints for text and file sends, and NtfyAdapter publishes explicit topics directly while retaining configured publish_topic for non-explicit replies."
@@ -1293,14 +1548,24 @@
       "notes": "Electron dependency pin and npm lockfile repair apply to upstream desktop packaging. Ultra has no apps/desktop package tree and builds/releases through the Rust workspace/install scripts.",
       "owner": "rust-runtime"
     },
+    "33d91029b26680a466cf057844df2fcb5fb87b15": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "344415892f5d1de80fe4141e4ba3dfb76d167124": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "349a3f601c6c": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "34e616e778d065acea1477ddc6933c30378def89": {
+      "disposition": "ported",
+      "notes": "Ported in Rust SlackAdapter: startup performs a best-effort auth.test scope audit, warns once per workspace when direct-message scopes exist but mpim:history/message.mpim coverage is missing, and continues startup if the audit fails. Unit and wiremock tests cover stale installs, once-only warnings, auth.test header parsing, and mpim-present suppression.",
+      "owner": "rust-runtime"
     },
     "355af2c20f49": {
       "disposition": "ported",
@@ -1309,6 +1574,11 @@
     "3589960e03d0": {
       "disposition": "ported",
       "notes": "Rust GenericProvider now maps OpenCode Go reasoning controls by model: Kimi K2 and DeepSeek thinking models receive provider-native thinking/reasoning_effort fields while non-target models drop unsupported controls."
+    },
+    "3590543312a12334b06dabbc47d623406999a9c2": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Teams pipeline: recording display names are reduced to the final path component and normalized before joining the run directory, preventing traversal.",
+      "owner": "rust-runtime"
     },
     "359f2be12e6c": {
       "disposition": "superseded",
@@ -1320,8 +1590,8 @@
     },
     "35dfe7b58f791c021d49514a13775ef9d4a6fc78": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Python/Electron CI or Docker-test orchestration delta is superseded by Hermes Agent Ultra's Rust-first CI surface: the local workflows build/test the Rust workspace, run parity gates, and use the distinct Rust Docker image/entrypoint contracts rather than upstream uv/s6/Electron docker jobs."
+      "notes": "Upstream Python/Electron CI or Docker-test orchestration delta is superseded by Hermes Agent Ultra's Rust-first CI surface: the local workflows build/test the Rust workspace, run parity gates, and use the distinct Rust Docker image/entrypoint contracts rather than upstream uv/s6/Electron docker jobs.",
+      "owner": "rust-runtime"
     },
     "3625dbb8442c": {
       "disposition": "ported",
@@ -1340,6 +1610,16 @@
       "disposition": "superseded",
       "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
     },
+    "36b7e5e9cc9821a1366f88c7e488b443736373e8": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
+    "36bfe3a4490259eb8f89a84b7a9cad2a7c4de8ab": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
+    },
     "374785ee2613": {
       "disposition": "ported",
       "notes": "Kanban dispatcher defaults and failure-limit guidance are represented by the local kanban skills and Rust kanban command surface."
@@ -1350,13 +1630,18 @@
     },
     "376d021feef98fdb5dca160d46c0125134c9b4e6": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/desktop/dashboard-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, web, or Electron desktop runtime tree, while Rust CLI/TUI/gateway/install paths own the applicable behavior. Mixed Rust/runtime/provider/platform commits remain pending for separate evidence."
+      "notes": "Upstream Electron/desktop/dashboard-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, web, or Electron desktop runtime tree, while Rust CLI/TUI/gateway/install paths own the applicable behavior. Mixed Rust/runtime/provider/platform commits remain pending for separate evidence.",
+      "owner": "rust-runtime"
+    },
+    "376d021feef9cb27e6f5a750d6a423221e49f6c8": {
+      "disposition": "superseded",
+      "notes": "Upstream macOS Electron update/uninstall handoff delta is superseded because apps/desktop is absent; Hermes Agent Ultra ships Rust CLI/TUI/gateway lifecycle paths instead of Electron app-exit handoff code.",
+      "owner": "rust-runtime"
     },
     "37c37c9dc51118b75bbd3eec9b689e540683a13a": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream google-antigravity provider-profile registration was transient and later removed upstream. Hermes Agent Ultra never ships a Rust google-antigravity provider alias; the optional antigravity-cli skill remains an operator guide, not an OAuth provider registration."
+      "notes": "Upstream google-antigravity provider-profile registration was transient and later removed upstream. Hermes Agent Ultra never ships a Rust google-antigravity provider alias; the optional antigravity-cli skill remains an operator guide, not an OAuth provider registration.",
+      "owner": "rust-runtime"
     },
     "37d717054ef6": {
       "disposition": "superseded",
@@ -1397,8 +1682,8 @@
     },
     "391090083c3bbf382cea7097fdac3b5cd41eee3f": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream fixes Electron desktop MoA preset add/delete/default save buttons in apps/desktop. Hermes Agent Ultra does not ship apps/desktop; Rust CLI/TUI MoA model switching and runtime MoA config own the applicable shipped surface, so there is no local desktop React persistence path to port."
+      "notes": "Upstream fixes Electron desktop MoA preset add/delete/default save buttons in apps/desktop. Hermes Agent Ultra does not ship apps/desktop; Rust CLI/TUI MoA model switching and runtime MoA config own the applicable shipped surface, so there is no local desktop React persistence path to port.",
+      "owner": "rust-runtime"
     },
     "395dbcc873c8": {
       "disposition": "superseded",
@@ -1412,9 +1697,19 @@
       "disposition": "superseded",
       "notes": "Python wheel/sdist optional-MCP packaging is not used by the Rust/Cargo runtime. Local MCP catalog and config handling are Rust-native."
     },
+    "39bff67957e11ae5ceca7ee8b7d6a057dfd1ac97": {
+      "disposition": "ported",
+      "notes": "Ported in Rust gateway: display.tool_progress supports runtime command control and log/all-style progress visibility through gateway slash command methods and tests.",
+      "owner": "rust-runtime"
+    },
     "39fe4ecee3d0": {
       "disposition": "ported",
       "notes": "Rust kanban store loading now refuses malformed or semantically empty existing boards.json state, preserves the original bytes, and writes a same-directory boards.json.corrupt.<timestamp> backup before returning an error."
+    },
+    "3a55f66602898b53524a232e3dbadea3ed9b0cf8": {
+      "disposition": "ported",
+      "notes": "Ported with Rust relay/session scope_id migration support: scope_id is canonical, guild_id remains a deprecated alias, relay helpers dual-read and dual-write both keys, SessionSource exposes with_scope/with_guild_id compatibility, and docs/tests cover the wire-contract behavior.",
+      "owner": "rust-runtime"
     },
     "3a5e36cfa50a": {
       "disposition": "superseded",
@@ -1443,8 +1738,8 @@
     },
     "3b1344c18c3dc485d5d89f7a9b061d32e76e9bf9": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "3be9fb73173e": {
       "disposition": "superseded",
@@ -1474,8 +1769,8 @@
     },
     "3ccda2aa059f": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust MCP HTTP and SSE transports seed MCP-Protocol-Version before initialize; transport tests cover both request builders."
+      "notes": "Rust MCP HTTP and SSE transports seed MCP-Protocol-Version before initialize; transport tests cover both request builders.",
+      "owner": "rust-runtime"
     },
     "3cf5e8225d88": {
       "disposition": "ported",
@@ -1487,8 +1782,8 @@
     },
     "3cf900eb67": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Managed lockfile churn before installer stash targets upstream managed clone/stash install.sh plus install.ps1. Ultra installer is release-binary/source-build only, has no managed clone stash path or PowerShell installer."
+      "notes": "Managed lockfile churn before installer stash targets upstream managed clone/stash install.sh plus install.ps1. Ultra installer is release-binary/source-build only, has no managed clone stash path or PowerShell installer.",
+      "owner": "rust-runtime"
     },
     "3d14f01fd674": {
       "disposition": "ported",
@@ -1530,6 +1825,11 @@
       "disposition": "ported",
       "notes": "Rust port implements upstream coding-context posture through crates/hermes-agent/src/coding_context.rs, AgentConfig/GatewayConfig agent.coding_context, prompt injection with workspace/verify facts, model-family edit-format guidance, prompt-only non-coding skill pruning, a lean coding toolset, ACP default toolset registration, and focus-mode platform tool collapse with live MCP inclusion. Tests cover detection, prompt gating, skill pruning, coding/hermes-acp toolsets, and platform focus behavior."
     },
+    "3e7ed0c53b59174c86cd7ff945c745a35e8c4e51": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "3e994e38f763": {
       "disposition": "superseded",
       "notes": "Hindsight profile env materialization only applies to the upstream Python embedded daemon; the Rust runtime now documents and exposes cloud/local_external HTTP modes only."
@@ -1542,14 +1842,24 @@
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
+    "3f19df2a5b71a0d68cb46e299d108c793634e98c": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
+    "3f543229f28c6a0fb588a73f093b85a183d86595": {
+      "disposition": "superseded",
+      "notes": "Superseded by Rust gateway clarify shape: Telegram does not implement the upstream cl:<id> clarify inline-button protocol, so there is no stale clarify button tap to expire. Rust gateway clarify is queued through ChannelClarifyBackend and answered by the next user message, while Telegram approval callbacks already alert when no pending approval exists.",
+      "owner": "rust-runtime"
+    },
     "3f7d1c801ddf": {
       "disposition": "ported",
       "notes": "Rust /undo [N] and /rewind [N] clamp to active user turns, truncate in-memory context, soft-delete persisted rows, preserve inactive audit rows, and stage the backed-up prompt for editing."
     },
     "3faf768cdef0": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust image_generate now supports OpenRouter-compatible OpenRouter and Nous Portal backends with provider selection, env/config/auth-store credential resolution, /chat/completions image-output payloads, local reference-image data URI inlining, generated image cache saves for data URI/HTTP responses, and mocked tests for payload/header/auth/error paths."
+      "notes": "Rust image_generate now supports OpenRouter-compatible OpenRouter and Nous Portal backends with provider selection, env/config/auth-store credential resolution, /chat/completions image-output payloads, local reference-image data URI inlining, generated image cache saves for data URI/HTTP responses, and mocked tests for payload/header/auth/error paths.",
+      "owner": "rust-runtime"
     },
     "3fc67b7333d7": {
       "disposition": "superseded",
@@ -1570,8 +1880,8 @@
     },
     "3fffecbdafec0bcb08a7335da4e15181bc6ff5d6": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "401aadb5b892": {
       "disposition": "superseded",
@@ -1591,18 +1901,18 @@
     },
     "404b06ac4fc3": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust Telegram send paths now surface Bot API parameters.retry_after as typed GatewayError::RateLimited for JSON and multipart sends, preserving server-requested flood-control delay instead of flattening it into a generic SendFailed string. Focused tests cover retry_after parsing and typed error mapping."
+      "notes": "Rust Telegram send paths now surface Bot API parameters.retry_after as typed GatewayError::RateLimited for JSON and multipart sends, preserving server-requested flood-control delay instead of flattening it into a generic SendFailed string. Focused tests cover retry_after parsing and typed error mapping.",
+      "owner": "rust-runtime"
     },
     "404fe730b7a2": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Right-sidebar header button tooltips are React desktop UI polish. Rust CLI/TUI/gateway has no matching right-sidebar tooltip surface."
+      "notes": "Right-sidebar header button tooltips are React desktop UI polish. Rust CLI/TUI/gateway has no matching right-sidebar tooltip surface.",
+      "owner": "rust-runtime"
     },
     "40722058e532": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust MCP HTTP/SSE clients now honor per-server keepalive_interval with a 180s default and 5s floor, probe idle sessions with MCP ping, latch -32601 ping-unsupported responses to tools/list fallback, and run manager-owned keepalive workers that reconnect failed HTTP sessions once. Config.yaml, mcp_servers.json, ACP-provided MCP servers, docs/status output, and the Unreal MCP profile carry the interval; focused fake-transport and parser/profile tests cover the behavior."
+      "notes": "Rust MCP HTTP/SSE clients now honor per-server keepalive_interval with a 180s default and 5s floor, probe idle sessions with MCP ping, latch -32601 ping-unsupported responses to tools/list fallback, and run manager-owned keepalive workers that reconnect failed HTTP sessions once. Config.yaml, mcp_servers.json, ACP-provided MCP servers, docs/status output, and the Unreal MCP profile carry the interval; focused fake-transport and parser/profile tests cover the behavior.",
+      "owner": "rust-runtime"
     },
     "40aef6af91e6": {
       "disposition": "superseded",
@@ -1610,12 +1920,17 @@
     },
     "40fddc9e4c45": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported as Rust relay protocol primitives: hermes_gateway::relay exposes going_idle and inbound_ack frame builders with bufferId validation and tests. The actual relay transport remains intentionally unregistered in Rust until the experimental relay adapter is scoped."
+      "notes": "Ported as Rust relay protocol primitives: hermes_gateway::relay exposes going_idle and inbound_ack frame builders with bufferId validation and tests. The actual relay transport remains intentionally unregistered in Rust until the experimental relay adapter is scoped.",
+      "owner": "rust-runtime"
     },
     "411faf08bd678fe3e49b22afcef1e9fd2d7f5592": {
       "disposition": "ported",
       "notes": "Ported in Rust/setup/install: hermes-agent now exposes DEFAULT_AGENT_IDENTITY-backed SOUL.md seeding, ignores exact legacy comment-only templates at prompt load, upgrades those templates during setup, preserves customized SOUL.md files, respects explicit/HERMES_HOME resolution, and install.sh seeds the real default persona instead of an empty scaffold.",
+      "owner": "rust-runtime"
+    },
+    "41c85fb9469bbde7c5446cc5386b2e2438936fb5": {
+      "disposition": "superseded",
+      "notes": "AGENTS.md subprocess isolation documentation is policy/docs-only and does not change Hermes Ultra Rust runtime behavior.",
       "owner": "rust-runtime"
     },
     "41ede963041f": {
@@ -1643,14 +1958,24 @@
       "disposition": "superseded",
       "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
     },
+    "42ca4381316c54394f7e3e078dfc75119fcde9ae": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "42e166c7ea2e": {
       "disposition": "superseded",
       "notes": "docker/runtime hardening delta superseded by local container/runtime architecture and existing fixes"
     },
     "4314d451ca96": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust gateway media cache already accepts arbitrary inbound document bytes and records unknown types as application/octet-stream, while Slack/Telegram/Discord document surfaces preserve file metadata and focused media/Telegram document tests cover the behavior."
+      "notes": "Rust gateway media cache already accepts arbitrary inbound document bytes and records unknown types as application/octet-stream, while Slack/Telegram/Discord document surfaces preserve file metadata and focused media/Telegram document tests cover the behavior.",
+      "owner": "rust-runtime"
+    },
+    "4345b3e767c73405e143b2f03a1e4e7773c2b472": {
+      "disposition": "superseded",
+      "notes": "Upstream Photon Spectrum TS v8 sidecar upgrade only changes the absent Python/Node Photon bridge. There is no Rust Photon sidecar/package-lock surface to update, so the Rust product boundary supersedes this dependency churn.",
+      "owner": "rust-runtime"
     },
     "435c706e8e5a": {
       "disposition": "superseded",
@@ -1668,18 +1993,28 @@
     },
     "43b8ba41816b6790e3bae852eb32277dc4dc6915": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported/proven in Rust: the Telegram CLI poll loop calls deleteWebhook(drop_pending_updates=false), preserves Bot API queued updates across reconnects, advances getUpdates offsets only after successful responses, and keeps the poll sidecar resident so watcher start() can recover after outages."
+      "notes": "Ported/proven in Rust: the Telegram CLI poll loop calls deleteWebhook(drop_pending_updates=false), preserves Bot API queued updates across reconnects, advances getUpdates offsets only after successful responses, and keeps the poll sidecar resident so watcher start() can recover after outages.",
+      "owner": "rust-runtime"
+    },
+    "43eaf79ae6451e10dacba3342d28230e6fef87de": {
+      "disposition": "superseded",
+      "notes": "Upstream committed-infographic cleanup is superseded by local repo state: no top-level infographic artifact tree is shipped, and parity/release documentation is generated under docs/website surfaces.",
+      "owner": "rust-runtime"
     },
     "43eaf79ae645dcab89e54f089f5d05b44db46735": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream committed-infographic cleanup is superseded by this repo state: no top-level infographic artifact tree is shipped locally, and parity/release docs are generated under docs/website surfaces instead."
+      "notes": "Upstream committed-infographic cleanup is superseded by this repo state: no top-level infographic artifact tree is shipped locally, and parity/release docs are generated under docs/website surfaces instead.",
+      "owner": "rust-runtime"
+    },
+    "43edbae638b5068e428ca82b7f9d6c1266050e25": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
     },
     "441bd6d8dbe5": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust Slack mention-pattern parsing accepts JSON list/string values and mixed newline/comma fallback from SLACK_MENTION_PATTERNS, with tests covering the CSV/newline split regression."
+      "notes": "Rust Slack mention-pattern parsing accepts JSON list/string values and mixed newline/comma fallback from SLACK_MENTION_PATTERNS, with tests covering the CSV/newline split regression.",
+      "owner": "rust-runtime"
     },
     "443950e82736": {
       "disposition": "ported",
@@ -1709,18 +2044,23 @@
     },
     "4526fccdbe6bd804eb26aa131f82d6e319be101b": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "452a725ae19f": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Mem0 with mode-aware schema semantics: api_key remains required for platform mode but is optional for oss/self-hosted mode, preserving the reviewed either/or auth contract while keeping the owner-only mem0.json config path. Focused Rust tests cover OSS schema required=false behavior."
+      "notes": "Ported in Rust Mem0 with mode-aware schema semantics: api_key remains required for platform mode but is optional for oss/self-hosted mode, preserving the reviewed either/or auth contract while keeping the owner-only mem0.json config path. Focused Rust tests cover OSS schema required=false behavior.",
+      "owner": "rust-runtime"
+    },
+    "453f134b3bc213f05db52b22c6a0eb18ef115339": {
+      "disposition": "superseded",
+      "notes": "Superseded by local Rust-first product shape: upstream centralizes desktop remote-git REST routing across apps/desktop and Python web_server surfaces that are absent from the shipped Rust runtime. Rust project/git operations remain CLI/TUI/tool owned.",
+      "owner": "rust-runtime"
     },
     "45540cfb5ef1e30c71d46166a171d88101e8fcb7": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream CI/workflow-only delta is superseded by Hermes Agent Ultra's local Rust-first deterministic gates and PR verification workflow; it does not add or change a shipped Rust runtime behavior. Runtime/install/docker changes remain pending for separate evidence."
+      "notes": "Upstream CI/workflow-only delta is superseded by Hermes Agent Ultra's local Rust-first deterministic gates and PR verification workflow; it does not add or change a shipped Rust runtime behavior. Runtime/install/docker changes remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "458ce792d24e": {
       "disposition": "ported",
@@ -1728,21 +2068,36 @@
     },
     "45bc4fb37fa8": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported as Rust relay management-plane contracts: hermes_gateway::relay maps ws/wss relay URLs to /relay/policy, projects requireAddress/freeResponseScopes/allowOtherBots with connector camelCase serialization, and keeps the relay adapter unregistered unless explicitly scoped later."
+      "notes": "Ported as Rust relay management-plane contracts: hermes_gateway::relay maps ws/wss relay URLs to /relay/policy, projects requireAddress/freeResponseScopes/allowOtherBots with connector camelCase serialization, and keeps the relay adapter unregistered unless explicitly scoped later.",
+      "owner": "rust-runtime"
     },
     "45e1689c03b2": {
       "disposition": "superseded",
       "notes": "Desktop marketplace submenu HUD token changes are Electron/React styling only."
     },
+    "460235d5848b1467cf7351cd6bd82078abe53edc": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Codex image backend: Codex reference images are capped at CODEX_MAX_SOURCE_IMAGES with payload-shape regression coverage.",
+      "owner": "rust-runtime"
+    },
     "461fcc096479f548a1990fe26f329649fe40c371": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
+    },
+    "46273a55a860995a6e326c905f7f06dfa980b642": {
+      "disposition": "superseded",
+      "notes": "Upstream docs/skills/website-only delta is superseded by local Rust-first docs, release notes, and parity evidence; no Rust runtime implementation is required for this queue row.",
+      "owner": "rust-runtime"
     },
     "464276228940": {
       "disposition": "superseded",
       "notes": "Python Langfuse plugin base64 redaction is superseded by Rust telemetry/redaction surfaces and optional plugin divergence; Rust runtime does not emit through that Python plugin."
+    },
+    "46ab06c238472d87506b654729b2f7f01f5b2033": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
     },
     "46b2afc56b79": {
       "disposition": "ported",
@@ -1777,6 +2132,11 @@
       "disposition": "ported",
       "notes": "Rust ACP exposes the editor session-management surface with load/resume/fork/list plus model/mode/config updates, now including the stable session/set_config_option method alias; handler tests cover camelCase routing and persisted session config."
     },
+    "476875acb9f00b00f659dd6f71c843fb2f08aac2": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "47d2d05892ef": {
       "disposition": "ported",
       "notes": "Rust provider picker copy now has provider_picker_description wired into hermes model output, setup provider labels, and the TUI provider modal; tests pin refreshed Nous/OpenRouter/Gemini/xAI/Qwen descriptions."
@@ -1784,6 +2144,11 @@
     "47d5177a7d61": {
       "disposition": "superseded",
       "notes": "Python lazy-singleton and Honcho TOCTOU fixes are superseded by Rust plugin instances and explicit Mutex state; no Python lazy singleton remains."
+    },
+    "481caa66f23c75eede53867e99a68400012cf501": {
+      "disposition": "ported",
+      "notes": "Ported in Rust display/gateway surfaces: hermes-cli-ui and hermes-intelligence build friendly human-phrased labels for built-in tools, display.friendly_tool_labels defaults on with env/config-set opt-out, gateway tool-start events and progress messages use the label path, verbose mode remains raw/debug-oriented, and focused Rust tests cover default labels plus legacy-off behavior.",
+      "owner": "rust-runtime"
     },
     "484f484c25bc": {
       "disposition": "superseded",
@@ -1795,8 +2160,8 @@
     },
     "488ae376dbef8e411f30e844e8b40ba55fc97e19": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "4891f9ae78b0": {
       "disposition": "superseded",
@@ -1808,13 +2173,13 @@
     },
     "489b85ee1e2b": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust DuckDuckGo web-search backend now applies a bounded wall-clock request timeout with DDG_SEARCH_TIMEOUT_SECONDS/HERMES_DDGS_TIMEOUT_SECONDS env knobs, minimum clamp, and slow-response timeout tests."
+      "notes": "Rust DuckDuckGo web-search backend now applies a bounded wall-clock request timeout with DDG_SEARCH_TIMEOUT_SECONDS/HERMES_DDGS_TIMEOUT_SECONDS env knobs, minimum clamp, and slow-response timeout tests.",
+      "owner": "rust-runtime"
     },
     "48a8f8416937dc3168903a89d0e34f8416c24965": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "48d8d80771e2": {
       "disposition": "superseded",
@@ -1830,8 +2195,8 @@
     },
     "491579fa05ef": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by Rust WhatsApp architecture: the repo has no scripts/whatsapp-bridge source tree or npm-installing bridge adapter path to mirror into HERMES_HOME; Rust WhatsApp runtime is the Cloud API adapter plus configurable bridge_url QR helper."
+      "notes": "Superseded by Rust WhatsApp architecture: the repo has no scripts/whatsapp-bridge source tree or npm-installing bridge adapter path to mirror into HERMES_HOME; Rust WhatsApp runtime is the Cloud API adapter plus configurable bridge_url QR helper.",
+      "owner": "rust-runtime"
     },
     "492c4c6573b4": {
       "disposition": "superseded",
@@ -1844,8 +2209,8 @@
     },
     "49662687646d": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust Slack Socket Mode session handling now enforces require_mention with literal <@bot_user_id> mentions and documented mention_patterns wake-word regexes. CLI config mapping and SLACK_MENTION_PATTERNS env bridging are covered by focused Rust tests."
+      "notes": "Rust Slack Socket Mode session handling now enforces require_mention with literal <@bot_user_id> mentions and documented mention_patterns wake-word regexes. CLI config mapping and SLACK_MENTION_PATTERNS env bridging are covered by focused Rust tests.",
+      "owner": "rust-runtime"
     },
     "498bfc7bc12a": {
       "disposition": "superseded",
@@ -1868,10 +2233,15 @@
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
+    "4a09b692ecc385ad48f00694a1e315b8eed120cd": {
+      "disposition": "ported",
+      "notes": "Ported in Rust API server: inbound requests carry model/provider/personality overrides and merge_request_runtime_overrides applies per-client runtime routing before agent execution.",
+      "owner": "rust-runtime"
+    },
     "4a0c02b7dcb0": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust file tools resolve bookkeeping paths against live terminal cwd before TERMINAL_CWD/process cwd; resolve_tool_path_prefers_live_cwd_then_terminal_cwd covers the behavior."
+      "notes": "Rust file tools resolve bookkeeping paths against live terminal cwd before TERMINAL_CWD/process cwd; resolve_tool_path_prefers_live_cwd_then_terminal_cwd covers the behavior.",
+      "owner": "rust-runtime"
     },
     "4a1840e68350": {
       "disposition": "superseded",
@@ -1881,24 +2251,39 @@
       "disposition": "superseded",
       "notes": "Upstream change is confined to apps/desktop React i18n wiring and zh-Hans catalog files. Hermes Agent Ultra has no Electron desktop tree in this Rust runtime repo; CLI/TUI/gateway text remains Rust-native and is not backed by the upstream desktop i18n catalog."
     },
+    "4a99571d54e0e0ca0dddd7918ba32446ac115362": {
+      "disposition": "ported",
+      "notes": "Rust ACP/session lifecycle carries profile_home metadata through create/update/fork and handler tests, so profile-local discovery is native without a Python slash_worker subprocess.",
+      "owner": "rust-runtime"
+    },
     "4aa793345ec9": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust Matrix adapter now has MatrixRoomIdentity classification and async resolution helpers that use joined_member_count <= 2 as the primary DM signal, preserve named DMs, and flag stale m.direct conflicts for rooms with 3+ members. Focused tests cover named DM and stale direct-room behavior."
+      "notes": "Rust Matrix adapter now has MatrixRoomIdentity classification and async resolution helpers that use joined_member_count <= 2 as the primary DM signal, preserve named DMs, and flag stale m.direct conflicts for rooms with 3+ members. Focused tests cover named DM and stale direct-room behavior.",
+      "owner": "rust-runtime"
+    },
+    "4aaaa206aa7d08b1cf72acb84802a2f7d2fd95c0": {
+      "disposition": "ported",
+      "notes": "Rust Telegram polling routes getUpdates through post_json_with_request_timeout using poll_request_timeout, with tests proving timeout grace and unhealthy transition behavior.",
+      "owner": "rust-runtime"
     },
     "4aeaba69225151b36ab7c23803eefb99ae140f8f": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "4b0a2040e72d7c5bf35288e388c4d21ef9a96ac1": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Python/Electron CI or Docker-test orchestration delta is superseded by Hermes Agent Ultra's Rust-first CI surface: the local workflows build/test the Rust workspace, run parity gates, and use the distinct Rust Docker image/entrypoint contracts rather than upstream uv/s6/Electron docker jobs."
+      "notes": "Upstream Python/Electron CI or Docker-test orchestration delta is superseded by Hermes Agent Ultra's Rust-first CI surface: the local workflows build/test the Rust workspace, run parity gates, and use the distinct Rust Docker image/entrypoint contracts rather than upstream uv/s6/Electron docker jobs.",
+      "owner": "rust-runtime"
     },
     "4b2d00f845eb": {
       "disposition": "ported",
       "notes": "Rust custom provider catalogs now preserve `discover_models: false` from both canonical llm_providers and legacy custom_providers, keep explicit `models` subsets without probing live `/models`, and expose config-aware provider lists with Rust model-switch tests."
+    },
+    "4b4349eb9a904d9babf519e0a580f960311c6035": {
+      "disposition": "superseded",
+      "notes": "Upstream docs/skills/website-only delta is superseded by local Rust-first docs, release notes, and parity evidence; no Rust runtime implementation is required for this queue row.",
+      "owner": "rust-runtime"
     },
     "4b7a18600393": {
       "disposition": "superseded",
@@ -1907,8 +2292,8 @@
     },
     "4b7f3826c2ce": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust Telegram adapter constructs Bot API clients through the shared reqwest platform_http_client_builder, including fallback-IP resolution and proxy branches, and the shared platform HTTP pool tests assert the CLOSE_WAIT-safe keepalive expiry below 5s with bounded idle connections."
+      "notes": "Rust Telegram adapter constructs Bot API clients through the shared reqwest platform_http_client_builder, including fallback-IP resolution and proxy branches, and the shared platform HTTP pool tests assert the CLOSE_WAIT-safe keepalive expiry below 5s with bounded idle connections.",
+      "owner": "rust-runtime"
     },
     "4bd297094af2": {
       "disposition": "ported",
@@ -1916,8 +2301,23 @@
     },
     "4c206b972d49": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by Rust-native gateway adapters: the Python plugins/platforms sys.path insertion path does not exist, and external Python plugin command dispatch is disabled in CLI tests."
+      "notes": "Superseded by Rust-native gateway adapters: the Python plugins/platforms sys.path insertion path does not exist, and external Python plugin command dispatch is disabled in CLI tests.",
+      "owner": "rust-runtime"
+    },
+    "4c2c54c78c3731c3f78787b6c7882eb4aea378d7": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
+    },
+    "4c3a388cba9608f8cda0cc604e6c557adb8b298c": {
+      "disposition": "superseded",
+      "notes": "Upstream widens the same discord.py expired-defer handling to /thread. Rust /thread and slash response handling use REST status/error paths, not discord.py defer exceptions.",
+      "owner": "rust-runtime"
+    },
+    "4c4b790f110be2c34fdfdb72575efe2d1f8ba632": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
     },
     "4c57a5b31837": {
       "disposition": "superseded",
@@ -1938,18 +2338,18 @@
     },
     "4cdd1a3230b8": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust project_facts records authoritative workspace metadata including detected root/cwd, manifests, package managers, verification commands, context files, and git branch/head/dirty status; exposed through tool and HTTP RPC tests."
+      "notes": "Rust project_facts records authoritative workspace metadata including detected root/cwd, manifests, package managers, verification commands, context files, and git branch/head/dirty status; exposed through tool and HTTP RPC tests.",
+      "owner": "rust-runtime"
     },
     "4cf69f0da43c841475b9c6d209b1487a376961a4": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Python/Electron CI or Docker-test orchestration delta is superseded by Hermes Agent Ultra's Rust-first CI surface: the local workflows build/test the Rust workspace, run parity gates, and use the distinct Rust Docker image/entrypoint contracts rather than upstream uv/s6/Electron docker jobs."
+      "notes": "Upstream Python/Electron CI or Docker-test orchestration delta is superseded by Hermes Agent Ultra's Rust-first CI surface: the local workflows build/test the Rust workspace, run parity gates, and use the distinct Rust Docker image/entrypoint contracts rather than upstream uv/s6/Electron docker jobs.",
+      "owner": "rust-runtime"
     },
     "4da744ef9b6182982684c6b46bd5f41569e907ee": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "4db58d45d4e0": {
       "disposition": "ported",
@@ -1965,8 +2365,8 @@
     },
     "4e023f5bc990": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust HTTP project.tree RPC builds a deterministic bounded project tree from the detected workspace root, skips heavy dependency/build directories, reports truncation, and is covered by rpc_project_tree_returns_bounded_entries."
+      "notes": "Rust HTTP project.tree RPC builds a deterministic bounded project tree from the detected workspace root, skips heavy dependency/build directories, reports truncation, and is covered by rpc_project_tree_returns_bounded_entries.",
+      "owner": "rust-runtime"
     },
     "4e78963fe86a5f2758bf754a7979dc31aaf1a3db": {
       "disposition": "superseded",
@@ -1974,8 +2374,13 @@
     },
     "4e9439cc3b330a6b6f1dbcc4f27a4a39e9eeb1ac": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/desktop/dashboard-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, web, or Electron desktop runtime tree, while Rust CLI/TUI/gateway/install paths own the applicable behavior. Mixed Rust/runtime/provider/platform commits remain pending for separate evidence."
+      "notes": "Upstream Electron/desktop/dashboard-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, web, or Electron desktop runtime tree, while Rust CLI/TUI/gateway/install paths own the applicable behavior. Mixed Rust/runtime/provider/platform commits remain pending for separate evidence.",
+      "owner": "rust-runtime"
+    },
+    "4e9439cc3b33d74ad511f320dc1c5c0a66423127": {
+      "disposition": "superseded",
+      "notes": "Superseded by local Rust-first product shape: upstream composer context picking through remote-aware desktop FS is an apps/desktop React behavior. This repo has no apps/desktop runtime; Rust CLI/TUI context and file access are mediated through typed tools and session state instead.",
+      "owner": "rust-runtime"
     },
     "4ece87efb0dd": {
       "disposition": "ported",
@@ -1988,8 +2393,13 @@
     },
     "4ffdedd369c1": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust project workspace tools are first-class ToolHandler surfaces: project_facts and project_tree are registered in builtins, project/coding/main runtime toolsets, and covered by registry/toolset/unit tests."
+      "notes": "Rust project workspace tools are first-class ToolHandler surfaces: project_facts and project_tree are registered in builtins, project/coding/main runtime toolsets, and covered by registry/toolset/unit tests.",
+      "owner": "rust-runtime"
+    },
+    "500c2b1e46e46684ddfb1f3464a4fe3a0fb060a0": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
     },
     "500cf537b7d0": {
       "disposition": "superseded",
@@ -1998,6 +2408,16 @@
     "50943251400b": {
       "disposition": "ported",
       "notes": "Adopted upstream shop skill v1.0.1 directly: optional-skills/productivity/shop replaces shop-app and includes CLI/direct-API reference files for catalog, checkout, orders, safety, and legal guidance."
+    },
+    "50a7dce6bd509ff430dce88de8a3c342ced07f3c": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
+    },
+    "50f685521734237faf0d902fa7d347492d9ea96a": {
+      "disposition": "ported",
+      "notes": "Ported in Rust: /moa is a one-shot slash command that requires a prompt, routes exactly one turn through the default virtual MoA preset, preserves the model-picker path for sticky moa:default selection, and restores the prior model after the turn even when inference fails. Covered by CLI command usage and app one-shot restore tests.",
+      "owner": "rust-runtime"
     },
     "50f9fee988b6": {
       "disposition": "superseded",
@@ -2009,8 +2429,8 @@
     },
     "515192c4b90c934c26389da37c47877e2cd274db": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust local environment subprocess isolation: foreground command setup now uses process_group(0) through Tokio/std CommandExt instead of a fork-time pre_exec setsid hook, preserving process-group termination without running code in the child between fork and exec. A Rust regression test asserts the local backend source keeps the fork hook out and retains process_group(0). Upstream Python preexec_fn call sites remain absent from the shipped Rust runtime."
+      "notes": "Ported in Rust local environment subprocess isolation: foreground command setup now uses process_group(0) through Tokio/std CommandExt instead of a fork-time pre_exec setsid hook, preserving process-group termination without running code in the child between fork and exec. A Rust regression test asserts the local backend source keeps the fork hook out and retains process_group(0). Upstream Python preexec_fn call sites remain absent from the shipped Rust runtime.",
+      "owner": "rust-runtime"
     },
     "518d37f6af49": {
       "disposition": "ported",
@@ -2018,17 +2438,22 @@
     },
     "5191ebba22d834faa52cd1f5f37acddd3d34ce96": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "5196575d40caa367395c5535da1c99caecef072c": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "51a2c07016b2": {
       "disposition": "ported",
       "notes": "X Article ingestion guidance is represented in skills/social-media/xurl/SKILL.md within the local skills catalog."
+    },
+    "51a710e57e931c65a6e44eed694ca437af5ae06d": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
     },
     "51b44b6e3fa1": {
       "disposition": "ported",
@@ -2043,18 +2468,43 @@
       "notes": "Ported in this batch: display.memory_notifications is typed config with env/config set/get bridge, and gateway background review callbacks are gated by this setting with focused tests.",
       "owner": "rust-runtime"
     },
+    "520212cc593dd8bc0472002877e31d7310bd295b": {
+      "disposition": "superseded",
+      "notes": "Upstream live agent terminal streaming changes are Electron desktop right-sidebar UI code. Hermes Agent Ultra does not ship the Electron desktop terminal tab surface; Rust CLI/gateway/TUI terminal execution and streaming surfaces are the product boundary.",
+      "owner": "rust-runtime"
+    },
     "525ee58b43f53b99a0858cfdb1fbf3991f08b8fe": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust image_generate as a first-class Krea 2 backend: provider selection accepts krea/krea-ai, model/config resolution supports krea-2-medium, krea-2-large, and krea-2-medium-turbo, direct KREA_API_KEY and Nous-managed Krea gateway transports submit to /generate/image/krea/krea-2/{model}, async jobs are polled through /jobs/{job_id}, generated URLs are materialized into the Rust image cache when possible, and hermetic wiremock tests cover direct, managed, retry, auth, config, and capability behavior."
+      "notes": "Ported in Rust image_generate as a first-class Krea 2 backend: provider selection accepts krea/krea-ai, model/config resolution supports krea-2-medium, krea-2-large, and krea-2-medium-turbo, direct KREA_API_KEY and Nous-managed Krea gateway transports submit to /generate/image/krea/krea-2/{model}, async jobs are polled through /jobs/{job_id}, generated URLs are materialized into the Rust image cache when possible, and hermetic wiremock tests cover direct, managed, retry, auth, config, and capability behavior.",
+      "owner": "rust-runtime"
+    },
+    "52a09d8faf6b3a44da5f3eff3e17f85a4f5ea90c": {
+      "disposition": "ported",
+      "notes": "Ported in Rust ByteRover: byterover.json and HERMES_BYTEROVER_AUTO_EXTRACT/BYTEROVER_AUTO_EXTRACT now control auto_extract, disabling background turn, explicit memory, and pre-compression curation while leaving brv_curate/brv_query tools available. CLI setup persists owner-only ByteRover config and tests cover config coercion/schema/setup.",
+      "owner": "rust-runtime"
     },
     "52f7e24a7496": {
       "disposition": "superseded",
       "notes": "Upstream React/TUI Plugins Hub overlay is superseded by Hermes Ultra's Rust skill/plugin governance surfaces and approved Rust CLI/TUI primary UX divergence."
     },
+    "5317993a6dca17f2269cbf79bff88cc912ba92a8": {
+      "disposition": "superseded",
+      "notes": "Upstream Python runtime delta is superseded by Hermes Ultra Rust-native agent/provider/tool architecture and existing deterministic Rust tests; the Python module path is not shipped in the Rust runtime.",
+      "owner": "rust-runtime"
+    },
     "53a2ac8f2dba": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "53a75f147f641d10ac678092e8a67700d7edf2a7": {
+      "disposition": "ported",
+      "notes": "Ported in hermes-auth: OAuth2Endpoints supports optional client_secret with RFC form-encoded client_secret_basic or client_secret_post token endpoint auth, while preserving public-client PKCE behavior. Focused Rust tests cover authorization-code Basic auth and refresh-token POST secret flows.",
+      "owner": "rust-runtime"
+    },
+    "53edf6f983e9093864e86b9c96186a33b4e4f369": {
+      "disposition": "ported",
+      "notes": "Rust Mem0 setup honors MEM0_HOST over MEM0_BASE_URL, writes oss mode for self-hosted hosts, and the system prompt label follows the effective host route.",
+      "owner": "rust-runtime"
     },
     "53fc10fc9a8b": {
       "disposition": "ported",
@@ -2066,13 +2516,13 @@
     },
     "5445e42b87b9918d5b1bfa9f4eadd8e4bb10ff37": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream PR #57969 / head 4bf749fd changed only Electron desktop copy-button tooltip and scrollbar-offset UI in apps/desktop/src/components/assistant-ui/tool/fallback.tsx and apps/desktop/src/components/ui/copy-button.tsx. Hermes Agent Ultra does not ship the Electron desktop app; Rust CLI/TUI/gateway/tool surfaces own copy/display behavior, so there is no Rust runtime port target."
+      "notes": "Upstream PR #57969 / head 4bf749fd changed only Electron desktop copy-button tooltip and scrollbar-offset UI in apps/desktop/src/components/assistant-ui/tool/fallback.tsx and apps/desktop/src/components/ui/copy-button.tsx. Hermes Agent Ultra does not ship the Electron desktop app; Rust CLI/TUI/gateway/tool surfaces own copy/display behavior, so there is no Rust runtime port target.",
+      "owner": "rust-runtime"
     },
     "546193aa6d0ab3aff44a9691723c3c0a63ffda99": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream installer delta targets Python/Electron Playwright or desktop/node dependency setup. Hermes Agent Ultra's installer downloads Rust release binaries, bootstraps SOUL/config, and has bounded post-install probes; it has no Playwright desktop install stage to patch."
+      "notes": "Upstream installer delta targets Python/Electron Playwright or desktop/node dependency setup. Hermes Agent Ultra's installer downloads Rust release binaries, bootstraps SOUL/config, and has bounded post-install probes; it has no Playwright desktop install stage to patch.",
+      "owner": "rust-runtime"
     },
     "547a014e7eae": {
       "disposition": "superseded",
@@ -2086,13 +2536,18 @@
     },
     "54b50037e1": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Pending prompt paused-on-you status is Electron chat/composer/thread state. Ultra Rust CLI/TUI/gateway busy and prompt state are separate surfaces."
+      "notes": "Pending prompt paused-on-you status is Electron chat/composer/thread state. Ultra Rust CLI/TUI/gateway busy and prompt state are separate surfaces.",
+      "owner": "rust-runtime"
+    },
+    "5505dbbf43a480a31e35ac4500f0584519e2484d": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
     },
     "553cf4f97757": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Restart gateway from Cmd+K with statusbar spinner is Electron desktop command-palette behavior. Rust gateway lifecycle is controlled by CLI/process surfaces, not apps/desktop Cmd+K."
+      "notes": "Restart gateway from Cmd+K with statusbar spinner is Electron desktop command-palette behavior. Rust gateway lifecycle is controlled by CLI/process surfaces, not apps/desktop Cmd+K.",
+      "owner": "rust-runtime"
     },
     "559c6ad94aee": {
       "disposition": "ported",
@@ -2112,13 +2567,18 @@
     },
     "5600105478ff": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by Rust-native gateway adapters: upstream moved Python Slack/DingTalk/WhatsApp/Matrix/Feishu/Telegram/WeCom/email/SMS adapters into bundled plugin directories, but Hermes Ultra already implements these as first-class Rust modules under crates/hermes-gateway/src/platforms with feature gates and no Python plugin import path."
+      "notes": "Superseded by Rust-native gateway adapters: upstream moved Python Slack/DingTalk/WhatsApp/Matrix/Feishu/Telegram/WeCom/email/SMS adapters into bundled plugin directories, but Hermes Ultra already implements these as first-class Rust modules under crates/hermes-gateway/src/platforms with feature gates and no Python plugin import path.",
+      "owner": "rust-runtime"
+    },
+    "5636c22828b0be1eadaf8968c7033efb27f705fa": {
+      "disposition": "superseded",
+      "notes": "Upstream Photon Spectrum TS sidecar upgrade is confined to the Python/Node Photon plugin bridge. Hermes Agent Ultra does not ship the Photon sidecar in the Rust runtime; shipped Rust gateway adapters cover first-class platform integrations without vendoring this JS bridge.",
+      "owner": "rust-runtime"
     },
     "563d347e4d420e233a2ed77274e949d93598057f": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "5643c2979013": {
       "disposition": "superseded",
@@ -2139,8 +2599,8 @@
     },
     "56b4ef74a631bdca0bd5cc58bd43369fc227ea83": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream CI/workflow-only delta is superseded by Hermes Agent Ultra's local Rust-first deterministic gates and PR verification workflow; it does not add or change a shipped Rust runtime behavior. Runtime/install/docker changes remain pending for separate evidence."
+      "notes": "Upstream CI/workflow-only delta is superseded by Hermes Agent Ultra's local Rust-first deterministic gates and PR verification workflow; it does not add or change a shipped Rust runtime behavior. Runtime/install/docker changes remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "56be1a63a33d": {
       "disposition": "superseded",
@@ -2148,8 +2608,8 @@
     },
     "572c7dbd93336f54d0989f9e8e6f94059f2d119a": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "573b964dc780": {
       "disposition": "superseded",
@@ -2160,6 +2620,11 @@
       "disposition": "superseded",
       "notes": "Upstream Photon spectrum-ts markdown/reaction support is implemented in the Python adapter and Node sidecar. The Rust gateway does not register Photon, while reaction lifecycle and markdown/document handling are covered for supported Rust adapters."
     },
+    "57462341f4cac5b86558c179aa5a329272d9f950": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "5772e638c9ba": {
       "disposition": "ported",
       "notes": "Removed the tracked infographic/ asset tree and added infographic/ to .gitignore so generated PR infographics stay in PR bodies rather than the repository."
@@ -2167,6 +2632,11 @@
     "57b43fdd4bf9": {
       "disposition": "ported",
       "notes": "Rust startup provider precedence is typed through provider:model resolution and config.llm_providers lookup without treating stale HERMES_INFERENCE_PROVIDER as an explicit launch provider; regression coverage keeps config-selected providers authoritative."
+    },
+    "57dd86f247637a080b9c2c42ae8240379f5b5c49": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
     },
     "580d9240979c": {
       "disposition": "superseded",
@@ -2178,8 +2648,8 @@
     },
     "587b5b9ac223": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust CLI backup/import and memory provider trait: MemoryProviderPlugin exposes config-only backup_paths, Honcho/Hindsight/OpenViking declare their home-scoped dotdirs, hermes backup archives existing regular external provider files under a reserved external/ archive prefix only when they live under HOME and outside HERMES_HOME, and hermes import safely restores hermes/ entries into HERMES_HOME while restoring external/ entries to HOME with traversal checks and 0600 tightening for credential-shaped files. Focused Rust tests cover prefix stripping, OpenViking external state round-trip, and traversal rejection."
+      "notes": "Ported in Rust CLI backup/import and memory provider trait: MemoryProviderPlugin exposes config-only backup_paths, Honcho/Hindsight/OpenViking declare their home-scoped dotdirs, hermes backup archives existing regular external provider files under a reserved external/ archive prefix only when they live under HOME and outside HERMES_HOME, and hermes import safely restores hermes/ entries into HERMES_HOME while restoring external/ entries to HOME with traversal checks and 0600 tightening for credential-shaped files. Focused Rust tests cover prefix stripping, OpenViking external state round-trip, and traversal rejection.",
+      "owner": "rust-runtime"
     },
     "587d1cf72095": {
       "disposition": "superseded",
@@ -2203,13 +2673,13 @@
     },
     "594380d44a": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Queued desktop-turn stop interrupt fix targets tui_gateway/server.py. Ultra has no Python tui_gateway server; Rust busy/interrupt handling lives in CLI/TUI/gateway session coordination."
+      "notes": "Queued desktop-turn stop interrupt fix targets tui_gateway/server.py. Ultra has no Python tui_gateway server; Rust busy/interrupt handling lives in CLI/TUI/gateway session coordination.",
+      "owner": "rust-runtime"
     },
     "596b813c9b03ecdc46b8c6a75aa1cb42e79eb7d2": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "59ea2f98e691": {
       "disposition": "superseded",
@@ -2226,17 +2696,22 @@
     },
     "5a2906a11b4422c4e4f0a5d9955dc2a08ae3266e": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "5a3092b60106": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
+    "5a3d7fb99d1f23d3156e17575cabc664fc7fe593": {
+      "disposition": "ported",
+      "notes": "Ported/superseded by Rust binary image handling: xAI/OpenRouter-compatible image references use std::fs::read/tokio::fs::read byte reads before base64 data-URL encoding, never text decoding. Existing Rust image/video generation tests cover local image paths encoded as data URLs, so the Python windows-footgun suppression is not needed.",
+      "owner": "rust-runtime"
+    },
     "5a4bdfda5062055ca8ab4bfb68a8d7bc99067e10": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "5aa755e4e63c": {
       "disposition": "superseded",
@@ -2265,8 +2740,8 @@
     },
     "5b45fb269a06": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Upstream sanitizes JS kanban dashboard markdown before HTML insertion. The Rust runtime equivalent sink is Matrix formatted_body generation: markdown_to_html now escapes raw HTML before markdown expansion, only emits links for http/https/mailto hrefs, escapes generated link attributes, and feature-enabled Matrix tests cover raw <script>/<img> payloads, unsafe javascript: links, safe mailto links, and escaped labels/hrefs."
+      "notes": "Upstream sanitizes JS kanban dashboard markdown before HTML insertion. The Rust runtime equivalent sink is Matrix formatted_body generation: markdown_to_html now escapes raw HTML before markdown expansion, only emits links for http/https/mailto hrefs, escapes generated link attributes, and feature-enabled Matrix tests cover raw <script>/<img> payloads, unsafe javascript: links, safe mailto links, and escaped labels/hrefs.",
+      "owner": "rust-runtime"
     },
     "5b71f7dd7249": {
       "disposition": "superseded",
@@ -2283,6 +2758,11 @@
     "5c0a1fec0c14": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "5c2c85c5452f227e6f3b79d90d2c50f7adaddf8f": {
+      "disposition": "superseded",
+      "notes": "Upstream Python runtime delta is superseded by Hermes Ultra Rust-native agent/provider/tool architecture and existing deterministic Rust tests; the Python module path is not shipped in the Rust runtime.",
+      "owner": "rust-runtime"
     },
     "5d3398aa8a20": {
       "disposition": "superseded",
@@ -2302,8 +2782,8 @@
     },
     "5d661a3ad785a5668b5bdd6b0081f099d76689ed": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "5d6c16e97237": {
       "disposition": "superseded",
@@ -2312,6 +2792,11 @@
     "5d8c44a39341": {
       "disposition": "superseded",
       "notes": "Docker matrix dependency preinstall targets upstream image composition. Local Rust build/test gates and Docker policy are authoritative for this fork."
+    },
+    "5db1430af9ecd7ecc1e5eba93e7e1e965af59927": {
+      "disposition": "ported",
+      "notes": "Ported in Rust by routing background/helper spawns through CommandNoWindowExt across local/Docker/Singularity/SSH environments, MCP stdio, gateway hooks, cron, CLI probes, plugin git operations, computer-use, code execution, TTS, video/ffmpeg, Teams ffmpeg, and project/context git probes. Foreground terminal semantics stay unchanged while Windows background console flashes are suppressed.",
+      "owner": "rust-runtime"
     },
     "5dee40fcc0a1": {
       "disposition": "superseded",
@@ -2327,8 +2812,18 @@
     },
     "5e3e89cc05d3": {
       "disposition": "superseded",
+      "notes": "Upstream adds an embedded-daemon health grace timeout for Python Hindsight. Rust Hindsight has no embedded daemon health loop; it uses bounded reqwest clients and already supports HINDSIGHT_TIMEOUT plus config timeout aliases for HTTP operations.",
+      "owner": "rust-runtime"
+    },
+    "5e51b123f32b7f6a51fbd5759e89ba5146ce4003": {
+      "disposition": "ported",
       "owner": "rust-runtime",
-      "notes": "Upstream adds an embedded-daemon health grace timeout for Python Hindsight. Rust Hindsight has no embedded daemon health loop; it uses bounded reqwest clients and already supports HINDSIGHT_TIMEOUT plus config timeout aliases for HTTP operations."
+      "notes": "Ported in Rust Mem0 setup: hermes memory setup mem0 accepts --mode selfhosted --host ... [--api-key ...] [--dry-run], interactive prompts expose platform/selfhosted/oss, self-hosted hosts are persisted to mem0.json, optional secrets route to $HERMES_HOME/.env, reachability checks are non-fatal, and focused Rust tests plus a CLI dry-run prove the surface."
+    },
+    "5e51f9c689d15440fe6f0242c4a34d0278089788": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
     },
     "5e5308d34d87": {
       "disposition": "superseded",
@@ -2382,9 +2877,19 @@
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
+    "5fdc2acedcf9caa2dffc01a0410ca74b1b28d369": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "5feec8b4cfcb": {
       "disposition": "superseded",
       "notes": "Upstream relay conformance tests target the Python gateway relay adapter. Ultra has no active Rust relay adapter for this experimental contract, so the Python conformance harness is not a Rust runtime requirement.",
+      "owner": "rust-runtime"
+    },
+    "5ff11a689b561fdb1404aede3fafa543bbbb86bf": {
+      "disposition": "ported",
+      "notes": "Ported in Rust: /timestamps and /ts are registered slash commands; the interactive TUI supports on/off/toggle/status without mutating prompt text and non-TUI surfaces return an explicit TUI-control message. Covered by TUI state tests and split-module slash parity gates.",
       "owner": "rust-runtime"
     },
     "5ffbfed193ad13662b9e402f6667f111a7beae63": {
@@ -2395,6 +2900,11 @@
     "6062c24fd1c2": {
       "disposition": "superseded",
       "notes": "upstream python CI/release workflow delta superseded by local rust-first parity gates and release pipeline"
+    },
+    "608e8a6062271661ac2f2f27375ef9ad7eb32b12": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
     },
     "6092be413d59": {
       "disposition": "superseded",
@@ -2414,6 +2924,11 @@
       "notes": "Upstream fixes a Python re import and Python test relocation after WhatsApp adapter plugin migration. The Rust WhatsApp module is compile-tested under the whatsapp feature and has no Python adapter import path.",
       "owner": "rust-runtime"
     },
+    "61622bb56a7a24c0fc39e8a5a46537dfd2b2d9b6": {
+      "disposition": "superseded",
+      "notes": "Superseded by Rust model-switch architecture: CLI/TUI and gateway model switches update runtime config/defaults without appending a model-switch marker into model-facing history, so strict providers never see a mid-conversation system message. Added gateway_model_switch_does_not_inject_mid_history_system_marker regression coverage.",
+      "owner": "rust-runtime"
+    },
     "6183e8ce1b5ee79f2d808d0c17ea46fbbf128c37": {
       "disposition": "ported",
       "notes": "Ported in Rust Telegram config: Bot API 10.1 rich messages are opt-in/default-off in serde defaults and CLI config mapping, with gateway and CLI tests pinning the default.",
@@ -2421,8 +2936,8 @@
     },
     "61c266b0dc75562a97dc0a377a7dc141d0b0a5ac": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "61d9e3366d65": {
       "disposition": "superseded",
@@ -2456,13 +2971,13 @@
     },
     "62fe9fd101": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Lint/type/formatting commit is overwhelmingly Electron desktop/TUI TypeScript/CJS cleanup. Ultra has no apps/desktop tree and enforces Rust/docs formatting separately."
+      "notes": "Lint/type/formatting commit is overwhelmingly Electron desktop/TUI TypeScript/CJS cleanup. Ultra has no apps/desktop tree and enforces Rust/docs formatting separately.",
+      "owner": "rust-runtime"
     },
     "6308d3416ab9": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Renaming desktop Restart messaging to Restart gateway is Electron UI copy. Rust has no desktop statusbar/restart action surface to port."
+      "notes": "Renaming desktop Restart messaging to Restart gateway is Electron UI copy. Rust has no desktop statusbar/restart action surface to port.",
+      "owner": "rust-runtime"
     },
     "630a4ef03c8e": {
       "disposition": "superseded",
@@ -2470,8 +2985,8 @@
     },
     "6326d5c6f6e5f574d6e788939716506610a7b832": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported by Rust Telegram rich_text.rs: table detection/rendering is centralized in the Telegram adapter include rather than duplicated in delivery code, with pipe-table rich-message tests covering the behavior."
+      "notes": "Ported by Rust Telegram rich_text.rs: table detection/rendering is centralized in the Telegram adapter include rather than duplicated in delivery code, with pipe-table rich-message tests covering the behavior.",
+      "owner": "rust-runtime"
     },
     "632a7088a32a": {
       "disposition": "ported",
@@ -2484,8 +2999,13 @@
     },
     "638243726eb99497bf9bd9f9cdffca492abe190b": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported to the Rust container image: Dockerfile now uses BuildKit layer-linked copies, explicit binary/script chmod at COPY time, targeted license-file permissions, and install -d ownership for /data instead of broad recursive chmod/chown sweeps. Dockerfile packaging/PID-1 contract tests assert the Rust-image invariants."
+      "notes": "Ported to the Rust container image: Dockerfile now uses BuildKit layer-linked copies, explicit binary/script chmod at COPY time, targeted license-file permissions, and install -d ownership for /data instead of broad recursive chmod/chown sweeps. Dockerfile packaging/PID-1 contract tests assert the Rust-image invariants.",
+      "owner": "rust-runtime"
+    },
+    "638d2e7bfcad1be6e779c0d1af95481a6e92d811": {
+      "disposition": "ported",
+      "notes": "Ported in Rust holographic memory: search_facts uses the same sanitized FTS/LIKE path as retrieval and tests cover special-character fallback plus category filters.",
+      "owner": "rust-runtime"
     },
     "63991bbd9751": {
       "disposition": "ported",
@@ -2504,10 +3024,15 @@
       "disposition": "superseded",
       "notes": "documentation-only upstream delta superseded by local docs and rust parity guides"
     },
+    "64972b64038b97cf9af095dd5f107723a2ee6ab3": {
+      "disposition": "ported",
+      "notes": "Ported in Rust config compatibility: nested model blocks now canonicalize model.default, model.name, and model.model into the root model string with default precedence, covered by python_yaml_compat alias and precedence tests.",
+      "owner": "rust-runtime"
+    },
     "64a507da44d2": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported as a first-class Rust relay protocol contract: crates/hermes-gateway/src/relay.rs decodes passthrough_forward frames, preserves bodyB64 byte parity, carries ordered headers and bufferId, and tolerates malformed base64 without killing the caller. The experimental relay adapter remains unregistered by Rust platform policy."
+      "notes": "Ported as a first-class Rust relay protocol contract: crates/hermes-gateway/src/relay.rs decodes passthrough_forward frames, preserves bodyB64 byte parity, carries ordered headers and bufferId, and tolerates malformed base64 without killing the caller. The experimental relay adapter remains unregistered by Rust platform policy.",
+      "owner": "rust-runtime"
     },
     "64da518db413": {
       "disposition": "superseded",
@@ -2532,13 +3057,13 @@
     },
     "65a477f12e3581fb1771019672385ce011a94929": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "65b13e9dbc9330fe34cba2d44f915b05fe4b1f33": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "65c762b2e83e": {
       "disposition": "superseded",
@@ -2554,12 +3079,17 @@
     },
     "66a0907c9566016b4d8f295c176e6917f67f0f04": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "66adeef11a71": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "66ba9e06d92542268c97c500d5312100c299d973": {
+      "disposition": "superseded",
+      "notes": "Upstream GitHub Actions/CI-only delta is superseded by Hermes Ultra local Rust deterministic gates and release workflow; it does not add shipped Rust runtime behavior.",
+      "owner": "rust-runtime"
     },
     "66c70966cd2a": {
       "disposition": "ported",
@@ -2575,8 +3105,8 @@
     },
     "6776b2f9b57c01249c435c74798bc07eb539929b": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "680189b5def4": {
       "disposition": "ported",
@@ -2584,13 +3114,13 @@
     },
     "68680db10d1744bcff4fd2fbc519cccc8447e0e3": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "6875d6cd3e11770ac3029811d31002b515084584": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "68a997fed4a1": {
       "disposition": "superseded",
@@ -2612,6 +3142,11 @@
       "disposition": "superseded",
       "notes": "documentation-only upstream delta superseded by local docs and rust parity guides"
     },
+    "69f08c2eb5a2a68a072debd3e7f274141b6b98bf": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
+    },
     "6a2909fe5a07": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
@@ -2626,8 +3161,8 @@
     },
     "6ac9ba9fc4ad3c6ca0a450578cc78cd4dd243551": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "6b330522e1fb": {
       "disposition": "superseded",
@@ -2635,8 +3170,8 @@
     },
     "6b3ea2cea6889d24a67fbd973868c8cca2d8a615": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "6b4073648ece": {
       "disposition": "ported",
@@ -2649,8 +3184,8 @@
     },
     "6bbacc2238997718026c7868f4b76092fe602ed8": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "6c00077d3838": {
       "disposition": "superseded",
@@ -2658,32 +3193,37 @@
     },
     "6c44471bfdb8": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream lazy-installs the Python hindsight-client dependency for the embedded Python plugin. The Rust runtime has no Python Hindsight dependency or lazy install path; crates/hermes-agent/src/memory_plugins/hindsight.rs uses native reqwest HTTP clients and config-backed cloud/local_external modes."
+      "notes": "Upstream lazy-installs the Python hindsight-client dependency for the embedded Python plugin. The Rust runtime has no Python Hindsight dependency or lazy install path; crates/hermes-agent/src/memory_plugins/hindsight.rs uses native reqwest HTTP clients and config-backed cloud/local_external modes.",
+      "owner": "rust-runtime"
     },
     "6c52e4a318f6766d1e0dc7a4d87789f8614b501c": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "6cb04be779de": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Desktop Keys-tab provider grouping is React settings UI over Electron provider identity. Rust provider credentials are owned by config/auth/provider surfaces, not apps/desktop settings panes."
+      "notes": "Desktop Keys-tab provider grouping is React settings UI over Electron provider identity. Rust provider credentials are owned by config/auth/provider surfaces, not apps/desktop settings panes.",
+      "owner": "rust-runtime"
     },
     "6d2727ef1ce1": {
       "disposition": "ported",
       "notes": "Rust config loading normalizes Discord allow_from aliases from platforms.discord.allow_from and platforms.discord.extra.allow_from into allowed_users while preserving DISCORD_ALLOWED_USERS/env precedence, with loader regression coverage."
     },
+    "6d879d486b19716f8b09bd47bffb0b6e5b690431": {
+      "disposition": "superseded",
+      "notes": "Upstream Python runtime delta is superseded by Hermes Ultra Rust-native agent/provider/tool architecture and existing deterministic Rust tests; the Python module path is not shipped in the Rust runtime.",
+      "owner": "rust-runtime"
+    },
     "6d9ca0457464": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust session runtime: SessionPersistence and session_search now follow compression continuations even when the child row predates parent ended_at, prefer compression/live continuations over stale closed siblings, and exclude explicit branch/delegate/tool children with focused regression tests."
+      "notes": "Ported in Rust session runtime: SessionPersistence and session_search now follow compression continuations even when the child row predates parent ended_at, prefer compression/live continuations over stale closed siblings, and exclude explicit branch/delegate/tool children with focused regression tests.",
+      "owner": "rust-runtime"
     },
     "6da615c77cf": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Scoped onboarding runtime readiness is Electron desktop/tui_gateway Python behavior. Ultra has no apps/desktop tree or tui_gateway/server.py; Rust CLI/TUI/gateway provider readiness owns the applicable surface."
+      "notes": "Scoped onboarding runtime readiness is Electron desktop/tui_gateway Python behavior. Ultra has no apps/desktop tree or tui_gateway/server.py; Rust CLI/TUI/gateway provider readiness owns the applicable surface.",
+      "owner": "rust-runtime"
     },
     "6de3963e3769": {
       "disposition": "ported",
@@ -2691,13 +3231,13 @@
     },
     "6e096a850a2c82bdad4e4caa8e2d739ae34086f4": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "6e12f8ce4a30c3a95b0f2bd64deaa5f0bf4a17d0": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "6e20c1992ff9": {
       "disposition": "superseded",
@@ -2726,17 +3266,27 @@
     },
     "6e88f7b6f7b9": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported as Rust wake-url contract surface: hermes_gateway::relay resolves wake URL precedence from env/config sources, trims trailing slashes, and tests absent/env/config behavior for the connector wake primitive while keeping relay inactive by default."
+      "notes": "Ported as Rust wake-url contract surface: hermes_gateway::relay resolves wake URL precedence from env/config sources, trims trailing slashes, and tests absent/env/config behavior for the connector wake primitive while keeping relay inactive by default.",
+      "owner": "rust-runtime"
+    },
+    "6f1a176b3309d0474e0ef329834b622603c60471": {
+      "disposition": "ported",
+      "notes": "Ported in Rust DiscordAdapter: configurable REST liveness probe uses Discord users/@me through reqwest, honors liveness_interval_seconds/liveness_failure_threshold config knobs, marks the adapter unhealthy after repeated failures so the existing platform_reconnect_watcher restarts it, gates outbound REST sends while unhealthy, and supports api_base_url for deterministic tests. Focused Rust tests cover authenticated /users/@me probing, unhealthy transition, and disabled zero-knob behavior.",
+      "owner": "rust-runtime"
     },
     "6f6eb871d834": {
       "disposition": "ported",
       "notes": "Rust ACP session/new now accepts profile/home metadata and preserves it on the SessionState handed to prompt executors, so new chats can remain attached to their owning profile in the Rust runtime surface. Regression coverage asserts create, prompt, list, and fork profile ownership."
     },
+    "6fb25f86ac4946b7f50238c68b545f77b57fd9f4": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Telegram routing: should_process_message rejects messages from the configured bot_username when the sender is a bot before private/group acceptance; regression coverage proves own-bot messages are filtered and other bots are not over-blocked.",
+      "owner": "rust-runtime"
+    },
     "6fd839ac84d0": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream pet feature-guide/petdex skill docs are superseded by the Rust-native /pet runtime catalog: /pet list exposes species and moods from PetSettings, and validation tests keep the catalog executable instead of relying on desktop docs assets."
+      "notes": "Upstream pet feature-guide/petdex skill docs are superseded by the Rust-native /pet runtime catalog: /pet list exposes species and moods from PetSettings, and validation tests keep the catalog executable instead of relying on desktop docs assets.",
+      "owner": "rust-runtime"
     },
     "6feb2afd50cb": {
       "disposition": "ported",
@@ -2752,13 +3302,13 @@
     },
     "70319626a922": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust BusySessionCoordinator: interrupt mode now preserves a busy mid-turn prompt by queueing it before interrupting the active control, and finish drains the pending prompt on the next turn. Focused session_control tests cover queued interrupt status detail."
+      "notes": "Ported in Rust BusySessionCoordinator: interrupt mode now preserves a busy mid-turn prompt by queueing it before interrupting the active control, and finish drains the pending prompt on the next turn. Focused session_control tests cover queued interrupt status detail.",
+      "owner": "rust-runtime"
     },
     "7078d9d1e29": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust OpenRouter-compatible image generation timeout is raised to 300s for slow quality-first models and covered by openrouter_timeout_budget_matches_slow_quality_first_models."
+      "notes": "Rust OpenRouter-compatible image generation timeout is raised to 300s for slow quality-first models and covered by openrouter_timeout_budget_matches_slow_quality_first_models.",
+      "owner": "rust-runtime"
     },
     "70aaa774be92": {
       "disposition": "ported",
@@ -2766,8 +3316,8 @@
     },
     "70e7132e2ff7": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust OpenViking and memory fan-out: AgentLoop only calls MemoryManager.on_memory_write for successful non-error memory tool results, OpenViking on_memory_write remains add-only for native memory mirroring, and viking_forget is now a first-class tool that deletes only exact user memory .md viking:// URIs while rejecting resources, directories, generated summaries, broad deletes, query/fragment URIs, and non-memory targets. Focused Rust tests cover schemas, URI validation, DELETE /api/v1/fs request shape, and auth headers."
+      "notes": "Ported in Rust OpenViking and memory fan-out: AgentLoop only calls MemoryManager.on_memory_write for successful non-error memory tool results, OpenViking on_memory_write remains add-only for native memory mirroring, and viking_forget is now a first-class tool that deletes only exact user memory .md viking:// URIs while rejecting resources, directories, generated summaries, broad deletes, query/fragment URIs, and non-memory targets. Focused Rust tests cover schemas, URI validation, DELETE /api/v1/fs request shape, and auth headers.",
+      "owner": "rust-runtime"
     },
     "70f53f36cb1c": {
       "disposition": "ported",
@@ -2780,8 +3330,8 @@
     },
     "7130d60861a9": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Intentional divergence: upstream removed Google Gemini CLI/Antigravity OAuth providers. Ultra preserves google-gemini-cli OAuth as a first-class Rust provider surface; no google-antigravity provider alias is exposed locally."
+      "notes": "Intentional divergence: upstream removed Google Gemini CLI/Antigravity OAuth providers. Ultra preserves google-gemini-cli OAuth as a first-class Rust provider surface; no google-antigravity provider alias is exposed locally.",
+      "owner": "rust-runtime"
     },
     "7137cccbd134": {
       "disposition": "ported",
@@ -2802,8 +3352,8 @@
     },
     "7243111c57bb6fad870e2eee7eda4cfcada4d7af": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "7245bc77eb3b": {
       "disposition": "ported",
@@ -2813,10 +3363,15 @@
       "disposition": "ported",
       "notes": "Teams meeting pipeline skill asset is present at skills/productivity/teams-meeting-pipeline/SKILL.md, backed by the Rust teams_pipeline runtime."
     },
+    "729bbb7a309a3d13d8cc7d1cd2fbab79e7d969f7": {
+      "disposition": "superseded",
+      "notes": "Upstream docs/skills/website-only delta is superseded by local Rust-first docs, release notes, and parity evidence; no Rust runtime implementation is required for this queue row.",
+      "owner": "rust-runtime"
+    },
     "72bfc48e63a1": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust TUI: App reads active subagent lineage records from HERMES_HOME/subagents, counts started/running/background_pending jobs, refreshes the TUI status tick, and renders the active subagent count in the status bar with focused App coverage."
+      "notes": "Ported in Rust TUI: App reads active subagent lineage records from HERMES_HOME/subagents, counts started/running/background_pending jobs, refreshes the TUI status tick, and renders the active subagent count in the status bar with focused App coverage.",
+      "owner": "rust-runtime"
     },
     "72c8037a24b58b7b1a38a99903cc0bf8a3d7595c": {
       "disposition": "ported",
@@ -2824,8 +3379,8 @@
     },
     "72e4cca00ecc2a1d9bdef95575bb2c779a87150c": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream only corrects a stale MCP comment in cli-config.yaml.example, a file not shipped by Hermes Agent Ultra. Local MCP configuration docs live under website/docs/reference/mcp-config-reference.md and website/docs/user-guide/features/tool-gateway.md."
+      "notes": "Upstream only corrects a stale MCP comment in cli-config.yaml.example, a file not shipped by Hermes Agent Ultra. Local MCP configuration docs live under website/docs/reference/mcp-config-reference.md and website/docs/user-guide/features/tool-gateway.md.",
+      "owner": "rust-runtime"
     },
     "72eb42d9ecdf": {
       "disposition": "superseded",
@@ -2842,6 +3397,11 @@
     "7330183d087f": {
       "disposition": "superseded",
       "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
+    },
+    "7337248a4c182d65b6c101acac1e21be5101c4cc": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
     },
     "733e297b8a5c": {
       "disposition": "superseded",
@@ -2878,22 +3438,27 @@
     },
     "74352a1e61361daa87f7ec5dfe9eed41777d79cd": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "743985bf1ec4c911cd5af7bec705a419d8cdd61b": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "743c55efa34f": {
       "disposition": "superseded",
       "notes": "Upstream HTML5 backend remount fix targets the desktop file tree drag/drop provider. Hermes Agent Ultra has no React DnD file tree runtime."
     },
+    "74541beb9ce32fcb1b8d89d698120d4b59d34ca8": {
+      "disposition": "ported",
+      "notes": "Ported in Rust WeCom callback adapter: POST callback requests now enforce a 64 KiB body limit from Content-Length and from buffered body length before Encrypt XML extraction/decrypt, returning 413 for oversized unauthenticated payloads. Focused wecom-callback tests cover oversized declared length, oversized buffered body, and normal callback envelopes.",
+      "owner": "rust-runtime"
+    },
     "745c4db235bdb09beb19564f66727dc1f43e4fe2": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "746618217950": {
       "disposition": "superseded",
@@ -2902,6 +3467,11 @@
     "74c8f51e95e4": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "7548910ecec412b84cb92e180f0e6017f176f0eb": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
     },
     "758c40135f0f": {
       "disposition": "ported",
@@ -2913,8 +3483,8 @@
     },
     "75b36a138f43": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported as the Rust TUI pet surface: /pet is registered and completable, PetSettings persist to pet.json, the TUI renders species-specific frames with dock/tick behavior, and command/app/TUI tests cover catalog validation and persistence. Upstream gateway RPCs are not a separate Rust target because the native TUI owns pet settings directly."
+      "notes": "Ported as the Rust TUI pet surface: /pet is registered and completable, PetSettings persist to pet.json, the TUI renders species-specific frames with dock/tick behavior, and command/app/TUI tests cover catalog validation and persistence. Upstream gateway RPCs are not a separate Rust target because the native TUI owns pet settings directly.",
+      "owner": "rust-runtime"
     },
     "75e29f97ee39": {
       "disposition": "superseded",
@@ -2922,8 +3492,8 @@
     },
     "76074b214517109f4816ea6e83042ea65712b131": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "769f307042d2": {
       "disposition": "superseded",
@@ -2950,14 +3520,19 @@
       "disposition": "superseded",
       "notes": "Upstream Singularity/run-script terminal environment tuning is not a separate Rust runtime surface; Rust terminal execution already exposes explicit timeout, workdir, background, PTY, stdin, and process-polling contracts through typed handlers and tests."
     },
+    "773a3703bfc1f8ff2f3aef40d7a565e7f4fe1404": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "77687156b4b8": {
       "disposition": "superseded",
       "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
     },
     "7785655b4ece4deb7e8bbeeaa2a6a8342746d465": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "77bb64813cb9": {
       "disposition": "superseded",
@@ -3007,17 +3582,22 @@
     },
     "79f270f5496267ca9713d40af277e8453e528d8f": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "79f297834a9b": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by Rust-native gateway adapters for Slack/Telegram/WhatsApp: there is no plugins/platforms Python sys.path mutation or cron namespace collision class in the Rust runtime."
+      "notes": "Superseded by Rust-native gateway adapters for Slack/Telegram/WhatsApp: there is no plugins/platforms Python sys.path mutation or cron namespace collision class in the Rust runtime.",
+      "owner": "rust-runtime"
     },
     "79f7e7a1e9d8": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "7a2369718a126f624357430a3defce1a1aec668d": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
     },
     "7a2d498b9dd2": {
       "disposition": "superseded",
@@ -3033,18 +3613,18 @@
     },
     "7a6b3cb923f1fa99260b909e3729c35e6ffee323": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "7a7b56d49830": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust hermes-config exposes a managed Node/npm/npx resolver that prefers Hermes-managed portable Node before PATH, and CLI dependency checks plus WhatsApp bridge-start guidance use it; managed-node and CLI tests cover the behavior."
+      "notes": "Rust hermes-config exposes a managed Node/npm/npx resolver that prefers Hermes-managed portable Node before PATH, and CLI dependency checks plus WhatsApp bridge-start guidance use it; managed-node and CLI tests cover the behavior.",
+      "owner": "rust-runtime"
     },
     "7a7f9a5b3d1af1bab4f7d50484b836c5dceb7a50": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "7aaae7acd0d6": {
       "disposition": "superseded",
@@ -3062,18 +3642,38 @@
       "disposition": "superseded",
       "notes": "Upstream /credits adds Python CLI/gateway billing views and Ink UI-TUI RPC/buttons. Hermes Agent Ultra's Rust runtime has provider auth diagnostics and usage accounting, but it does not ship the upstream Python CLI or Ink TUI money surface, so this UI-only command remains reference-only until a Rust-native billing surface is deliberately designed."
     },
+    "7bb8aa3bd55d0d4b39bc9e026d780d92fe0b306a": {
+      "disposition": "ported",
+      "notes": "Ported with Rust tests for browser open-timeout floors, timeout diagnostics, sandbox hint formatting, bounded CDP timeout behavior, and failed-navigate labeling. The upstream desktop chip text is represented in the Rust tool error surface because this repo does not ship the Electron chip UI.",
+      "owner": "rust-runtime"
+    },
     "7bc6f1806284": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream skips the local_embedded Hindsight daemon when running as root. Rust Hindsight does not launch an embedded daemon and normalizes legacy local/local_embedded modes to local_external HTTP, so the root daemon guard is not applicable."
+      "notes": "Upstream skips the local_embedded Hindsight daemon when running as root. Rust Hindsight does not launch an embedded daemon and normalizes legacy local/local_embedded modes to local_external HTTP, so the root daemon guard is not applicable.",
+      "owner": "rust-runtime"
     },
     "7c00ffd92c41": {
       "disposition": "ported",
       "notes": "Google Workspace setup fallback behavior is represented in skills/productivity/google-workspace/scripts/setup.py, including virtualenv/pip diagnostics and uv-compatible setup guidance."
     },
+    "7c0a5def58fbec985ace8c887ca3484f7b8cf584": {
+      "disposition": "ported",
+      "notes": "Ported/already covered in Rust Holographic memory: shutdown deterministically drops the rusqlite Connection by clearing the guarded Option instead of relying on later process teardown. Added a focused regression test that initialized connections are gone after shutdown.",
+      "owner": "rust-runtime"
+    },
+    "7c1a029553d87c43ecff8a3821336bc95872213b": {
+      "disposition": "superseded",
+      "notes": "Upstream release metadata commit for v0.18.0 is superseded by local Hermes Ultra release/tag history and does not represent a runtime patch.",
+      "owner": "rust-runtime"
+    },
     "7c226cc57fe6": {
       "disposition": "superseded",
       "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "7c7b489813184c54dc3d57a0a7d1c37182c4d8ff": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Slack adapter: Block Kit rendering is first-class and native table/block structures are represented by the Rust socket_blocks model and tests.",
+      "owner": "rust-runtime"
     },
     "7cbe943d2dc1": {
       "disposition": "ported",
@@ -3085,8 +3685,8 @@
     },
     "7cf6758e336c67b1b90cb93928f609008a3a8e5e": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "7d183f64979f": {
       "disposition": "superseded",
@@ -3094,13 +3694,13 @@
     },
     "7d1b72a15d": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Cursor-anchored pet zoom is Electron pet overlay UI only. Ultra has no desktop pet overlay runtime."
+      "notes": "Cursor-anchored pet zoom is Electron pet overlay UI only. Ultra has no desktop pet overlay runtime.",
+      "owner": "rust-runtime"
     },
     "7d3c1d55f4e7f74539ffde1c8bde39701c2a3996": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "7d66d30d774e": {
       "disposition": "superseded",
@@ -3108,8 +3708,8 @@
     },
     "7d86178cf51a": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by absent Rust Raft subprocess path: upstream sets stdin=DEVNULL on a Python Raft bridge subprocess, but Hermes Ultra has no Raft bridge adapter or Python subprocess launcher in the Rust gateway runtime."
+      "notes": "Superseded by absent Rust Raft subprocess path: upstream sets stdin=DEVNULL on a Python Raft bridge subprocess, but Hermes Ultra has no Raft bridge adapter or Python subprocess launcher in the Rust gateway runtime.",
+      "owner": "rust-runtime"
     },
     "7d938cc5c9c7": {
       "disposition": "superseded",
@@ -3117,8 +3717,8 @@
     },
     "7daa6d83fcaa4822f5a6f878c5e78f0d94ff1d26": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "7de8cd4c5f67": {
       "disposition": "ported",
@@ -3126,17 +3726,22 @@
     },
     "7e101e553b52e157e9a8a5c11faf81921776e06f": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust MoA runtime config: reference_models and aggregator_model now reject moa/mixture virtual-provider slots, including env-derived config, before dispatching any OpenAI-compatible requests. Focused hermes-tools tests cover reference, aggregator, and env-derived recursive slot rejection."
+      "notes": "Ported in Rust MoA runtime config: reference_models and aggregator_model now reject moa/mixture virtual-provider slots, including env-derived config, before dispatching any OpenAI-compatible requests. Focused hermes-tools tests cover reference, aggregator, and env-derived recursive slot rejection.",
+      "owner": "rust-runtime"
     },
     "7e2af0c2e872": {
       "disposition": "superseded",
       "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
     },
+    "7e2ca7f68da63a29e1695b5e24901cc57e32f2ac": {
+      "disposition": "superseded",
+      "notes": "Superseded by Rust Telegram HTTP transport: outbound sends use a reqwest client and do not expose PTB's bot._request[1] general request pool that can be shutdown/reinitialized after a Python pool timeout. No Rust send pool reset hook exists or is needed for that Python-specific failure mode.",
+      "owner": "rust-runtime"
+    },
     "7e2db0a140dbdbcf32035f9174c3e189317f8168": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "7e3c8a31f0f3": {
       "disposition": "ported",
@@ -3148,13 +3753,18 @@
     },
     "7eb9678c5470": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream test covers Electron hidden link-title audio muting, a desktop-only surface absent from the Rust runtime."
+      "notes": "Upstream test covers Electron hidden link-title audio muting, a desktop-only surface absent from the Rust runtime.",
+      "owner": "rust-runtime"
+    },
+    "7ee0b689739e80c75d7c32f42cf2a79a2207c0a0": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Feishu shutdown semantics: real stop() sets a closing guard so post-shutdown calls cannot resurrect outbound work, while start() clears the guard before reconnect token refresh. Focused async tests cover refusal and re-arm state.",
+      "owner": "rust-runtime"
     },
     "7ef0f360d0ce": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust tools now record bounded passive terminal verification evidence under HERMES_HOME and HTTP JSON-RPC exposes verification.status for workspace/session lookup. Focused tools and HTTP route tests cover ledger recording, pass/fail status, session filtering, workspace scoping, and not-applicable behavior."
+      "notes": "Rust tools now record bounded passive terminal verification evidence under HERMES_HOME and HTTP JSON-RPC exposes verification.status for workspace/session lookup. Focused tools and HTTP route tests cover ledger recording, pass/fail status, session filtering, workspace scoping, and not-applicable behavior.",
+      "owner": "rust-runtime"
     },
     "7f016f5f3360": {
       "disposition": "ported",
@@ -3166,8 +3776,8 @@
     },
     "7f1c278db817": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by absent Rust Photon sidecar: upstream intercepts console.log in the Photon JavaScript sidecar, but Hermes Ultra does not ship or execute that sidecar."
+      "notes": "Superseded by absent Rust Photon sidecar: upstream intercepts console.log in the Photon JavaScript sidecar, but Hermes Ultra does not ship or execute that sidecar.",
+      "owner": "rust-runtime"
     },
     "7f302c91b240": {
       "disposition": "superseded",
@@ -3175,8 +3785,8 @@
     },
     "7f43378931f3f3ed619588ba50d08779c82ea1eb": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported as Rust ACP regression coverage: tests prove session.title renames a live runtime-only session without REST, persists exactly once, updates session_info_update/list surfaces, maps session.title and session/title method aliases, and rejects empty-title or missing-session RPC calls."
+      "notes": "Ported as Rust ACP regression coverage: tests prove session.title renames a live runtime-only session without REST, persists exactly once, updates session_info_update/list surfaces, maps session.title and session/title method aliases, and rejects empty-title or missing-session RPC calls.",
+      "owner": "rust-runtime"
     },
     "7fbe9b79ab1d": {
       "disposition": "superseded",
@@ -3184,8 +3794,13 @@
     },
     "7ff48a6291f5": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Discord component authorization: discord_component_allows_with_pairing now allows explicitly approved PairingManager users after allowlist/role checks fail, while denied/unpaired users remain fail-closed. Focused Rust tests cover approved, denied, and unpaired component subjects."
+      "notes": "Ported in Rust Discord component authorization: discord_component_allows_with_pairing now allows explicitly approved PairingManager users after allowlist/role checks fail, while denied/unpaired users remain fail-closed. Focused Rust tests cover approved, denied, and unpaired component subjects.",
+      "owner": "rust-runtime"
+    },
+    "7ff86f4458dd7547cab4392686896cbe5fb649a1": {
+      "disposition": "superseded",
+      "notes": "Upstream patch is Electron desktop shared embeds registry plumbing. Hermes Ultra Rust-first shipped surfaces do not use apps/desktop; no Rust runtime behavior is missing.",
+      "owner": "rust-runtime"
     },
     "8044bf0206c1": {
       "disposition": "superseded",
@@ -3202,8 +3817,13 @@
     },
     "807bdc17f62b": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream fixes Python discord.py auto-create-thread duplicate MESSAGE_CREATE dispatch. The Rust Discord adapter has no live inbound auto-create-thread dispatcher calling create_thread from message handling; duplicate suppression is centralized in Gateway::should_suppress_duplicate before session dispatch, so the Python thread-starter preseed path is absent."
+      "notes": "Upstream fixes Python discord.py auto-create-thread duplicate MESSAGE_CREATE dispatch. The Rust Discord adapter has no live inbound auto-create-thread dispatcher calling create_thread from message handling; duplicate suppression is centralized in Gateway::should_suppress_duplicate before session dispatch, so the Python thread-starter preseed path is absent.",
+      "owner": "rust-runtime"
+    },
+    "808ba82125e2ccaca9d0df1d5557a173e5242504": {
+      "disposition": "superseded",
+      "notes": "Upstream GitHub Actions/CI-only delta is superseded by Hermes Ultra local Rust deterministic gates and release workflow; it does not add shipped Rust runtime behavior.",
+      "owner": "rust-runtime"
     },
     "80bb5f294755": {
       "disposition": "superseded",
@@ -3240,17 +3860,22 @@
     },
     "8194dbf6126f404a43acb93f2778854d3c1a620e": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "81ac562bf0": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Inline embed detection/module primitives are Electron assistant-ui components and package-lock changes. Ultra has no apps/desktop assistant-ui renderer."
+      "notes": "Inline embed detection/module primitives are Electron assistant-ui components and package-lock changes. Ultra has no apps/desktop assistant-ui renderer.",
+      "owner": "rust-runtime"
     },
     "81cd67829191": {
       "disposition": "ported",
       "notes": "Google Workspace SKILL.md frontmatter declares required_credential_files for google_token.json and google_client_secret.json."
+    },
+    "821d9f709f365453abde7ca71445bc0aad9bdaa1": {
+      "disposition": "ported",
+      "notes": "Ported/superseded by Rust prompt config: AgentConfig exposes system_prompt plus coding_context auto/focus/on/off, and build_system_prompt injects deterministic coding guidance only on coding tool/workspace surfaces.",
+      "owner": "rust-runtime"
     },
     "82205276c1ae": {
       "disposition": "ported",
@@ -3266,8 +3891,13 @@
     },
     "838daca9f4cf": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Tooltip indentation and author-map formatting are desktop/metadata polish with no Rust runtime behavior to port."
+      "notes": "Tooltip indentation and author-map formatting are desktop/metadata polish with no Rust runtime behavior to port.",
+      "owner": "rust-runtime"
+    },
+    "83b7c52ece76b73ee878e9336722572e7d273cab": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
     },
     "83c13862f107": {
       "disposition": "superseded",
@@ -3276,6 +3906,11 @@
     "83c23e88617c": {
       "disposition": "superseded",
       "notes": "installer/release python-script delta superseded by local rust-first install/release flow"
+    },
+    "83e10a6777f93ba2dfb2b344314912bb9f969202": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
     },
     "840ebe063eea": {
       "disposition": "superseded",
@@ -3287,22 +3922,27 @@
     },
     "8446c1570683d99859f53b27002f21f4d19c1955": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Documentation-only upstream delta is superseded by local Rust-first docs/parity/release surfaces; it does not add or change a shipped Rust runtime behavior. Skills/docs/config-mixed items remain pending for separate evidence."
+      "notes": "Documentation-only upstream delta is superseded by local Rust-first docs/parity/release surfaces; it does not add or change a shipped Rust runtime behavior. Skills/docs/config-mixed items remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "84e1d31e5442eeff0bfcf1c2ffab6acf7fe95f45": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Kanban injected-guidance refactor is represented locally by Rust Kanban command/runtime behavior plus v2 kanban-worker and kanban-orchestrator skills that explicitly state the lifecycle is auto-injected while retaining deeper playbooks. Rust Kanban tests cover command parsing, task state, attachments, and goal-loop behavior."
+      "notes": "Kanban injected-guidance refactor is represented locally by Rust Kanban command/runtime behavior plus v2 kanban-worker and kanban-orchestrator skills that explicitly state the lifecycle is auto-injected while retaining deeper playbooks. Rust Kanban tests cover command parsing, task state, attachments, and goal-loop behavior.",
+      "owner": "rust-runtime"
     },
     "84eb5f1f891b": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
+    "84f350efe06be9f0c2e9b05471acad5db91b0e7b": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
+    },
     "8501caf51f6d0ff5782a0a00c85a319a449d781b": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Telegram gateway polling: getUpdates requests now have bounded poll-window-plus-grace timeouts, polling errors flow through exponential backoff counters, and sustained failures mark the adapter unhealthy so the gateway reconnect watcher can restart it without losing the resident poll task."
+      "notes": "Ported in Rust Telegram gateway polling: getUpdates requests now have bounded poll-window-plus-grace timeouts, polling errors flow through exponential backoff counters, and sustained failures mark the adapter unhealthy so the gateway reconnect watcher can restart it without losing the resident poll task.",
+      "owner": "rust-runtime"
     },
     "850413f1203f": {
       "disposition": "superseded",
@@ -3314,8 +3954,8 @@
     },
     "851f75d4df0a1b5fb4d58c78087652c311add903": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Discord authorization: user allowlist matching now treats * as an allow-all wildcard for component and slash auth, complementing the existing gateway/platform wildcard policy and channel wildcard tests."
+      "notes": "Ported in Rust Discord authorization: user allowlist matching now treats * as an allow-all wildcard for component and slash auth, complementing the existing gateway/platform wildcard policy and channel wildcard tests.",
+      "owner": "rust-runtime"
     },
     "85383c636309": {
       "disposition": "superseded",
@@ -3327,8 +3967,8 @@
     },
     "8559246bfb": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Clarify prompt rebuild to match chat UI is Electron assistant-ui/i18n behavior. Ultra Rust clarify/approval prompts are handled in CLI/TUI, not apps/desktop."
+      "notes": "Clarify prompt rebuild to match chat UI is Electron assistant-ui/i18n behavior. Ultra Rust clarify/approval prompts are handled in CLI/TUI, not apps/desktop.",
+      "owner": "rust-runtime"
     },
     "85b65e29f09b": {
       "disposition": "superseded",
@@ -3349,18 +3989,18 @@
     },
     "8666fd7635bab1f66d82d180e5afffa89a57e8ba": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "866f1d65c4aa7b8589f03b0810ef24464bf86965": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "86b990fe0fac": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream floating desktop pet overlay and Cmd+K picker are Electron desktop-only surfaces. Hermes Agent Ultra has no apps/desktop tree; the shipped Rust pet UX is the CLI/TUI /pet command, persisted settings, and TUI frame rendering."
+      "notes": "Upstream floating desktop pet overlay and Cmd+K picker are Electron desktop-only surfaces. Hermes Agent Ultra has no apps/desktop tree; the shipped Rust pet UX is the CLI/TUI /pet command, persisted settings, and TUI frame rendering.",
+      "owner": "rust-runtime"
     },
     "86c64cfb5bd5": {
       "disposition": "superseded",
@@ -3368,8 +4008,8 @@
     },
     "86e4521cb1d9": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust gateway delivery now has adapter-aware long-output handling: PlatformAdapter exposes splits_long_messages, DeliveryRouter and live Gateway sends preserve full payloads for verified chunking adapters while saving audit copies, non-chunking adapters truncate to 4000 chars with a full-output file footer, and cron gateway delivery passes the job id as the audit label. Focused delivery/gateway tests cover chunking preservation, non-chunking truncation, audit-file contents, and job-label sanitization."
+      "notes": "Rust gateway delivery now has adapter-aware long-output handling: PlatformAdapter exposes splits_long_messages, DeliveryRouter and live Gateway sends preserve full payloads for verified chunking adapters while saving audit copies, non-chunking adapters truncate to 4000 chars with a full-output file footer, and cron gateway delivery passes the job id as the audit label. Focused delivery/gateway tests cover chunking preservation, non-chunking truncation, audit-file contents, and job-label sanitization.",
+      "owner": "rust-runtime"
     },
     "86f2946fbe78": {
       "disposition": "superseded",
@@ -3384,9 +4024,29 @@
       "disposition": "superseded",
       "notes": "python runtime path delta superseded by rust-native implementation for corresponding product surface"
     },
+    "8795dfa33169b82f6cae7ec22632c430778182d0": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
+    "87b65e24a799ded350c31afcdb7077cf45bf5c13": {
+      "disposition": "ported",
+      "notes": "Rust compression is scoped to explicit gateway/app-server/session runtime paths rather than global Python runtime state; gateway /compress and agent-cache tests cover the app-server-facing behavior.",
+      "owner": "rust-runtime"
+    },
+    "87be36c240ecc14c4b47584b401fc236acba549f": {
+      "disposition": "ported",
+      "notes": "Discord component labels now budget by UTF-16 units via discord_utf16_len/truncate_discord_utf16_units, with emoji boundary tests for clarify buttons.",
+      "owner": "rust-runtime"
+    },
     "87c6edc1d04f": {
       "disposition": "ported",
       "notes": "Google Workspace setup.py and gws_bridge.py were synced from upstream source truth and now pass explicit urlopen timeouts for OAuth/live-check network calls."
+    },
+    "882730026739c51e6ae5c7cbe47e9b64a920a065": {
+      "disposition": "superseded",
+      "notes": "Upstream Photon tapback correlation targets the absent Photon adapter and Spectrum TS sidecar. Hermes Agent Ultra does not ship that bridge; Rust gateway reaction/media behavior is owned by the compiled platform adapters instead.",
+      "owner": "rust-runtime"
     },
     "883e11f0a09a": {
       "disposition": "superseded",
@@ -3394,21 +4054,36 @@
     },
     "8845f3316c26": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by Rust architecture and tests: the Rust dashboard command only enables the api_server platform and does not auto-import plugin Python backend APIs; plugin discovery test fixtures with dashboard/manifest.json api.py prove discovery keeps user/project Python dashboard backends inert."
+      "notes": "Superseded by Rust architecture and tests: the Rust dashboard command only enables the api_server platform and does not auto-import plugin Python backend APIs; plugin discovery test fixtures with dashboard/manifest.json api.py prove discovery keeps user/project Python dashboard backends inert.",
+      "owner": "rust-runtime"
     },
     "8878484f8519": {
       "disposition": "superseded",
       "notes": "Upstream remote filesystem browsing wires Electron desktop profile routes. Hermes Agent Ultra does not ship the Electron remote file tree; Rust remote/profile behavior is represented by ACP/gateway session metadata and explicit tool surfaces."
     },
+    "88bd1c01e1956ef6ed35ac6cce00e02ec7cf29bb": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
+    },
     "88bdb6b07451": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
+    "88c9dfecb23c372c20e760057e44856188b91566": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Slack adapter: Block Kit docs/runtime contract is represented directly by typed Rust builders rather than Python docstrings.",
+      "owner": "rust-runtime"
+    },
+    "88e29e35bd327c51306edad22d700d79b4b97f40": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "890e890281": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Desktop package-lock churn targets apps/desktop/package.json and top-level package-lock.json, neither of which are Ultra Rust runtime surfaces."
+      "notes": "Desktop package-lock churn targets apps/desktop/package.json and top-level package-lock.json, neither of which are Ultra Rust runtime surfaces.",
+      "owner": "rust-runtime"
     },
     "891c9a682348": {
       "disposition": "superseded",
@@ -3430,13 +4105,28 @@
       "disposition": "ported",
       "notes": "Google OAuth redirect scope parsing is implemented in skills/productivity/google-workspace/scripts/setup.py by extracting the scope query parameter from the pasted callback URL and storing granted scopes."
     },
+    "89cf65ab63988656124770e43cf8defd1ec8799b": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "8a19884bf399": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
+    "8a7d0790dffbcaf6bfb94dfc0f9ed794a2a5525f": {
+      "disposition": "ported",
+      "notes": "Split pairing-store behavior is covered by Rust DmManager platform-scoped pairing state and Discord component pairing fallback, with gateway/DM tests proving no cross-platform allowlist bleed.",
+      "owner": "rust-runtime"
+    },
     "8a9ded5b21b1": {
       "disposition": "ported",
       "notes": "Rust gateway now has a dependency-free 48 kHz stereo s16le continuous VoiceMixer with ambient loops, ducked speech overlays, clipping, stop/cleanup, and synthesized ambient PCM, plus VoiceManager voice_fx lifecycle integration for join/remove, active checks, ack phrase selection, speech enqueue/read/stop, and focused mixer/manager unit tests."
+    },
+    "8ad15ff7dde90dc7f05114133cc3b553947018e6": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
     },
     "8b1ff55f5382": {
       "disposition": "superseded",
@@ -3463,6 +4153,11 @@
       "notes": "Ported/superseded by the Rust TUI model/provider modal implementation in crates/hermes-cli/src/tui.rs; the Python tui_gateway cleanup target is not shipped as the runtime backend.",
       "owner": "rust-runtime"
     },
+    "8ce3c2f99152e20be26abe604c57929fb8496dc7": {
+      "disposition": "superseded",
+      "notes": "Upstream patch is Electron desktop appearance/zoom UI only. Hermes Ultra does not ship apps/desktop as a primary runtime product.",
+      "owner": "rust-runtime"
+    },
     "8cf7df867e7d": {
       "disposition": "superseded",
       "notes": "Upstream Raft check_fn log-spam fix targets a Python bundled raft platform plugin. Hermes Agent Ultra Rust gateway has no raft platform adapter/check_fn registration path, so the repeated load_gateway_config warning failure mode is absent.",
@@ -3475,8 +4170,8 @@
     },
     "8d1706ae5cb2e0bcffd6496d45e3c7f10e4b0cc1": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "8d256779d8fa": {
       "disposition": "ported",
@@ -3488,8 +4183,18 @@
     },
     "8d8c7111d96d8c9451573e942746f16fb9a555da": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
+    },
+    "8da0a56ba86a713a49b6fd61c79004aad7580a19": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
+    "8dcbc910bfd131dcfa7b83bf61e11e4807dce4ec": {
+      "disposition": "superseded",
+      "notes": "Upstream Python runtime delta is superseded by Hermes Ultra Rust-native agent/provider/tool architecture and existing deterministic Rust tests; the Python module path is not shipped in the Rust runtime.",
+      "owner": "rust-runtime"
     },
     "8e0c48e6d25b": {
       "disposition": "ported",
@@ -3497,17 +4202,22 @@
     },
     "8e356eccea34214252955f5035ebef379518b760": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Documentation/infographic-only upstream delta is superseded by Hermes Agent Ultra's Rust-first docs/parity/release surfaces for this batch; it does not add or change a shipped Rust runtime behavior. Runtime, provider, platform, and install changes remain pending for separate evidence."
+      "notes": "Documentation/infographic-only upstream delta is superseded by Hermes Agent Ultra's Rust-first docs/parity/release surfaces for this batch; it does not add or change a shipped Rust runtime behavior. Runtime, provider, platform, and install changes remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "8e629b9f386d": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
+    "8e94e8f8821986b5e94200936c1b6bc2b603487f": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
+    },
     "8ebe37f6ad2d": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "GPU-disabled remote-display notification is Electron desktop renderer behavior. Hermes Agent Ultra has no Electron GPU acceleration or desktop notification renderer."
+      "notes": "GPU-disabled remote-display notification is Electron desktop renderer behavior. Hermes Agent Ultra has no Electron GPU acceleration or desktop notification renderer.",
+      "owner": "rust-runtime"
     },
     "8f73d0d945d5": {
       "disposition": "superseded",
@@ -3521,10 +4231,20 @@
       "disposition": "superseded",
       "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
     },
+    "8fe8c2d6c476d50d4aaed13a924329fabd57a190": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "9026a8c78974": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by Rust platform policy: upstream added a Python Raft bundled platform plugin and tests, but Hermes Ultra does not advertise or register a Rust Raft platform adapter. The Rust gateway owns first-class native adapters under crates/hermes-gateway/src/platforms and does not import Python plugins/platforms at runtime."
+      "notes": "Superseded by Rust platform policy: upstream added a Python Raft bundled platform plugin and tests, but Hermes Ultra does not advertise or register a Rust Raft platform adapter. The Rust gateway owns first-class native adapters under crates/hermes-gateway/src/platforms and does not import Python plugins/platforms at runtime.",
+      "owner": "rust-runtime"
+    },
+    "9048457eabb4ec95ec0321ba580fc32b4cfa7b67": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
     },
     "906bee9cf791": {
       "disposition": "superseded",
@@ -3538,6 +4258,11 @@
       "disposition": "superseded",
       "notes": "Upstream remote workspace defaults are Electron desktop profile defaults. Hermes Agent Ultra workspace/cwd state is carried by CLI, ACP, gateway session metadata, and terminal/workdir normalization rather than desktop remote workspace defaults."
     },
+    "917f6bdb00b8b4d0f1c678702c639a5bc966a8eb": {
+      "disposition": "ported",
+      "notes": "Ported in Rust: vision_analyze no longer depends solely on HERMES_OPENAI_API_KEY/OPENAI_API_KEY. The OpenAI-compatible vision backend resolves AUXILIARY_VISION_PROVIDER/MODEL/BASE_URL/API_KEY, supports custom endpoints and provider keys such as OpenRouter/Nous/Gemini/xAI/Z.ai/GMI/HuggingFace, and builtin registration advertises those env surfaces. Covered by vision endpoint resolver tests.",
+      "owner": "rust-runtime"
+    },
     "91e9459e1006": {
       "disposition": "ported",
       "notes": "Rust OpenViking tracks all background writers per session id in an inflight writer map and drains every writer for that session before commit.",
@@ -3545,8 +4270,8 @@
     },
     "92451151c6429e1d2774c5e7f43269ebcf8c64aa": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Post-revert final skill surface is present locally: optional concept-diagrams and bundled architecture-diagram/sketch skill assets remain available, and html-artifact is absent."
+      "notes": "Post-revert final skill surface is present locally: optional concept-diagrams and bundled architecture-diagram/sketch skill assets remain available, and html-artifact is absent.",
+      "owner": "rust-runtime"
     },
     "928f1ac0e187": {
       "disposition": "superseded",
@@ -3554,8 +4279,8 @@
     },
     "929dbf777801": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Selectable rendered logs are React desktop presentation behavior. Rust logs and command output remain terminal/TUI text surfaces."
+      "notes": "Selectable rendered logs are React desktop presentation behavior. Rust logs and command output remain terminal/TUI text surfaces.",
+      "owner": "rust-runtime"
     },
     "92a456f711eb": {
       "disposition": "superseded",
@@ -3573,8 +4298,13 @@
     },
     "93192059c96c5ba56c28c6c41255bc63af4c95fa": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
+    },
+    "931e2356af9bdc7ee0996e25ff9afc51216763ad": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
     },
     "93228d529996": {
       "disposition": "superseded",
@@ -3590,13 +4320,13 @@
     },
     "935f2bc48daa9c7fad73f80c95d4375da18a39c1": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Documentation-only upstream delta is superseded by local Rust-first docs/parity/release surfaces; it does not add or change a shipped Rust runtime behavior. Skills/docs/config-mixed items remain pending for separate evidence."
+      "notes": "Documentation-only upstream delta is superseded by local Rust-first docs/parity/release surfaces; it does not add or change a shipped Rust runtime behavior. Skills/docs/config-mixed items remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "9362ce2575e00f5a795285b74e79d54c02e1326c": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream html-artifact consolidation was later reverted by 92451151; Hermes Agent Ultra already matches the post-revert skill surface by retaining concept-diagrams, architecture-diagram, and sketch skill assets and not shipping html-artifact."
+      "notes": "Upstream html-artifact consolidation was later reverted by 92451151; Hermes Agent Ultra already matches the post-revert skill surface by retaining concept-diagrams, architecture-diagram, and sketch skill assets and not shipping html-artifact.",
+      "owner": "rust-runtime"
     },
     "93679ef27d74": {
       "disposition": "superseded",
@@ -3648,10 +4378,15 @@
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
+    "94d70dee54c4f9c54d9681b0f49d629c08e275f1": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "9578e52795e3": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by absent Rust Photon sidecar: upstream detects Python Photon sidecar death and reconnects. Hermes Ultra has no Photon sidecar process or platform adapter in crates/hermes-gateway/src/platforms."
+      "notes": "Superseded by absent Rust Photon sidecar: upstream detects Python Photon sidecar death and reconnects. Hermes Ultra has no Photon sidecar process or platform adapter in crates/hermes-gateway/src/platforms.",
+      "owner": "rust-runtime"
     },
     "95a0955e19f8": {
       "disposition": "ported",
@@ -3659,8 +4394,8 @@
     },
     "95d53c3bcb06": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust CLI /reasoning now exposes full|clamp runtime modes, status/help report the active mode, and the TUI live-thinking preview keeps complete text in full mode while retaining compact caps in clamp mode. Focused command and TUI tests cover mode switching, status/help output, and cap bypass behavior; detailed transcript rendering already preserves stored reasoning_content line-for-line."
+      "notes": "Rust CLI /reasoning now exposes full|clamp runtime modes, status/help report the active mode, and the TUI live-thinking preview keeps complete text in full mode while retaining compact caps in clamp mode. Focused command and TUI tests cover mode switching, status/help output, and cap bypass behavior; detailed transcript rendering already preserves stored reasoning_content line-for-line.",
+      "owner": "rust-runtime"
     },
     "95d970a7521c8fe1244544b666bf05a0f43fadbd": {
       "disposition": "ported",
@@ -3673,8 +4408,8 @@
     },
     "964ec680cc9250b3389104e4d1e0cabe1dd1872c": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "96cd37e212e8": {
       "disposition": "superseded",
@@ -3697,6 +4432,11 @@
       "disposition": "ported",
       "notes": "Rust MCP stdio configs now reject the same high-signal shell-plus-network-egress exfiltration shape before direct client or manager connection. Tests cover the dangerous payload, clean npx, benign shell pipes, and manager rejection."
     },
+    "9738870489d04ee168f87263d85922ae2a858d42": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "97524344adbd": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
@@ -3705,15 +4445,20 @@
       "disposition": "superseded",
       "notes": "Upstream contributor docs recommend the Python standard installer. Ultra contributor docs intentionally use the Rust workspace flow in CONTRIBUTING.md with cargo build/test/install, so the upstream Python venv layout does not apply."
     },
+    "97640fd9adf532d6ce4ebc63ec817137ba685157": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron titlebar/window-control overlay delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: apps/desktop is absent locally, and CLI/TUI/gateway surfaces do not ship Electron WCO behavior.",
+      "owner": "rust-runtime"
+    },
     "97640fd9adf5584bc0dc7246518a26c2d771aef8": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/desktop/dashboard-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, web, or Electron desktop runtime tree, while Rust CLI/TUI/gateway/install paths own the applicable behavior. Mixed Rust/runtime/provider/platform commits remain pending for separate evidence."
+      "notes": "Upstream Electron/desktop/dashboard-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, web, or Electron desktop runtime tree, while Rust CLI/TUI/gateway/install paths own the applicable behavior. Mixed Rust/runtime/provider/platform commits remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "97888fed483c1e867666b6beb4eb03e409cc9481": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream fixes browser executable auto-detection in a Python-era installer. Hermes Agent Ultra install.sh is release-asset/source-build only, has no find_system_browser/AGENT_BROWSER_EXECUTABLE_PATH browser fallback, and scripts/install.ps1 is not shipped, so the Snap Chromium repair path is not applicable locally."
+      "notes": "Upstream fixes browser executable auto-detection in a Python-era installer. Hermes Agent Ultra install.sh is release-asset/source-build only, has no find_system_browser/AGENT_BROWSER_EXECUTABLE_PATH browser fallback, and scripts/install.ps1 is not shipped, so the Snap Chromium repair path is not applicable locally.",
+      "owner": "rust-runtime"
     },
     "97ecfa0fc487": {
       "disposition": "ported",
@@ -3749,13 +4494,13 @@
     },
     "98ecd0beeba9f4f1b62df73b9c6e03dd4126f3d2": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream only fixes a stale Python tui_gateway/server.py MCP late-refresh docstring. Hermes Agent Ultra does not ship tui_gateway/server.py; Rust MCP late-refresh behavior and documentation are owned by the Rust CLI/tool snapshot surfaces and existing parity checkpoints."
+      "notes": "Upstream only fixes a stale Python tui_gateway/server.py MCP late-refresh docstring. Hermes Agent Ultra does not ship tui_gateway/server.py; Rust MCP late-refresh behavior and documentation are owned by the Rust CLI/tool snapshot surfaces and existing parity checkpoints.",
+      "owner": "rust-runtime"
     },
     "991220747fb5ac3dbd0cafb236fdda518d0b247c": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "9915665e4c51": {
       "disposition": "superseded",
@@ -3765,29 +4510,44 @@
       "disposition": "ported",
       "notes": "Rust ACP now keeps successful web_extract completions silent while rendering compact per-URL failures; read_file fenced completion and compact replay rendering are covered by hermes-acp tools tests."
     },
+    "9998ff4cbebc9812aec66a7d0839665fa7fbfa36": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "99ddba94edee": {
       "disposition": "ported",
       "notes": "The current upstream Grok skill was adopted in its optional catalog placement with modern Hermes frontmatter and guidance."
     },
     "99f3072aa06a": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust CLI model switching is now transactional: App::try_switch_model builds the replacement provider/agent before mutating current_model, runtime env, or session DB state, while user-facing /model and TUI picker paths abort with a failure notice instead of claiming success. Focused app and command tests force a rebuild failure and verify the old model, env, agent config, and session model remain intact."
+      "notes": "Rust CLI model switching is now transactional: App::try_switch_model builds the replacement provider/agent before mutating current_model, runtime env, or session DB state, while user-facing /model and TUI picker paths abort with a failure notice instead of claiming success. Focused app and command tests force a rebuild failure and verify the old model, env, agent config, and session model remain intact.",
+      "owner": "rust-runtime"
     },
     "99feb036077a": {
       "disposition": "superseded",
       "notes": "Superseded by Rust Honcho configuration surface: pinUserPeer is the canonical runtime field and peerName is only emitted as a non-empty compatibility label from crates/hermes-cli/src/commands.rs.",
       "owner": "rust-runtime"
     },
+    "9a0010fd469f0de6c7e2146f955ed9980d02b397": {
+      "disposition": "ported",
+      "notes": "Ported for remaining Rust backend spawn legs, including environment backends, gateway hooks/routing, cron, CLI probes, plugin git operations, source-contract tests, and Chrome debug launch preserving detached/process-group flags while adding CREATE_NO_WINDOW through windows_no_window_creation_flags.",
+      "owner": "rust-runtime"
+    },
     "9a2f2756f7e6": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Selecting slash output and shell logs in the thread is React desktop presentation behavior. Rust terminal/TUI output remains native terminal text, not Electron thread DOM selection."
+      "notes": "Selecting slash output and shell logs in the thread is React desktop presentation behavior. Rust terminal/TUI output remains native terminal text, not Electron thread DOM selection.",
+      "owner": "rust-runtime"
+    },
+    "9a322726ae89e2f242f8f20fb8f854b7867ba7a0": {
+      "disposition": "ported",
+      "notes": "Rust Mem0 config defaults rerank to false, exposes schema default false, and tests cover the load/setup behavior; no dead Python get_all path exists in Rust.",
+      "owner": "rust-runtime"
     },
     "9a4600c5fb9bdd21e5d035181bfc7fbdb9340497": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "9b1e0d6f70bb": {
       "disposition": "superseded",
@@ -3803,12 +4563,17 @@
     },
     "9b7122118716474a53f559df44b8baf0526ce2ce": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "9bdf01852ac1": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "9be292f1e678437644396b47b3410b433ba3433f": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
     },
     "9bfff6e16cf1": {
       "disposition": "superseded",
@@ -3826,6 +4591,11 @@
       "disposition": "superseded",
       "notes": "Upstream Homebrew PATH repair is scoped to the Electron desktop backend environment for Python subprocesses. Hermes Agent Ultra does not ship the upstream Electron desktop backend; the Rust CLI/TUI release path uses Cargo/Homebrew install artifacts and normal shell PATH resolution."
     },
+    "9c6229ce249e4bbd86a22463be73ac2986db6324": {
+      "disposition": "ported",
+      "notes": "Ported with shared Rust subprocess environment policy: hermes_core::subprocess_env strips provider credentials by default, always strips tier-1 live tokens/gateway secrets, preserves safe env vars, normalizes PATH, and is used by gateway command hooks and quick exec. Focused tests cover helper policy plus hook and quick-exec child environments.",
+      "owner": "rust-runtime"
+    },
     "9cbb91abd3a8": {
       "disposition": "superseded",
       "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
@@ -3838,6 +4608,11 @@
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
+    "9ce79cd642125eb0997d31310fe12cb0fddd6ba5": {
+      "disposition": "ported",
+      "notes": "Ported in Rust media tools: xAI image generation stores public_url/file_output when present, xAI image edits use quality model/image fields, and xAI video generation supports text/image-to-video with reference images, duration caps, and auth-store/env credentials.",
+      "owner": "rust-runtime"
+    },
     "9cf1140caaefa6f275667ed1b11a61aabb6199dd": {
       "disposition": "ported",
       "notes": "Rust ACP polished tool errors are treated as failed for core tool outputs while generic optional JSON error payloads remain completed; completion-status tests cover both sides of the conservative rule."
@@ -3846,10 +4621,15 @@
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
+    "9d10dcd490e68eae94849496586242defbede058": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
+    },
     "9d225fbf4eaf3cc8aa490e12ccf1145123793677": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Telegram rich-message delivery: pipe-table-primary Markdown now auto-routes through sendRichMessage even when rich_messages is false, while task lists/details/math still require explicit rich opt-in; encoded topic chat IDs route through sendRichMessage without reply anchors and rich edit finalization forwards message_thread_id."
+      "notes": "Ported in Rust Telegram rich-message delivery: pipe-table-primary Markdown now auto-routes through sendRichMessage even when rich_messages is false, while task lists/details/math still require explicit rich opt-in; encoded topic chat IDs route through sendRichMessage without reply anchors and rich edit finalization forwards message_thread_id.",
+      "owner": "rust-runtime"
     },
     "9d2ec8d35a2a": {
       "disposition": "superseded",
@@ -3881,16 +4661,31 @@
     },
     "9e4348f28ac114c3f88d68e2df1fb915f1c2d3b9": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Documentation-only upstream delta is superseded by local Rust-first docs/parity/release surfaces; it does not add or change a shipped Rust runtime behavior. Skills/docs/config-mixed items remain pending for separate evidence."
+      "notes": "Documentation-only upstream delta is superseded by local Rust-first docs/parity/release surfaces; it does not add or change a shipped Rust runtime behavior. Skills/docs/config-mixed items remain pending for separate evidence.",
+      "owner": "rust-runtime"
+    },
+    "9e490138a009c9c9aa64ac90fd6804928a6646b8": {
+      "disposition": "superseded",
+      "notes": "Superseded by Rust architecture and existing guards: the local Feishu adapter has no internet-facing webhook rate-limiter table matching the upstream Python bypass surface, and the local WhatsApp adapter is Cloud API based rather than a Baileys bridge returning absolute cache paths. Native file/media delivery goes through gateway/media validation and canonicalization before adapter send, with existing tests for unsafe media marker and file delivery rejection.",
+      "owner": "rust-runtime"
     },
     "9e4d79b17fcf": {
       "disposition": "ported",
       "notes": "Rust sync_runtime_model_env and CLI chat env setup now write HERMES_TUI_PROVIDER unconditionally alongside HERMES_INFERENCE_PROVIDER, covering the explicit-provider carrier bug fixed upstream for /model followed by new sessions."
     },
+    "9e4ed4d7a922844710a5ebd9e551a72e5090eca2": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "9e85408c7bfd": {
       "disposition": "ported",
       "notes": "rust todo tool remains first-class in CLI/API toolsets and builtin registration; existing toolset tests and new registry/schema contract cover create/update/list parity"
+    },
+    "9e96e709951824be8336c5a733bb0d98d6ab32da": {
+      "disposition": "ported",
+      "notes": "Ported in Rust: /prompt and /compose are first-class CLI/TUI slash commands that open $VISUAL/$EDITOR on a temporary markdown draft, strip #! instruction lines, cancel empty buffers, and queue the saved prompt as the next normal agent turn. Covered by fake-editor command tests for readback, header stripping, initial text, alias, and empty-buffer cancellation.",
+      "owner": "rust-runtime"
     },
     "9eb0bcd60fc6": {
       "disposition": "superseded",
@@ -3901,10 +4696,20 @@
       "disposition": "ported",
       "notes": "Rust resume now falls back from missing exact snapshot stems to session-id search over saved session snapshots, matching exact, prefix, and substring IDs case-insensitively across both file stems and session_info.session_id, with deterministic exact-before-prefix-before-substring ranking and focused CLI tests."
     },
+    "9ee7333e5b36633993c3898a01a26f0b189b81bc": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "9f02eea1d28440b54dc1956afc16cf3acc05ae42": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
+    },
+    "9f0309504496a82d15b07aef30f8f7bf84cab660": {
+      "disposition": "superseded",
+      "notes": "Upstream docs/skills/website-only delta is superseded by local Rust-first docs, release notes, and parity evidence; no Rust runtime implementation is required for this queue row.",
+      "owner": "rust-runtime"
     },
     "9f1b1977bca3": {
       "disposition": "ported",
@@ -3917,8 +4722,8 @@
     },
     "9fd2b2cb9fab9e5d7a49b4102ad028fa430ede1e": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "9ff0ba082739": {
       "disposition": "superseded",
@@ -3930,17 +4735,27 @@
     },
     "a0471e24648ef29ef6a3c681eb5b9917ae910258": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream CI/workflow-only delta is superseded by Hermes Agent Ultra's local Rust-first deterministic gates and PR verification workflow; it does not add or change a shipped Rust runtime behavior. Runtime/install/docker changes remain pending for separate evidence."
+      "notes": "Upstream CI/workflow-only delta is superseded by Hermes Agent Ultra's local Rust-first deterministic gates and PR verification workflow; it does not add or change a shipped Rust runtime behavior. Runtime/install/docker changes remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "a0ec4f52b948": {
       "disposition": "superseded",
       "notes": "Desktop settings/provider disconnect UI targets absent apps/desktop files. Ultra already exposes Rust provider credential disconnect behavior through the TUI provider picker and auth state helpers."
     },
+    "a10113658b6033c5902bbe873bfe2e1f05815339": {
+      "disposition": "superseded",
+      "notes": "Upstream Python pre_verify/verify-on-stop hook plugin is superseded by Hermes Ultra Rust execution discipline, deterministic verification gates, ContextLattice checkpoint policy, and explicit shell/test verification workflow; no Python hook plugin runtime is shipped.",
+      "owner": "rust-runtime"
+    },
+    "a10727a555ad5e5c4155b3b74d19959c36c436db": {
+      "disposition": "ported",
+      "notes": "Ported as Rust CDP diagnostics rather than Python agent-browser daemon plumbing: local browser commands now have bounded CDP timeouts, first-navigation open timeout floors, endpoint/remote-debugging hints, sandbox hints, and browser_navigate failures labeled as Failed to open.",
+      "owner": "rust-runtime"
+    },
     "a1639921ac44": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Desktop messaging save/toggle toasts offering Restart gateway are Electron settings UI. Rust config changes do not route through desktop toast actions."
+      "notes": "Desktop messaging save/toggle toasts offering Restart gateway are Electron settings UI. Rust config changes do not route through desktop toast actions.",
+      "owner": "rust-runtime"
     },
     "a1cda2410b30": {
       "disposition": "superseded",
@@ -3948,8 +4763,8 @@
     },
     "a1e699ae55085416924df00b9105cc1764f1fa06": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "a1eaad2fc0bf": {
       "disposition": "superseded",
@@ -3974,13 +4789,13 @@
     },
     "a268dfff0a055dad7d73d45ede53a5687159a65c": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "a28fe788a6651bb09ad0cfff40d9e84e2f2edfe4": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream installer delta targets Python/Electron Playwright or desktop/node dependency setup. Hermes Agent Ultra's installer downloads Rust release binaries, bootstraps SOUL/config, and has bounded post-install probes; it has no Playwright desktop install stage to patch."
+      "notes": "Upstream installer delta targets Python/Electron Playwright or desktop/node dependency setup. Hermes Agent Ultra's installer downloads Rust release binaries, bootstraps SOUL/config, and has bounded post-install probes; it has no Playwright desktop install stage to patch.",
+      "owner": "rust-runtime"
     },
     "a2b8e430e851": {
       "disposition": "superseded",
@@ -4002,12 +4817,22 @@
     },
     "a391523bccc35af2bdee558734600a496da02420": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "a40e20e1368d": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "a40f22798ec6b5877958f6dbe5aeda8468e7d628": {
+      "disposition": "superseded",
+      "notes": "Upstream installer managed-clone reset is shell/PowerShell installer behavior; Hermes Ultra release/install flow is Rust-first and handled by local installer scripts outside the Rust runtime queue.",
+      "owner": "rust-runtime"
+    },
+    "a488fcf107d1c61400db4274c0baf357b908c772": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
     },
     "a49596cbb2c1": {
       "disposition": "ported",
@@ -4015,8 +4840,8 @@
     },
     "a4a74ca9e9a0f7d7d8e731d927139ccba0a588ec": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "a4b1554c7349": {
       "disposition": "ported",
@@ -4034,12 +4859,17 @@
     },
     "a4fa1481e281": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust gateway command dispatch now routes /learn through a ForwardPrompt result into SlashCommandOutcome::ForwardToAgent, so the synthesized learning prompt fires as a normal agent turn instead of being handled as a static reply. Gateway tests lock the parser and active-session bypass behavior."
+      "notes": "Rust gateway command dispatch now routes /learn through a ForwardPrompt result into SlashCommandOutcome::ForwardToAgent, so the synthesized learning prompt fires as a normal agent turn instead of being handled as a static reply. Gateway tests lock the parser and active-session bypass behavior.",
+      "owner": "rust-runtime"
     },
     "a4fb0a3ac39f": {
       "disposition": "ported",
       "notes": "Rust cron delivery routing preserves explicit inline platform chat ids/--deliver-chat-id, carries DeliverConfig on CronCompletionEvent, and the gateway cron delivery loop sends successful or failed cron completions through registered adapters. Telegram cron deliveries resolve TELEGRAM_CRON_THREAD_ID at fire time for unthreaded/home targets while explicit telegram:chat:thread wins. Tests cover stored chat id preservation, home-channel fallback, explicit thread precedence, webhook serialization, and docs now document the env var."
+    },
+    "a56aa9ac47b0fd52e50a40b1812728ee16bee873": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
     },
     "a59d5e37e8ab": {
       "disposition": "superseded",
@@ -4064,17 +4894,27 @@
     },
     "a61baa96157241c2e422fd85b3527bee14b41c62": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
+    },
+    "a61cf774ce925964d679f5ad04966251e37444ca": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
     },
     "a6485bddb855536e60baa7074573a820d3d1ee76": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "a652131c421b": {
       "disposition": "superseded",
       "notes": "Upstream Photon orphan-sidecar cleanup is Python subprocess/Node sidecar lifecycle logic. Hermes Agent Ultra does not run that sidecar from Rust, so this failure mode is outside the local Rust runtime surface."
+    },
+    "a682091044955167c9a728f9641ff279c96a73a7": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
     },
     "a68ac0c49af1": {
       "disposition": "superseded",
@@ -4082,18 +4922,18 @@
     },
     "a6a28ce3e2174c0be494f553ab5fd79b7039190f": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream CI/workflow-only delta is superseded by Hermes Agent Ultra's local Rust-first deterministic gates and PR verification workflow; it does not add or change a shipped Rust runtime behavior. Runtime/install/docker changes remain pending for separate evidence."
+      "notes": "Upstream CI/workflow-only delta is superseded by Hermes Agent Ultra's local Rust-first deterministic gates and PR verification workflow; it does not add or change a shipped Rust runtime behavior. Runtime/install/docker changes remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "a6ae179f43e1e5c6d8e372f6ec4b4c6b2f8c0b15": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "a6b670d4a251f98ca3bac91a867bb469f7ce4e93": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "a72bb03757c0": {
       "disposition": "superseded",
@@ -4107,10 +4947,15 @@
       "disposition": "ported",
       "notes": "ComfyUI bug-fix coverage is represented by the local skill scripts, tests, workflows, cloud/local guidance, and expanded references under skills/creative/comfyui."
     },
+    "a796e0b79632bad8df19062e149f30a540f883a0": {
+      "disposition": "superseded",
+      "notes": "Upstream fixes python-telegram-bot typing-indicator cooldown. The Rust Telegram adapter does not send chat-action typing indicators on the runtime path, so the transient typing failure mode is absent.",
+      "owner": "rust-runtime"
+    },
     "a7983d5ad768": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by Rust dashboard/session architecture: upstream hides Python sidecar sessions in dashboard history, while Hermes Ultra has no Python run_agent/tui_gateway sidecar session source in the Rust runtime; gateway session sources are typed in crates/hermes-gateway/src/session_control.rs."
+      "notes": "Superseded by Rust dashboard/session architecture: upstream hides Python sidecar sessions in dashboard history, while Hermes Ultra has no Python run_agent/tui_gateway sidecar session source in the Rust runtime; gateway session sources are typed in crates/hermes-gateway/src/session_control.rs.",
+      "owner": "rust-runtime"
     },
     "a7dd98c8609c": {
       "disposition": "superseded",
@@ -4121,15 +4966,30 @@
       "disposition": "superseded",
       "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
     },
+    "a8a97c358feee4ee546670691f6f72e8812f9d3a": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
+    },
+    "a8c862900b9c24a1706cbcb17c2b9968c88f277c": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
+    },
     "a8f1d9cc76b1bb2719260534d83aa26c1407731a": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
+    },
+    "a8f9d089f124c7e8ab6689585eb33f9f6565890b": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
     },
     "a911bcda18cf": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Install-facing docs now point to the Ultra release installer/Cargo source install, use hermes-ultra commands, remove Hermes app pip-extra recommendations, and are covered by tests/website/test_ultra_install_docs.py."
+      "notes": "Install-facing docs now point to the Ultra release installer/Cargo source install, use hermes-ultra commands, remove Hermes app pip-extra recommendations, and are covered by tests/website/test_ultra_install_docs.py.",
+      "owner": "rust-runtime"
     },
     "a919269eb5c5": {
       "disposition": "ported",
@@ -4143,9 +5003,24 @@
       "disposition": "ported",
       "notes": "Baoyu article illustrator was adopted from current upstream after its Hermes tool-capability alignment, including the prompt and workflow updates."
     },
+    "a94f657a505962cc046b29322750e03450c55645": {
+      "disposition": "superseded",
+      "notes": "Upstream Python runtime delta is superseded by Hermes Ultra Rust-native agent/provider/tool architecture and existing deterministic Rust tests; the Python module path is not shipped in the Rust runtime.",
+      "owner": "rust-runtime"
+    },
     "a9669323922f6e79482536f2c05846c354571528": {
       "disposition": "ported",
       "notes": "Ported in Rust Telegram adapter: rich newline normalization protects Markdown pipe tables from hard-break injection, preserving table layout with focused regression coverage.",
+      "owner": "rust-runtime"
+    },
+    "a9b5598909585b851b1ed65f05034033676d1a86": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React desktop remote-mode delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop as a runtime product.",
+      "owner": "rust-runtime"
+    },
+    "aa07400e1a8f37e835714d8a68c1b72e634e3793": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
       "owner": "rust-runtime"
     },
     "aa1e2edd35a8": {
@@ -4154,8 +5029,8 @@
     },
     "aa2ae36c3fcb6ea9af76c603d262389d832a24dd": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "aa52cd3b574e": {
       "disposition": "superseded",
@@ -4171,16 +5046,26 @@
     },
     "aab49f6927c": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Pet generation RPC/gallery plumbing is desktop/tui_gateway/Python pet runtime only. Ultra has no desktop pet overlay or tui_gateway server; image generation is exposed through Rust image_gen backends."
+      "notes": "Pet generation RPC/gallery plumbing is desktop/tui_gateway/Python pet runtime only. Ultra has no desktop pet overlay or tui_gateway server; image generation is exposed through Rust image_gen backends.",
+      "owner": "rust-runtime"
     },
     "aaccaada282b": {
       "disposition": "ported",
       "notes": "Rust Anthropic provider now carries ordered signed thinking/tool_use content blocks in-memory on parsed responses and replays them before reconstructing from reasoning_content/tool_calls. Regression tests cover interleaved block preservation in parse_response and convert_messages."
     },
+    "aaeba213d90c7234772280a335e6324659c004f9": {
+      "disposition": "ported",
+      "notes": "Rust Telegram polling has bounded request timeout plus immediate 409/conflict unhealthy handling covered by telegram_polling_conflict_marks_adapter_unhealthy_immediately.",
+      "owner": "rust-runtime"
+    },
     "ab1a42fcea4f": {
       "disposition": "superseded",
       "notes": "Relay connector contract is retained only as experimental/reference documentation; current Ultra Rust runtime does not register the upstream Python relay adapter as a first-class platform surface.",
+      "owner": "rust-runtime"
+    },
+    "ab1f9b94c5055f859a3b0183f6bdd0ff4d93d65a": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Telegram delivery: encoded chat_id splitting now accepts @username bases for topic-thread delivery while preserving malformed IDs unsplit; telegram_username_gateway_chat_id_sends_to_topic_thread covers the Bot API payload shape.",
       "owner": "rust-runtime"
     },
     "ab5f1a1f1141": {
@@ -4197,8 +5082,8 @@
     },
     "ab9134bf16d2": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust OpenViking: synchronous current-query recall prefetch uses the search/search contract with find fallback, configurable recall policy knobs, threshold/ranking/dedup caps, L2 reads for empty abstracts, batched viking_read, and focused local HTTP tests."
+      "notes": "Ported in Rust OpenViking: synchronous current-query recall prefetch uses the search/search contract with find fallback, configurable recall policy knobs, threshold/ranking/dedup caps, L2 reads for empty abstracts, batched viking_read, and focused local HTTP tests.",
+      "owner": "rust-runtime"
     },
     "abbf05024131": {
       "disposition": "superseded",
@@ -4206,8 +5091,8 @@
     },
     "ac128af1cec30238f21376273ce4f96088a800bd": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "ac6d747fa610": {
       "disposition": "ported",
@@ -4235,12 +5120,17 @@
     },
     "ad831dd4928e817bbb4b913561ec5ee09e0672b9": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "ada0b4f131ba": {
       "disposition": "ported",
       "notes": "rust gateway/platform adapter surface sends inline image URLs natively and now strips/delivers local MEDIA image markers through validated send_file paths; tests cover inline image extraction and media marker delivery"
+    },
+    "adacb16d624336f18380a0a40b4b704c699c3f10": {
+      "disposition": "superseded",
+      "notes": "Upstream readable agent terminal tab fixes are limited to the absent Electron desktop terminal UI. Hermes Agent Ultra's shipped runtime uses Rust CLI/gateway/TUI surfaces, so no Rust port applies.",
+      "owner": "rust-runtime"
     },
     "ae433634db56": {
       "disposition": "superseded",
@@ -4256,8 +5146,8 @@
     },
     "ae8db1ab531b": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Hidden link-title audio muting is Electron desktop hidden-window behavior. Rust has no link-title browser window or autoplay audio surface."
+      "notes": "Hidden link-title audio muting is Electron desktop hidden-window behavior. Rust has no link-title browser window or autoplay audio surface.",
+      "owner": "rust-runtime"
     },
     "ae8fa11097e1": {
       "disposition": "ported",
@@ -4272,14 +5162,24 @@
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
+    "af5cea04ab77352209a0495b25e5c5c295a73395": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
+    },
     "af7b7f632272": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust coding context now exposes structured ProjectFacts via hermes_agent::coding_context and the HTTP JSON-RPC project.facts method. Focused agent and HTTP route tests cover manifests, package managers, verification commands, context files, and null outside-workspace behavior."
+      "notes": "Rust coding context now exposes structured ProjectFacts via hermes_agent::coding_context and the HTTP JSON-RPC project.facts method. Focused agent and HTTP route tests cover manifests, package managers, verification commands, context files, and null outside-workspace behavior.",
+      "owner": "rust-runtime"
     },
     "af978ecb17ef": {
       "disposition": "superseded",
       "notes": "Upstream expensive-model picker confirmation is superseded by Rust runtime cost accounting and configurable session spend guard; Hermes Ultra does not use the Python/Electron picker flow."
+    },
+    "afb5808d8c9e0418ab14107a1c1f8b5598d6489b": {
+      "disposition": "superseded",
+      "notes": "Upstream patch configures discord.py View timeouts. Rust Discord does not use discord.py interactive views; approval and prompt lifecycles are centralized in Rust gateway/tools surfaces.",
+      "owner": "rust-runtime"
     },
     "afc186fa4eed": {
       "disposition": "superseded",
@@ -4291,8 +5191,8 @@
     },
     "aff5ae692fb2e09a68344c841f5a6a461fb33f3f": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "b000e05b117b": {
       "disposition": "superseded",
@@ -4308,12 +5208,17 @@
     },
     "b02f453496a2f1afd963aeb30c44996b41bbe134": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "b07b7894ec55": {
       "disposition": "superseded",
       "notes": "Streaming paint in unfocused secondary Electron windows is an apps/desktop BrowserWindow preference fix. Ultra has no Electron session windows; Rust TUI/gateway streaming is terminal/platform-adapter driven.",
+      "owner": "rust-runtime"
+    },
+    "b080b93ad87428221f7bf40360d11fc13e837727": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Slack adapter: SlackAdapter exposes Block Kit message builders and post_blocks/post_block_kit paths, with Block Kit builder/round-trip tests.",
       "owner": "rust-runtime"
     },
     "b08f53a75893": {
@@ -4338,6 +5243,11 @@
       "disposition": "ported",
       "notes": "Imported ntfy as a platform plugin under plugins/platforms/ntfy with standalone send, env enablement, identity hardening, and local plugin regression tests."
     },
+    "b1500af27738c80aebe0d615325ad39e86a1807f": {
+      "disposition": "ported",
+      "notes": "Ported as a Rust-native cli-config.yaml.example aligned to GatewayConfig instead of the stale upstream Python-shaped sample. The example keeps model openai-codex:dynamic, documents provider context windows, terminal/web/session knobs, and is covered by hermes-config test repo_cli_config_example_parses_as_rust_gateway_config.",
+      "owner": "rust-runtime"
+    },
     "b15dc58064eb": {
       "disposition": "superseded",
       "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
@@ -4352,8 +5262,8 @@
     },
     "b1ab5a8ae1d93d863ce3418f7abdb4fc8fee2c1d": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Antigravity CLI delegation, output-format, and timeout/bounding guidance is ported into the optional Rust-loaded antigravity-cli skill, with version bumped to 0.2.0."
+      "notes": "Antigravity CLI delegation, output-format, and timeout/bounding guidance is ported into the optional Rust-loaded antigravity-cli skill, with version bumped to 0.2.0.",
+      "owner": "rust-runtime"
     },
     "b1af653bf6bd": {
       "disposition": "superseded",
@@ -4375,6 +5285,11 @@
       "disposition": "superseded",
       "notes": "Rust ACP start events already carry compact title/kind/arguments only and do not synthesize read_file output content; existing title tests cover read_file start compactness."
     },
+    "b296915c82c9da02bd6edacf52490e68f85e1f16": {
+      "disposition": "ported",
+      "notes": "Ported as a Rust-native Feishu lifecycle guard instead of Python executor plumbing: the adapter has no blocking SDK executor, but stop() now marks the runtime closing and outbound API/token/file/image-url paths refuse work before network or local file IO until start/reconnect re-arms the adapter.",
+      "owner": "rust-runtime"
+    },
     "b2bd31c724c1": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
@@ -4383,9 +5298,19 @@
       "disposition": "ported",
       "notes": "ported in local commit d67220e0b (kanban assignee casing fix)"
     },
+    "b31b0b9d95d1dbaae0197b9f3f7d3f3d0d4efc28": {
+      "disposition": "superseded",
+      "notes": "Documentation reconciliation commit targets upstream Python/website surfaces; Hermes Ultra tracks Rust docs and parity gates separately, with no shipped Rust runtime delta.",
+      "owner": "rust-runtime"
+    },
     "b38d2d133bbb76fb9d91f08c3b1a838f5ce0a5b9": {
       "disposition": "ported",
       "notes": "Rust ACP tool completions compute failed status from structured success=false, ok=false, and nonzero exit_code/returncode while keeping status calculation separate from display formatting; focused tests cover the status path."
+    },
+    "b4289200ba93fad96a2e1e87270e036613b14293": {
+      "disposition": "ported",
+      "notes": "Ported in Rust credential persistence: auth.json already creates owner-only temp files before writing via OpenOptionsExt::mode(0o600), and hermes-auth encrypted token store now uses the same owner-only create-before-write primitive with failure cleanup and a Unix mode test. This closes the OAuth-token TOCTOU class without importing the Python web_server surface.",
+      "owner": "rust-runtime"
     },
     "b459bac02c98": {
       "disposition": "ported",
@@ -4395,6 +5320,11 @@
       "disposition": "ported",
       "notes": "Rust Kanban JSON store now supports per-task file attachments with path-safe copy, unique filenames, metadata, list/remove commands, worker-context absolute path surfacing, and regression tests for copy/collision/delete/context behavior."
     },
+    "b48fcfa8bd93268647c77113900f603ac7f7a93b": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "b4ba3f5e3b37": {
       "disposition": "superseded",
       "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
@@ -4403,10 +5333,15 @@
       "disposition": "superseded",
       "notes": "Upstream Photon Windows-safe os.kill comments document Python sidecar cleanup behavior. Hermes Agent Ultra does not depend on that Python subprocess lifecycle in the Rust runtime."
     },
+    "b508d4296e045c2754f075628ec80761b86f7126": {
+      "disposition": "superseded",
+      "notes": "Upstream Python parallel-test timeout plus infographic delta is superseded by local Rust/pytest targeted verification and WD-Black cargo target policy; scripts/run_tests_parallel.py is not a shipped Rust runtime surface.",
+      "owner": "rust-runtime"
+    },
     "b508d4296e04bd0c5361b63615915e9c00c6017c": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Python test-runner timeout/infographic delta is superseded by this repo's Rust CI/gateway parity workflow and WD-Black local verification; scripts/run_tests_parallel.py is not the shipped Rust runtime surface."
+      "notes": "Upstream Python test-runner timeout/infographic delta is superseded by this repo's Rust CI/gateway parity workflow and WD-Black local verification; scripts/run_tests_parallel.py is not the shipped Rust runtime surface.",
+      "owner": "rust-runtime"
     },
     "b55ac45264e9": {
       "disposition": "superseded",
@@ -4418,12 +5353,17 @@
     },
     "b5bd66eac9b1": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust Telegram parser already preserves current documents and replied group documents when the addressed message has no own media, only filtering oversized documents. Existing Telegram parse tests cover document metadata and replied-document size behavior."
+      "notes": "Rust Telegram parser already preserves current documents and replied group documents when the addressed message has no own media, only filtering oversized documents. Existing Telegram parse tests cover document metadata and replied-document size behavior.",
+      "owner": "rust-runtime"
     },
     "b5c1fe78aa48": {
       "disposition": "ported",
       "notes": "Skill bundle aliases are implemented in the Rust CLI via /bundles and skill-bundles discovery in crates/hermes-cli/src/commands.rs, allowing /<slug> to load multiple skills."
+    },
+    "b6045170bb7bad85c9a361054bf69b4d7f0722f2": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
     },
     "b6206020d383": {
       "disposition": "superseded",
@@ -4443,8 +5383,8 @@
     },
     "b674f7ba28": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Pet backend setup overlay is Electron desktop state/UI behavior. Ultra has no apps/desktop pet-generate overlay; Rust image_gen provider availability is surfaced through tool capabilities and errors."
+      "notes": "Pet backend setup overlay is Electron desktop state/UI behavior. Ultra has no apps/desktop pet-generate overlay; Rust image_gen provider availability is surfaced through tool capabilities and errors.",
+      "owner": "rust-runtime"
     },
     "b6945ce772b3": {
       "disposition": "superseded",
@@ -4457,23 +5397,38 @@
     },
     "b6d107240819": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream fixes Python CLI --worktree branching from stale local HEAD. The Rust CLI in this repository has no --worktree/git-worktree creation path (rg across crates finds only TERMINAL_CWD consumption and docs/tests), so there is no Rust runtime worktree-base resolver to patch. Existing Rust terminal/file tools consume an already-materialized TERMINAL_CWD and do not create branches."
+      "notes": "Upstream fixes Python CLI --worktree branching from stale local HEAD. The Rust CLI in this repository has no --worktree/git-worktree creation path (rg across crates finds only TERMINAL_CWD consumption and docs/tests), so there is no Rust runtime worktree-base resolver to patch. Existing Rust terminal/file tools consume an already-materialized TERMINAL_CWD and do not create branches.",
+      "owner": "rust-runtime"
     },
     "b6d2ac176e27": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Mem0: MEM0_HOST is accepted as a self-hosted/OSS endpoint alias for base_url, host-only config activates the provider without a cloud API key, auth headers are omitted when api_key is empty, the system prompt identifies OSS/self-hosted mode, and config schema exposes MEM0_HOST. Focused Rust tests cover host activation and request headers."
+      "notes": "Ported in Rust Mem0: MEM0_HOST is accepted as a self-hosted/OSS endpoint alias for base_url, host-only config activates the provider without a cloud API key, auth headers are omitted when api_key is empty, the system prompt identifies OSS/self-hosted mode, and config schema exposes MEM0_HOST. Focused Rust tests cover host activation and request headers.",
+      "owner": "rust-runtime"
+    },
+    "b6d8fc41c8d186116531df6cf9bd1cc25ce4e602": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
     },
     "b6e2a54a94f5": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust MCP refresh parity now diffs reload snapshots against the advertised tool schema surface, so restricted/custom platform toolsets do not report hidden MCP handlers as added. ACP prompt execution no longer appends all live mcp-* schemas after planner filtering; explicit MCP server aliases still resolve through the shared platform planner. Python in-place tools/valid_tool_names race and post-build memory/context reinjection issues are superseded by Rust AgentLoop construction plus advertised-tool-name guards."
+      "notes": "Rust MCP refresh parity now diffs reload snapshots against the advertised tool schema surface, so restricted/custom platform toolsets do not report hidden MCP handlers as added. ACP prompt execution no longer appends all live mcp-* schemas after planner filtering; explicit MCP server aliases still resolve through the shared platform planner. Python in-place tools/valid_tool_names race and post-build memory/context reinjection issues are superseded by Rust AgentLoop construction plus advertised-tool-name guards.",
+      "owner": "rust-runtime"
+    },
+    "b6e57e215bf08fdf2308881af48d4b97761319d2": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
     },
     "b72c9e1b2c9f7c60520d6b411f61796d1a0931e1": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
+    },
+    "b7322f946db6ac22353714a136ae3d7950b38745": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop pet roam behavior is an Electron/React-only UX delta under apps/desktop. Hermes Agent Ultra does not ship that desktop pet runtime; Rust CLI/TUI/gateway surfaces own the shipped interactive UX, so no Rust runtime port is applicable.",
+      "owner": "rust-runtime"
     },
     "b75757d4aa85": {
       "disposition": "ported",
@@ -4513,8 +5468,8 @@
     },
     "b848ce2c79bf": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust approval regexes cover absolute and project env/config writes, including absolute .env targets, with test_sensitive_write_patterns_require_confirmation exercising those cases."
+      "notes": "Rust approval regexes cover absolute and project env/config writes, including absolute .env targets, with test_sensitive_write_patterns_require_confirmation exercising those cases.",
+      "owner": "rust-runtime"
     },
     "b85c46054036": {
       "disposition": "ported",
@@ -4531,8 +5486,8 @@
     },
     "b8d220f268": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Project settings and shell chrome are Electron desktop UI only. Ultra has no apps/desktop tree; Rust CLI/TUI/gateway own project/session configuration."
+      "notes": "Project settings and shell chrome are Electron desktop UI only. Ultra has no apps/desktop tree; Rust CLI/TUI/gateway own project/session configuration.",
+      "owner": "rust-runtime"
     },
     "b8f8d3ef9e55": {
       "disposition": "ported",
@@ -4544,8 +5499,8 @@
     },
     "b936f92b25b4": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Rendered send/prefill directive notices are desktop assistant-thread UI. Rust slash-command output and TUI command handling own the local runtime behavior."
+      "notes": "Rendered send/prefill directive notices are desktop assistant-thread UI. Rust slash-command output and TUI command handling own the local runtime behavior.",
+      "owner": "rust-runtime"
     },
     "b93c9f639381": {
       "disposition": "superseded",
@@ -4559,14 +5514,29 @@
       "disposition": "superseded",
       "notes": "Opening chats in separate Electron windows is desktop-only and not part of the Rust CLI/gateway runtime."
     },
+    "b98baa3039e357d97ccb8d84e6d70b1902a03582": {
+      "disposition": "ported",
+      "notes": "Ported in Rust providers: GenericProvider extra_headers, OpenRouter profile headers, and provider_profiles extra_headers_for_profile carry configured provider-specific HTTP headers into LLM API calls with Rust tests.",
+      "owner": "rust-runtime"
+    },
     "b9b4756ab4805437003b55127c369dc18ce22b3b": {
       "disposition": "ported",
       "notes": "Rust ACP/gateway already port the dashboard session-title contract: session.title/session-title normalizes and persists explicit titles, emits session_info_update with title payloads, and session/list, /status, and /sessions prefer explicit titles over history-derived fallbacks. Focused ACP and gateway tests cover live runtime-only title updates, event propagation, persistence, and title surfacing.",
       "owner": "rust-runtime"
     },
+    "b9d9b8aad685530e078a368a7d364b4918fd3042": {
+      "disposition": "superseded",
+      "notes": "Upstream patch handles discord.py expired slash defer exceptions. Rust Discord uses explicit REST interaction responses and status checks, so the discord.py expired-defer exception path is absent.",
+      "owner": "rust-runtime"
+    },
     "b9f1ac8c1022": {
       "disposition": "superseded",
       "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
+    },
+    "ba0bc01d1f740c562b55925e404b82a48809c364": {
+      "disposition": "ported",
+      "notes": "Ported in Rust delegation: delegate_task no longer exposes model-facing toolset schema; subagents inherit parent tools while internal compatibility remains.",
+      "owner": "rust-runtime"
     },
     "ba19d530ad24": {
       "disposition": "superseded",
@@ -4574,8 +5544,8 @@
     },
     "ba37c910e0e2d19b3329a7e74dca21def8d4c3b6": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "ba44de06da10": {
       "disposition": "superseded",
@@ -4586,14 +5556,34 @@
       "notes": "Ported in Rust Discord history primitives: reply messages now have a tested channel-context hydration gate and deterministic reply-anchored context formatting that merges reply-window and recent-window history chronologically without duplicate message IDs.",
       "owner": "rust-runtime"
     },
+    "ba865e40388f31c34e4ab7aca9be764ca7e0d078": {
+      "disposition": "superseded",
+      "notes": "Upstream patch is Python dependency-install ladder plumbing. Hermes Ultra is Rust-first for runtime/install surfaces and repo packaging tests forbid Python dependency pollution in shipped install paths.",
+      "owner": "rust-runtime"
+    },
     "ba9e3a491bfa": {
       "disposition": "ported",
       "notes": "Rust Honcho now parses host-scoped OAuth grants, refreshes near-expiry hch-at access tokens with the stored refresh token, serializes rotation with process and best-effort file locks, persists rotated apiKey/oauth metadata owner-only while preserving unrelated config, sends refreshed Authorization/X-API-Key headers, and lets memory setup preserve existing OAuth grants without requiring a pasted cloud API key. Desktop Electron connect UI is intentionally absent from the Rust-first surface.",
       "owner": "rust-runtime"
     },
+    "babbefb16438ef28e061690117a1dad08e71ff54": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
+    "bb304b491407054a847a6fae6eef6db688efb7bf": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
+    },
     "bb5cb3283898": {
       "disposition": "ported",
       "notes": "Ported in Rust Honcho setup/runtime: crates/hermes-cli/src/commands.rs and hermes_agent::memory_plugins::honcho own pinUserPeer identity mapping, legacy peerName behavior, runtimePeerPrefix, and userPeerAliases; Python Honcho CLI delta has no remaining runtime target.",
+      "owner": "rust-runtime"
+    },
+    "bb67dad07a8c1540032e36f8ed10d76d2b186062": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
       "owner": "rust-runtime"
     },
     "bbc842d31ec8": {
@@ -4635,9 +5625,19 @@
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
+    "bd1d354fc3c509b622853f5b6205fff1007c66dd": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "bd3a5873e11f084d74be876a505a406224a6ef3e": {
       "disposition": "ported",
       "notes": "Rust ACP replays native todo plan updates from persisted tool results after tool_call_complete, supports trailing human hints and empty todo lists for plan clearing, and covers replay ordering plus CLI live converter behavior."
+    },
+    "bd53230739da3bacbf58211f79a56cebcbfb4e06": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
     },
     "bd6d0987629e": {
       "disposition": "superseded",
@@ -4678,8 +5678,8 @@
     },
     "bef1d3e4ff6aaf8b6143ce66d7a5e6169a08a86f": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "bf090deed33e": {
       "disposition": "superseded",
@@ -4695,8 +5695,8 @@
     },
     "bf60bbb6c5": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Overlay zoom-anchor refactor is Electron pet overlay UI only. Ultra has no desktop pet overlay runtime."
+      "notes": "Overlay zoom-anchor refactor is Electron pet overlay UI only. Ultra has no desktop pet overlay runtime.",
+      "owner": "rust-runtime"
     },
     "bf80508d6566": {
       "disposition": "superseded",
@@ -4720,8 +5720,8 @@
     },
     "bff91f978fd93158edcd0e5e3c1137b8d0f829b7": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "c02192ff6ace129fc9bcc2f8907eabd6eb3f0f1d": {
       "disposition": "ported",
@@ -4730,18 +5730,28 @@
     },
     "c0409a87ff05": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust core now exposes the platform-neutral SendErrorKind taxonomy, classify_send_error_text, and GatewayError::send_error_kind for deterministic send-failure branching. StreamConsumer can consume typed GatewayError/SendErrorKind values so rate-limited edit failures keep adaptive flood backoff while permanent send failures fall back immediately, with focused hermes-core and hermes-gateway tests."
+      "notes": "Rust core now exposes the platform-neutral SendErrorKind taxonomy, classify_send_error_text, and GatewayError::send_error_kind for deterministic send-failure branching. StreamConsumer can consume typed GatewayError/SendErrorKind values so rate-limited edit failures keep adaptive flood backoff while permanent send failures fall back immediately, with focused hermes-core and hermes-gateway tests.",
+      "owner": "rust-runtime"
     },
     "c080b2dc3ee6": {
       "disposition": "ported",
       "notes": "Rust approval gateway callbacks now emit GatewayApprovalRequest::redacted_for_display using redact_approval_command before user-facing TUI/chat transports, while the internal queue retains the raw command for resolution; hermes-tools approval tests cover credential redaction, command-structure preservation, and raw-queue/redacted-egress behavior.",
       "owner": "rust-runtime"
     },
+    "c0adfd4a67ca1db66ae13724d2d1286b66e4147f": {
+      "disposition": "superseded",
+      "notes": "Upstream patch is Electron desktop markdown preview UI only. Hermes Ultra does not ship apps/desktop as a primary runtime; Rust CLI/TUI/gateway/dashboard surfaces own shipped preview and operator UX.",
+      "owner": "rust-runtime"
+    },
+    "c0b308e1fedd3c681adc0953276b6632f0ee3c03": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "c0b4a3438ac66a4f0c25d4aa9f6f54f2f9f24816": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream installer delta targets Python/Electron Playwright or desktop/node dependency setup. Hermes Agent Ultra's installer downloads Rust release binaries, bootstraps SOUL/config, and has bounded post-install probes; it has no Playwright desktop install stage to patch."
+      "notes": "Upstream installer delta targets Python/Electron Playwright or desktop/node dependency setup. Hermes Agent Ultra's installer downloads Rust release binaries, bootstraps SOUL/config, and has bounded post-install probes; it has no Playwright desktop install stage to patch.",
+      "owner": "rust-runtime"
     },
     "c10fea8d264e": {
       "disposition": "ported",
@@ -4763,10 +5773,20 @@
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
+    "c19bfb50ad6fc6368635cb0df8ec81bb820160bb": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React desktop remote-mode delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop as a runtime product.",
+      "owner": "rust-runtime"
+    },
     "c1bb34d5e86deee11d92e26a3574e5f3781fbe9b": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
+    },
+    "c1c179a2395a19c3a8e4fb5dae7ef527227da07a": {
+      "disposition": "ported",
+      "notes": "Ported in Rust terminal runtime: foreground command stdout/stderr are sanitized at the formatting boundary using assignment redaction plus credential_guard fallback line redaction, so env dumps and process output do not return secret values. Terminal formatter tests cover key=value and bare-token redaction.",
+      "owner": "rust-runtime"
     },
     "c1eb2dcda7d7": {
       "disposition": "superseded",
@@ -4798,6 +5818,11 @@
     "c2fa302e933a": {
       "disposition": "superseded",
       "notes": "Desktop backend-skew toast nag is apps/desktop update-store UX. Ultra does not run that Electron update store; Rust CLI/TUI version/status surfaces own runtime skew reporting.",
+      "owner": "rust-runtime"
+    },
+    "c2fb651c5e0073ac749b90cfe44ab5ec4add884f": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
       "owner": "rust-runtime"
     },
     "c3464ecf453d": {
@@ -4832,13 +5857,13 @@
     },
     "c39b2b50eeb8": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by Rust-only process startup: upstream hardens Python entrypoints against cwd packages named utils/proxy/ui shadowing imports. Hermes Ultra has no Python gateway/acp entrypoint import path, and scripts/check-rust-runtime-no-python.sh verifies no Rust runtime Python execution path."
+      "notes": "Superseded by Rust-only process startup: upstream hardens Python entrypoints against cwd packages named utils/proxy/ui shadowing imports. Hermes Ultra has no Python gateway/acp entrypoint import path, and scripts/check-rust-runtime-no-python.sh verifies no Rust runtime Python execution path.",
+      "owner": "rust-runtime"
     },
     "c42d44cb2fc2": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by intentional Rust security posture: upstream restored Python user dashboard backend auto-import, but Hermes Ultra has no Python dashboard backend import path and keeps user/project dashboard API files inert."
+      "notes": "Superseded by intentional Rust security posture: upstream restored Python user dashboard backend auto-import, but Hermes Ultra has no Python dashboard backend import path and keeps user/project dashboard API files inert.",
+      "owner": "rust-runtime"
     },
     "c4811c382fd5": {
       "disposition": "superseded",
@@ -4866,20 +5891,30 @@
       "notes": "Ported by Rust TUI model picker: crates/hermes-cli/src/tui.rs constructs provider:model selections and calls App::switch_model, so dashboard-side Python model update glue is not the active runtime path.",
       "owner": "rust-runtime"
     },
+    "c648ecdca526f8c421d8c8c00e1aa9b330bbcb5e": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Telegram intake: unauthorized users are rejected in should_process_update before TelegramAdapter::parse_update and before CLI text batching/route_message. The model now includes sender_chat for from-less channel-post authorization, and tests cover unauthorized users, allowed group senders, callback tap users, and sender_chat allowlists.",
+      "owner": "rust-runtime"
+    },
     "c6575df92781a5b6859845b39ee59d7f07a8cf31": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust as a first-class virtual MoA provider: model/provider catalogs expose moa:default, provider identity/startup diagnostics treat MoA as a no-key virtual provider instead of a generic API backend, CLI model switching persists moa:default without rebuilding a fake agent, and selected MoA turns automatically route through Rust quorum fan-out with upstream-style reference voters and a concrete aggregator model before restoring the visible virtual selection."
+      "notes": "Ported in Rust as a first-class virtual MoA provider: model/provider catalogs expose moa:default, provider identity/startup diagnostics treat MoA as a no-key virtual provider instead of a generic API backend, CLI model switching persists moa:default without rebuilding a fake agent, and selected MoA turns automatically route through Rust quorum fan-out with upstream-style reference voters and a concrete aggregator model before restoring the visible virtual selection.",
+      "owner": "rust-runtime"
     },
     "c6b0eb4de0e5": {
       "disposition": "superseded",
       "notes": "Upstream desktop remote-artifact authenticated download is superseded by Rust gateway/media delivery boundaries; Electron artifacts UI and Python web_server files endpoint are outside the Rust-only runtime.",
       "owner": "rust-runtime"
     },
+    "c6ba4b229ed138dcf636322487c968d2ffe4b999": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "c6c1fd8b6b6828361bc117b532848537904ac562": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Documentation/infographic-only upstream delta is superseded by Hermes Agent Ultra's Rust-first docs/parity/release surfaces for this batch; it does not add or change a shipped Rust runtime behavior. Runtime, provider, platform, and install changes remain pending for separate evidence."
+      "notes": "Documentation/infographic-only upstream delta is superseded by Hermes Agent Ultra's Rust-first docs/parity/release surfaces for this batch; it does not add or change a shipped Rust runtime behavior. Runtime, provider, platform, and install changes remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "c6c8abbadb80": {
       "disposition": "ported",
@@ -4888,17 +5923,22 @@
     },
     "c6d6a1c30d033287f2cbbd9d7ecdd47146f1942a": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "c6dc2fcd2153": {
       "disposition": "superseded",
       "notes": "Upstream desktop profile-backend release-before-delete targets Electron and Python profile managers. Rust profile/session lifecycle is managed through typed config, App session state, and SessionPersistence."
     },
+    "c6eb7f9e7284c5268ceed0c3fc92e1f2a5d892c7": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
+    },
     "c6fbd5a10494541ec3f29b77bc639e6ce3441c18": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "c6fdf48b79eb": {
       "disposition": "ported",
@@ -4916,6 +5956,11 @@
       "disposition": "ported",
       "notes": "Rust ACP now converts its slash command table into availableCommands updates with input hints and emits available_commands_update after session new/load/resume/fork; handler and server run_on tests prove the lifecycle and JSON-RPC notification path."
     },
+    "c73e74386b20164fa218414131fe8b03f07b3e7c": {
+      "disposition": "superseded",
+      "notes": "Upstream Vertex provider is superseded by Hermes Ultra generic/OpenAI-compatible provider routing, Gemini/OpenAI-compatible setup, custom base_url/headers, and OAuth provider surfaces; no dedicated Python vertex_adapter runtime is shipped.",
+      "owner": "rust-runtime"
+    },
     "c7513df4f9e4": {
       "disposition": "ported",
       "notes": "Ported in Rust Honcho setup semantics: pinUserPeer is only true for the single-user/operator peer shape; multi/hybrid runtime peers are modeled through runtimePeerPrefix/userPeerAliases.",
@@ -4923,8 +5968,8 @@
     },
     "c7542358f2ba5b4b7ef3f49d9e13f9b2e92c98e7": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "c77c470d2762": {
       "disposition": "superseded",
@@ -4941,8 +5986,8 @@
     },
     "c7e0501e9b58": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Already ported in Rust OpenViking: shutdown enumerates all tracked session writer queues and drains each with the configured session drain timeout before clearing provider state. Existing focused tests cover writer draining and stale writer behavior; the current OpenViking test filter passes 30 tests."
+      "notes": "Already ported in Rust OpenViking: shutdown enumerates all tracked session writer queues and drains each with the configured session drain timeout before clearing provider state. Existing focused tests cover writer draining and stale writer behavior; the current OpenViking test filter passes 30 tests.",
+      "owner": "rust-runtime"
     },
     "c7e8854cb383": {
       "disposition": "ported",
@@ -4962,15 +6007,20 @@
       "notes": "Rust OpenViking does not block command/session-switch callers on old-session writer drains; old commits run through a deferred finalizer and non-blocking switch coverage asserts prompt return.",
       "owner": "rust-runtime"
     },
+    "c8e5f999c2b02c45c8d4531bd7721b745bbd4702": {
+      "disposition": "ported",
+      "notes": "Ported in Rust quick-command/terminal surfaces: command execution sanitizes credential environment and strips ANSI/redacts sensitive output before returning gateway/TUI-visible text.",
+      "owner": "rust-runtime"
+    },
     "c8fd47be14921fed55e643092f9ab18c7953885d": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Documentation/infographic-only upstream delta is superseded by Hermes Agent Ultra's Rust-first docs/parity/release surfaces for this batch; it does not add or change a shipped Rust runtime behavior. Runtime, provider, platform, and install changes remain pending for separate evidence."
+      "notes": "Documentation/infographic-only upstream delta is superseded by Hermes Agent Ultra's Rust-first docs/parity/release surfaces for this batch; it does not add or change a shipped Rust runtime behavior. Runtime, provider, platform, and install changes remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "c918d07b50921da6be27a881c67669cf1337f2f1": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Python/Electron CI or Docker-test orchestration delta is superseded by Hermes Agent Ultra's Rust-first CI surface: the local workflows build/test the Rust workspace, run parity gates, and use the distinct Rust Docker image/entrypoint contracts rather than upstream uv/s6/Electron docker jobs."
+      "notes": "Upstream Python/Electron CI or Docker-test orchestration delta is superseded by Hermes Agent Ultra's Rust-first CI surface: the local workflows build/test the Rust workspace, run parity gates, and use the distinct Rust Docker image/entrypoint contracts rather than upstream uv/s6/Electron docker jobs.",
+      "owner": "rust-runtime"
     },
     "c92a95a130cc": {
       "disposition": "superseded",
@@ -4982,12 +6032,17 @@
     },
     "c93b9f9057e4": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust relay contracts: close code 4401 after a successful handshake maps to disabled instead of retrying, while pre-handshake 4401 and ordinary closes remain retryable. Focused relay tests cover the terminal opt-out mapping."
+      "notes": "Ported in Rust relay contracts: close code 4401 after a successful handshake maps to disabled instead of retrying, while pre-handshake 4401 and ordinary closes remain retryable. Focused relay tests cover the terminal opt-out mapping.",
+      "owner": "rust-runtime"
     },
     "c9b32a654cd1": {
       "disposition": "ported",
       "notes": "Darwinian-evolver was adopted from upstream at optional-skills/research/darwinian-evolver with SKILL.md, helper scripts, and template assets."
+    },
+    "c9df4bc094fb27ddfc8b278380d9598dc534587b": {
+      "disposition": "superseded",
+      "notes": "Superseded by Rust gateway lifecycle: Hermes Agent Ultra has no configurable restart_drain_timeout/systemd drain window. Gateway::stop_all finalizes active sessions and stops adapters immediately, avoiding the stale systemd TimeoutStopSec crash-loop class entirely; existing hook_lifecycle coverage proves stop_all emits shutdown finalization for active sessions.",
+      "owner": "rust-runtime"
     },
     "ca1fb32c2619": {
       "disposition": "superseded",
@@ -5012,8 +6067,8 @@
     },
     "cb17a9efb2dffb35ab5f827f0766d17b94fab91f": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "cb29e8a82e7e": {
       "disposition": "ported",
@@ -5023,10 +6078,30 @@
       "disposition": "superseded",
       "notes": "Desktop composer model picker sticky state targets absent apps/desktop and tui_gateway Python files. Ultra tracks model/provider session state through Rust gateway runtime state and TUI model switch paths."
     },
+    "cb6d6d46ab6b20b173c8215a1f066b53847e9ee5": {
+      "disposition": "ported",
+      "notes": "Ported in Rust holographic memory: SQLite FTS5 recall sanitizes natural-language queries, falls back safely when FTS is unavailable, scores trusted category matches, and has focused tests.",
+      "owner": "rust-runtime"
+    },
     "cb6edbf448e7878fd25bf6db20df4c18ed8755a7": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
+    },
+    "cb9308f0a65ff2f0a5880c54f67203946d0dc317": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
+    },
+    "cb982ad997c5e04c6b647c4cbb3d1b020ec383fb": {
+      "disposition": "ported",
+      "notes": "Ported in Rust for backend git/bash/helper spawns: coding context, context references, project workspace facts, plugin clone/update, specpatch git probes, doctor bash probes, background triage self-invocation, and quick exec all route through the no-window helper where applicable.",
+      "owner": "rust-runtime"
+    },
+    "cb9d18c759417f0bf0ff94fb932a423c74d706d5": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
     },
     "cbce5e93fcb9": {
       "disposition": "superseded",
@@ -5039,16 +6114,26 @@
     },
     "cbe5c5689f9cb0e86903431c6337e0d87abf4b9b": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "cbf851ae1d72": {
       "disposition": "superseded",
       "notes": "Upstream patch bounds Python TUI startup MCP discovery; Rust TUI startup does not connect/discover configured MCP servers on App::new, and hermes-mcp discovery remains explicit client/CLI behavior with transport/call timeouts, so the freeze path is absent in current Rust runtime."
     },
+    "cc0aa18fe718967bc5032271f69d3c2fdd85a5b9": {
+      "disposition": "superseded",
+      "notes": "Upstream patch is generated Kanban dashboard dist UI grab-to-pan behavior, not a Rust runtime parity gap; Rust Kanban command/store behavior is covered separately.",
+      "owner": "rust-runtime"
+    },
     "cc14b74718aa": {
       "disposition": "ported",
       "notes": "Ported in this batch: profile create --clone-from now implies a config clone in crates/hermes-cli/src/main.rs, has parser/behavior regression coverage, and website profile docs show the clone-from-only form."
+    },
+    "cc1e4c32c0227e808821822a4f6206d317973528": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
     },
     "cc38282b04d9": {
       "disposition": "superseded",
@@ -5058,9 +6143,19 @@
       "disposition": "superseded",
       "notes": "Upstream refactors Electron served-token adoption and foreign-backend refusal into a helper. Hermes Agent Ultra has no Electron dashboard-token helper; the underlying local token adoption/refusal failure mode is absent from the Rust runtime."
     },
+    "cc7d20d6838343f8acc70aecf207bae22dde4a88": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
+    },
     "cc8e5ec2afbf": {
       "disposition": "superseded",
       "notes": "Upstream migrates the Python Discord adapter into a bundled plugin. Ultra's live Discord runtime is Rust-native in crates/hermes-gateway/src/platforms/discord.rs and registered from crates/hermes-cli/src/main.rs; Python plugin migration is not a Rust runtime path."
+    },
+    "cca8b4ef4e3f8bac1708bd5951450b645d8c20a3": {
+      "disposition": "superseded",
+      "notes": "Upstream GitHub Actions/CI-only delta is superseded by Hermes Ultra local Rust deterministic gates and release workflow; it does not add shipped Rust runtime behavior.",
+      "owner": "rust-runtime"
     },
     "ccaa5165a006": {
       "disposition": "superseded",
@@ -5074,10 +6169,15 @@
       "disposition": "superseded",
       "notes": "The Python on_memory_write metadata ABC compatibility shim is not a Rust API surface; Rust memory writes use typed trait methods and provider tool handlers."
     },
+    "cd592c105cbbc0bbf927b30ee9d061b1dd7b0b1b": {
+      "disposition": "ported",
+      "notes": "Ported/superseded in Rust WhatsApp gateway: PlatformAdapter::send_file uploads local media to WhatsApp Cloud API, maps extension categories to native image/video/audio/document payloads, then sends the uploaded media id. This batch adds api_base_url configurability and a wiremock test proving upload-then-native-image send with caption through the Rust adapter and gateway media path.",
+      "owner": "rust-runtime"
+    },
     "cd5fb760a5ee42181d21b1c66cb61033cb2a8d18": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "cda64a59612f": {
       "disposition": "ported",
@@ -5105,8 +6205,8 @@
     },
     "ce802e932c645304badf0112e175e77f23b86a5b": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported by Rust resident polling lifecycle: the Telegram poll task stays alive while the adapter is stopped instead of exiting or busy-spinning, then resumes after start() marks the adapter running again. The Python test-double get_me spin failure is not present in Rust."
+      "notes": "Ported by Rust resident polling lifecycle: the Telegram poll task stays alive while the adapter is stopped instead of exiting or busy-spinning, then resumes after start() marks the adapter running again. The Python test-double get_me spin failure is not present in Rust.",
+      "owner": "rust-runtime"
     },
     "cea87d913904": {
       "disposition": "superseded",
@@ -5116,14 +6216,19 @@
       "disposition": "superseded",
       "notes": "Upstream passive update fix avoids SSH origin fetches in Python banner and Electron desktop checks. Hermes Agent Ultra's Rust update command already uses the GitHub HTTPS releases API in crates/hermes-cli/src/update.rs with HERMES_UPDATE_REPO override support and never shells out to git fetch origin for update checks."
     },
+    "cf05b38683ebe2035d41f9eb7c39c735092e8f68": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "cf786593cd83": {
       "disposition": "ported",
       "notes": "Rust now propagates active provider output caps into AgentConfig.max_tokens so gateway/CLI/cron agent paths pass configured max_tokens into provider requests through the existing AgentLoop max_tokens chain."
     },
     "cf7bf5bdc900078cc18a2055a6bcaf1abfb1e7a0": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Discord outbound formatting: GFM pipe tables are rewritten to Discord-safe bold-heading plus bullet groups before send/edit splitting, fenced code tables are preserved, Unicode splitting is char-boundary safe, and hermes-gateway tests cover the formatter and split behavior."
+      "notes": "Ported in Rust Discord outbound formatting: GFM pipe tables are rewritten to Discord-safe bold-heading plus bullet groups before send/edit splitting, fenced code tables are preserved, Unicode splitting is char-boundary safe, and hermes-gateway tests cover the formatter and split behavior.",
+      "owner": "rust-runtime"
     },
     "cf9dc366dd0b": {
       "disposition": "superseded",
@@ -5152,8 +6257,8 @@
     },
     "d0af7fc954fe61c030a29be38d5c63f67f0bf7b2": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "d0de4601d204": {
       "disposition": "ported",
@@ -5176,6 +6281,11 @@
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
+    "d173e8c3a76bcd8ca86df6861fb1e1349872e560": {
+      "disposition": "ported",
+      "notes": "Ported in Rust disk_cleanup: cleanup skips protected cron roots even when auto-delete categories match, with focused protection tests.",
+      "owner": "rust-runtime"
+    },
     "d1771114eda9": {
       "disposition": "ported",
       "notes": "Rust session_search now sanitizes FTS5 MATCH input by quoting query terms before execution, so colon-containing queries are treated as literal search text instead of FTS column filters. Regression coverage proves workspace:hermes searches return matching sessions without error.",
@@ -5184,6 +6294,11 @@
     "d18618f48f18": {
       "disposition": "ported",
       "notes": "Rust Honcho respects HOME-anchored default profile fallback paths while still allowing the active HERMES_HOME profile to override them."
+    },
+    "d1c8c03416d7c6780d31ce2371c5b0777f10afaf": {
+      "disposition": "ported",
+      "notes": "Rust has native context compression surfaces: Agent ContextCompressor, gateway /compress, app-server cache flattening, and resume compression-tip resolution; cli-config.yaml.example is Rust-native and dynamic-model based.",
+      "owner": "rust-runtime"
     },
     "d1ecebcbfd8c": {
       "disposition": "superseded",
@@ -5207,6 +6322,11 @@
       "notes": "WS-only inbound relay is part of the upstream experimental Python relay adapter. Ultra keeps native Rust platform adapters and does not expose the relay adapter as active runtime surface.",
       "owner": "rust-runtime"
     },
+    "d2de9580e181b3cabb3b84c6e970bd3902eb13d3": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "d3120aeab064": {
       "disposition": "superseded",
       "notes": "upstream python CI/release workflow delta superseded by local rust-first parity gates and release pipeline"
@@ -5221,8 +6341,18 @@
     },
     "d398076c21175458003fed2d64c8339ed8861293": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
+    },
+    "d3c866746234ed3de27732de696328c328317fb9": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
+    },
+    "d3d621f7c38bb801d9d734cb2898bd4f9b134709": {
+      "disposition": "superseded",
+      "notes": "Upstream reverted earlier Python no-window wrappers. Hermes Agent Ultra does not inherit those reverted Python helper layers; the Rust runtime now implements the final behavior directly through hermes-core CommandNoWindowExt and explicit source-contract tests.",
+      "owner": "rust-runtime"
     },
     "d41427504ef04": {
       "disposition": "ported",
@@ -5232,34 +6362,49 @@
       "disposition": "superseded",
       "notes": "Upstream AGENTS.md plugin/skill documentation refresh is superseded by local AGENTS.md Rust parity rules plus docs/parity compatibility policy and skills governance."
     },
+    "d43e0cf304a14c9a3c98ff0506a1f79cf4938e99": {
+      "disposition": "ported",
+      "notes": "Ported in Rust agent loop: codex acknowledgement continuations are handled in both non-streaming and streaming run paths with bounded retry counters, independent of Python api_mode branching.",
+      "owner": "rust-runtime"
+    },
     "d473e7c9385e": {
       "disposition": "ported",
       "notes": "Rust disk-cleanup auto categorization only marks cron/cronjobs output subtrees as cron-output and explicitly leaves cron/jobs.json plus .tick.lock as control-plane state; covered by hermes-tools disk_cleanup tests."
     },
     "d4aec4e92f2c6973169743022f2226b57cd80284": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Python/Electron CI or Docker-test orchestration delta is superseded by Hermes Agent Ultra's Rust-first CI surface: the local workflows build/test the Rust workspace, run parity gates, and use the distinct Rust Docker image/entrypoint contracts rather than upstream uv/s6/Electron docker jobs."
+      "notes": "Upstream Python/Electron CI or Docker-test orchestration delta is superseded by Hermes Agent Ultra's Rust-first CI surface: the local workflows build/test the Rust workspace, run parity gates, and use the distinct Rust Docker image/entrypoint contracts rather than upstream uv/s6/Electron docker jobs.",
+      "owner": "rust-runtime"
     },
     "d4be583d986f7bcca4f8414fd21ef9e34b18c948": {
       "disposition": "ported",
       "notes": "Ported in Rust Telegram adapter: the default command-menu cap is 60 while still clamping to Telegram's 100-command API maximum, with command ordering/cap coverage.",
       "owner": "rust-runtime"
     },
+    "d4c14011ebbc59d1479a53c207692933b79d0287": {
+      "disposition": "superseded",
+      "notes": "Claude-design skill/web docs are optional prompt-skill content and not a Rust runtime gap; local skill index work is tracked separately from upstream Python queue parity.",
+      "owner": "rust-runtime"
+    },
     "d4e7dd609da6": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust managed-node resolver computes candidate command names once, mirrors platform-specific node/bin ordering, and prepends existing managed Node dirs without duplicate PATH entries; tests cover Windows and POSIX ordering."
+      "notes": "Rust managed-node resolver computes candidate command names once, mirrors platform-specific node/bin ordering, and prepends existing managed Node dirs without duplicate PATH entries; tests cover Windows and POSIX ordering.",
+      "owner": "rust-runtime"
     },
     "d4fa2db1c5dfd961776c77a619767e9ef17abce9": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "d539cd9004a1": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported/proven in Rust config persistence: save_config_yaml and atomic_yaml_write write UTF-8 bytes through Rust String serialization, and a focused test now round-trips emoji/personality/system_prompt text while preserving valid UTF-8 and omitting home_dir."
+      "notes": "Ported/proven in Rust config persistence: save_config_yaml and atomic_yaml_write write UTF-8 bytes through Rust String serialization, and a focused test now round-trips emoji/personality/system_prompt text while preserving valid UTF-8 and omitting home_dir.",
+      "owner": "rust-runtime"
+    },
+    "d5ba374c038a99db99e3036d938271e70a6930fd": {
+      "disposition": "superseded",
+      "notes": "Superseded by Rust direct polling: there is no PTB updater.running=true/consumer-task-dead split. Rust owns the getUpdates request directly with a timeout bounded by TELEGRAM_POLL_STALL_GRACE_SECONDS, exponential backoff, consecutive-error health gates, and immediate 409 conflict fail-closed tests.",
+      "owner": "rust-runtime"
     },
     "d61785889678": {
       "disposition": "ported",
@@ -5280,6 +6425,11 @@
     "d6615d8ec7d5": {
       "disposition": "ported",
       "notes": "Rust Telegram topic lanes are represented by adapter-level message_thread_id to composite chat_id routing plus Gateway session keys scoped by the encoded chat_id. Regression tests cover independent Telegram topic sessions, /new current-topic isolation, adapter topic send routing, topic binding recovery helpers, and config/env allowed_topics/ignored_threads hydration."
+    },
+    "d68d2716a7492db6853a81632de4d7e8acd69160": {
+      "disposition": "superseded",
+      "notes": "Upstream Python runtime delta is superseded by Hermes Ultra Rust-native agent/provider/tool architecture and existing deterministic Rust tests; the Python module path is not shipped in the Rust runtime.",
+      "owner": "rust-runtime"
     },
     "d6b65bbc47cf": {
       "disposition": "ported",
@@ -5307,8 +6457,8 @@
     },
     "d799284b1554f7b390ed27808e0b9af5eb435fef": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Creative ideation v2.1.0 method library is ported into the bundled Rust-loaded ideation skill, preserving the local skill identifier while adding routing rules, anti-slop guidance, method catalog, exercises, and all method reference files."
+      "notes": "Creative ideation v2.1.0 method library is ported into the bundled Rust-loaded ideation skill, preserving the local skill identifier while adding routing rules, anti-slop guidance, method catalog, exercises, and all method reference files.",
+      "owner": "rust-runtime"
     },
     "d7cd0bc0863cda1a203f00422b1441ca2d9890ed": {
       "disposition": "ported",
@@ -5328,6 +6478,11 @@
       "notes": "Ported in Rust Honcho setup: setup_honcho_provider builds the gateway-gated identity tree for single/multi/hybrid deployments with aiPeer, pinUserPeer, runtimePeerPrefix, and aliases.",
       "owner": "rust-runtime"
     },
+    "d836b2bac4447c099475a38c90b5f577a952d4ef": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Matrix and Mattermost adapters. Matrix invite auto-join now filters invite-state senders when an allowlist is configured while preserving default/no-allowlist behavior and allow-all escape hatch. Mattermost dynamic REST post/thread ids reject traversal path segments before interpolation. Focused matrix and mattermost feature tests cover both hardenings.",
+      "owner": "rust-runtime"
+    },
     "d842155da1e8": {
       "disposition": "ported",
       "notes": "Ported by Rust session/profile scoping: hermes-config resolves effective HERMES_HOME/profile config before runtime state, and ACP/session stores cwd explicitly in Rust session models.",
@@ -5343,13 +6498,13 @@
     },
     "d8fe1c0b4195": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Tests cover upstream Electron desktop/tui_gateway onboarding readiness. Ultra lacks those paths; Rust provider readiness is tested in Rust command/model surfaces instead."
+      "notes": "Tests cover upstream Electron desktop/tui_gateway onboarding readiness. Ultra lacks those paths; Rust provider readiness is tested in Rust command/model surfaces instead.",
+      "owner": "rust-runtime"
     },
     "d91b8d8368bb": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "This is a TypeScript desktop unit-test factory cleanup for keyVar EnvVarInfo, with no Rust runtime target."
+      "notes": "This is a TypeScript desktop unit-test factory cleanup for keyVar EnvVarInfo, with no Rust runtime target.",
+      "owner": "rust-runtime"
     },
     "d94fb47717eb": {
       "disposition": "superseded",
@@ -5365,8 +6520,8 @@
     },
     "da0ed979fa": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Zoomable primitive open-full/pan/copy is Electron desktop UI only. Ultra has no assistant-ui zoomable component surface."
+      "notes": "Zoomable primitive open-full/pan/copy is Electron desktop UI only. Ultra has no assistant-ui zoomable component surface.",
+      "owner": "rust-runtime"
     },
     "da18fd084a0b": {
       "disposition": "superseded",
@@ -5382,13 +6537,13 @@
     },
     "da5484b61ff75ac1727136ede9fbd3189935ae08": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "da73223f4aba9beee9c020a5fee02f243414a3d7": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "da9425bf9b08": {
       "disposition": "superseded",
@@ -5398,14 +6553,19 @@
       "disposition": "superseded",
       "notes": "Python session-cache RLock fixes are superseded by Rust Honcho's Mutex-protected session_key, prefetch, and turn-count state with no shared Python SDK cache."
     },
+    "db16854f343c67548933ac2e0e1d4d586bdeaaa6": {
+      "disposition": "superseded",
+      "notes": "Superseded by Rust Telegram inbound-media design: the adapter does not silently download/cache user attachments before dispatch. It preserves Telegram file IDs and bounded metadata on IncomingMessage, and oversized documents/videos are dropped by size gates with tests, so the upstream Python empty-turn-on-download-failure path is absent.",
+      "owner": "rust-runtime"
+    },
     "db22efbe88bd": {
       "disposition": "ported",
       "notes": "Optional and bundled local skills declare platforms frontmatter and Rust skill loading honors platform aliases/filters during command discovery."
     },
     "db6ced4712": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Inline embed consent gate is Electron assistant-ui/settings/i18n behavior. Ultra has no desktop inline embed renderer or per-service embed consent store."
+      "notes": "Inline embed consent gate is Electron assistant-ui/settings/i18n behavior. Ultra has no desktop inline embed renderer or per-service embed consent store.",
+      "owner": "rust-runtime"
     },
     "db744e7d1e58b64fdb8dfdb62cdba228081f9eca": {
       "disposition": "ported",
@@ -5416,9 +6576,19 @@
       "disposition": "superseded",
       "notes": "Upstream filesystem routing facade is desktop/Electron backend routing. Hermes Agent Ultra has no desktop filesystem facade; local file operations remain Rust tool and terminal surfaces under approval/workspace policy."
     },
+    "dbc925b7550c2224631d6fb1a2fa0ec236d76beb": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Telegram inbound media parsing: Video metadata is first-class, unknown/oversized videos are rejected before file IDs reach downstream download paths, and tests cover normal videos plus oversized current and replied videos.",
+      "owner": "rust-runtime"
+    },
     "dbe14ce35d9cb087ae9fe3e3f166f6c475297e25": {
       "disposition": "ported",
       "notes": "Ported in Rust Telegram adapter: startup registers BotCommand menus for default/private/group scopes from the Rust gateway command catalog with configurable priority, mode, and cap.",
+      "owner": "rust-runtime"
+    },
+    "dbe734beff0caf5e8ee2acbe4277db7f6cf84a21": {
+      "disposition": "superseded",
+      "notes": "Superseded by Rust runtime scope: this upstream row patches Python dashboard_auth interactive login/provider registry behavior for the drain-secret plugin. Hermes Ultra does not expose a Rust dashboard-auth provider registry or /auth/login surface; token/service credential access is not presented as an interactive Rust login provider.",
       "owner": "rust-runtime"
     },
     "dc5ef1ac8ed9": {
@@ -5440,8 +6610,8 @@
     },
     "dd0e4ab81abccf7df5b11c6c16853d5e5de9db69": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Python/Electron CI or Docker-test orchestration delta is superseded by Hermes Agent Ultra's Rust-first CI surface: the local workflows build/test the Rust workspace, run parity gates, and use the distinct Rust Docker image/entrypoint contracts rather than upstream uv/s6/Electron docker jobs."
+      "notes": "Upstream Python/Electron CI or Docker-test orchestration delta is superseded by Hermes Agent Ultra's Rust-first CI surface: the local workflows build/test the Rust workspace, run parity gates, and use the distinct Rust Docker image/entrypoint contracts rather than upstream uv/s6/Electron docker jobs.",
+      "owner": "rust-runtime"
     },
     "dd12a5403de9": {
       "disposition": "superseded",
@@ -5455,10 +6625,15 @@
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
+    "dd659c8d175858bab96012b52b4201e381cd19cc": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "dd980aaba1": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Alt-wheel pet scaling is Electron pet overlay UI only. Ultra has no desktop pet overlay runtime."
+      "notes": "Alt-wheel pet scaling is Electron pet overlay UI only. Ultra has no desktop pet overlay runtime.",
+      "owner": "rust-runtime"
     },
     "dde9c0d19d16": {
       "disposition": "ported",
@@ -5474,13 +6649,13 @@
     },
     "de6e9ac76014d73b80f75f1bd1887f3ee4fb701d": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Documentation/infographic-only upstream delta is superseded by Hermes Agent Ultra's Rust-first docs/parity/release surfaces for this batch; it does not add or change a shipped Rust runtime behavior. Runtime, provider, platform, and install changes remain pending for separate evidence."
+      "notes": "Documentation/infographic-only upstream delta is superseded by Hermes Agent Ultra's Rust-first docs/parity/release surfaces for this batch; it does not add or change a shipped Rust runtime behavior. Runtime, provider, platform, and install changes remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "de7ad8b78eaeab96324b9800e28f12d8b92e83a7": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "de80d28f3848": {
       "disposition": "superseded",
@@ -5489,6 +6664,11 @@
     "de8bdf529d64": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "dec44994a5be54d835060f593079f0c732567e80": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
     },
     "ded194eb6aca": {
       "disposition": "superseded",
@@ -5500,18 +6680,18 @@
     },
     "defeda8c559f": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Broad upstream docs sync targets Python/Electron desktop docs, cli-config.yaml.example, and relay docs. Ultra lacks apps/desktop and cli-config.yaml.example, and its relay reference explicitly documents that the Rust runtime does not register the experimental relay adapter."
+      "notes": "Broad upstream docs sync targets Python/Electron desktop docs, cli-config.yaml.example, and relay docs. Ultra lacks apps/desktop and cli-config.yaml.example, and its relay reference explicitly documents that the Rust runtime does not register the experimental relay adapter.",
+      "owner": "rust-runtime"
     },
     "df4015bbc176535e9bf58d5541186563365a2275": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Documentation-only upstream delta is superseded by local Rust-first docs/parity/release surfaces; it does not add or change a shipped Rust runtime behavior. Skills/docs/config-mixed items remain pending for separate evidence."
+      "notes": "Documentation-only upstream delta is superseded by local Rust-first docs/parity/release surfaces; it does not add or change a shipped Rust runtime behavior. Skills/docs/config-mixed items remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "df514654ba5d7359fc3484ca2396892c054889fe": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "df55660e3c3c": {
       "disposition": "superseded",
@@ -5519,8 +6699,8 @@
     },
     "dfb561a3aebf459da9f05718da04784af8e661f3": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "dfc5563641f0": {
       "disposition": "ported",
@@ -5530,13 +6710,28 @@
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
+    "dff491a2b993e9e9db43d1834ac5d46c2f87173e": {
+      "disposition": "ported",
+      "notes": "Ported in Rust CLI: hermes serve is a first-class alias for the headless dashboard/API backend with host/port/no-open/insecure flags and parser coverage.",
+      "owner": "rust-runtime"
+    },
     "e003c53b06d8": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
+    "e009ba57ac4feac11e326db8f4c7da95d9028485": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "e0121c59d3b3": {
       "disposition": "superseded",
       "notes": "Drag-sort profiles in the rail only changes apps/desktop profile-switcher UI state. Rust profiles are filesystem-backed YAML entries listed deterministically by CLI/gateway surfaces, not an ordered desktop rail."
+    },
+    "e0176cbd47a186d3117282a14d8e36529023b000": {
+      "disposition": "superseded",
+      "notes": "Upstream patch optionally mentions Discord approval owners in discord.py exec prompts. Rust approval ownership is enforced through centralized approval/allowlist tooling rather than Discord view-owner mentions.",
+      "owner": "rust-runtime"
     },
     "e026fd88cdbb": {
       "disposition": "superseded",
@@ -5555,9 +6750,19 @@
       "notes": "Superseded by user policy and local gate scripts: official GitHub pull_request CI is optional, while local shell/Rust gates define the required validation before push.",
       "owner": "local-gates"
     },
+    "e0a78336c1e3d3ea2216510154430f6142f4464a": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "e0a999aa8a22": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "e0bca1cbe2d13af97924dfd8a4c8b0e81ab648b7": {
+      "disposition": "ported",
+      "notes": "Discord REST response bodies now use bounded chunk readers for text and JSON, fail closed on oversized JSON, and have wiremock coverage for truncation and rejection.",
+      "owner": "rust-runtime"
     },
     "e0e25717116c": {
       "disposition": "superseded",
@@ -5566,6 +6771,11 @@
     "e0f6a35ac659": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
+    },
+    "e117cfdff08b7e43b7d0b7f7e661be7b710e7a4f": {
+      "disposition": "superseded",
+      "notes": "Upstream live agent terminals and agent-driven tab close are Electron desktop UI changes. The Rust runtime has no apps/desktop tab lifecycle to port; CLI/gateway session lifecycle is implemented in compiled Rust.",
+      "owner": "rust-runtime"
     },
     "e1710378b738": {
       "disposition": "ported",
@@ -5599,18 +6809,23 @@
     },
     "e2b801872992867c3e48630f22f939fcf0d807c9": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
+    },
+    "e32ebc6aa26fff446bcc7e11a254d2d4c671f3b2": {
+      "disposition": "ported",
+      "notes": "Ported in Rust: /learn is a first-class slash command that records an objective learning ledger entry, queues a next-turn system note to distill reusable project knowledge/skill guidance, and is exposed in CLI command catalogs. Covered by command tests for ledger capture and next-turn note queuing.",
+      "owner": "rust-runtime"
     },
     "e3505c7f73a4": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust: computer_use is no longer macOS-gated or documented as macOS-only in the runtime surface; the Rust schema and CLI manage macOS/Windows/Linux through cua-driver MCP while keeping the desktop-mutating toolset explicit."
+      "notes": "Ported in Rust: computer_use is no longer macOS-gated or documented as macOS-only in the runtime surface; the Rust schema and CLI manage macOS/Windows/Linux through cua-driver MCP while keeping the desktop-mutating toolset explicit.",
+      "owner": "rust-runtime"
     },
     "e36d9862ec": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Assistant markdown embed/fence rendering is Electron desktop UI only. Ultra CLI/TUI markdown rendering is a separate Rust surface."
+      "notes": "Assistant markdown embed/fence rendering is Electron desktop UI only. Ultra CLI/TUI markdown rendering is a separate Rust surface.",
+      "owner": "rust-runtime"
     },
     "e372803554be": {
       "disposition": "superseded",
@@ -5627,6 +6842,11 @@
     "e3adbb5ae9d6": {
       "disposition": "ported",
       "notes": "Ported as a Rust-wide memory fix rather than an OpenViking-only Python plugin patch: MemoryManager now strips slash-skill scaffolding before provider prefetch, queued prefetch, or sync fan-out."
+    },
+    "e3c9924b8b358e4b7b0a600178426fd70e6f9481": {
+      "disposition": "ported",
+      "notes": "Ported in Rust auth/runtime hints: stale Nous re-authentication guidance now consistently says `hermes auth add nous` across Chronos and agent 401 diagnostics; focused agent diagnostic test asserts the new hint and source search leaves no stale Rust hints.",
+      "owner": "rust-runtime"
     },
     "e3ed7722b5b1": {
       "disposition": "superseded",
@@ -5648,6 +6868,11 @@
       "disposition": "ported",
       "notes": "Rust shares static provider/model knowledge through model_switch curated catalogs, canonical provider IDs, and provider_model_ids_for_config tests for custom provider maps instead of duplicating startup detector code."
     },
+    "e5253d852b24f87af91d77b66141cc5c0b9e6f69": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "e5472da58470": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
@@ -5656,14 +6881,29 @@
       "disposition": "ported",
       "notes": "Rust DiscordInteractionAuthPolicy includes allowed_role_ids and role matching for components, slash commands, autocomplete, and fail-closed paths."
     },
+    "e55ddc3e33b28cf036371b8d81c73109521ac3f1": {
+      "disposition": "ported",
+      "notes": "Ported as Rust MCP background-discovery noninteractive guard: McpManager::connect_all_parallel now marks spawned discovery configs with a runtime-only suppress_interactive_oauth flag, and StdioTransport injects HERMES_MCP_BACKGROUND_DISCOVERY/HERMES_MCP_SUPPRESS_INTERACTIVE_OAUTH/MCP_NONINTERACTIVE into child env without changing normal explicit MCP connect/login paths. Transport test covers marker isolation.",
+      "owner": "rust-runtime"
+    },
+    "e55e9fad2c2e2de6181e12c65d3a12baf718d759": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
+    },
+    "e5d22ab80d979d38d8062e666af418ed847618a9": {
+      "disposition": "superseded",
+      "notes": "Upstream Daytona fix quotes a Python SDK shell mkdir in the single-upload path. Hermes Agent Ultra's Rust DaytonaBackend does not run mkdir for writes; it sends PUT /workspace/{id}/file with the remote path URL-encoded, so the shell-metacharacter injection class is absent.",
+      "owner": "rust-runtime"
+    },
     "e5d41f05d47e": {
       "disposition": "ported",
       "notes": "Spotify skill catalog coverage exists at skills/media/spotify/SKILL.md with cross-platform frontmatter, while Spotify tool surfacing remains gated through the Rust tool/catalog setup paths."
     },
     "e5e25836350a7041e58bb4ecfd55cba893630df4": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "e618cbee4418": {
       "disposition": "superseded",
@@ -5671,8 +6911,8 @@
     },
     "e62afaca6259": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust /learn prompt now embeds the full hardline skill-authoring standards: <=60-char description count-and-trim, platforms gating, human-first author credit, Hermes wrapped-tool framing, and scripts/references/templates layout. Gateway tests assert the standards remain present."
+      "notes": "Rust /learn prompt now embeds the full hardline skill-authoring standards: <=60-char description count-and-trim, platforms gating, human-first author credit, Hermes wrapped-tool framing, and scripts/references/templates layout. Gateway tests assert the standards remain present.",
+      "owner": "rust-runtime"
     },
     "e67ab2e042d3": {
       "disposition": "superseded",
@@ -5680,8 +6920,13 @@
     },
     "e684b808adf4c3a2740a93a9cc425b8b9bc3c2b5": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/desktop/dashboard-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, web, or Electron desktop runtime tree, while Rust CLI/TUI/gateway/install paths own the applicable behavior. Mixed Rust/runtime/provider/platform commits remain pending for separate evidence."
+      "notes": "Upstream Electron/desktop/dashboard-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, web, or Electron desktop runtime tree, while Rust CLI/TUI/gateway/install paths own the applicable behavior. Mixed Rust/runtime/provider/platform commits remain pending for separate evidence.",
+      "owner": "rust-runtime"
+    },
+    "e684b808adf4c4865a10e77f057535b2fd785f64": {
+      "disposition": "superseded",
+      "notes": "Upstream old-Electron-runtime dashboard fallback is superseded because no Electron desktop runtime is shipped locally; Rust CLI/TUI/gateway startup paths are the runtime surface.",
+      "owner": "rust-runtime"
     },
     "e68fc4def2ba": {
       "disposition": "superseded",
@@ -5691,14 +6936,19 @@
       "disposition": "ported",
       "notes": "Rust TUI tool-output rendering now defaults to a small 16-line/1KiB retained preview while preserving full agent context/session storage; regression coverage pins truncation and preview-size behavior."
     },
+    "e774d7fbf9be43beb7577498cb6125da1e47159e": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "e7a7872a874837ca36105ca3e90db464cf7c125a": {
       "disposition": "ported",
       "notes": "Rust process_registry now exposes deduplicated process notification receipts via notify/record_event/list_events/clear_events. Completion events are one-shot per process session, watch_match identities include command/pattern/output/suppressed/message_id so distinct matches are preserved, and focused tests cover replay dedup plus distinct watch-match emission."
     },
     "e7d2f0b93c": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Windows console-flash/gateway restart hardening targets Electron/Python gateway/web_server/browser_tool files absent from Ultra. Rust gateway/process handling is separate."
+      "notes": "Windows console-flash/gateway restart hardening targets Electron/Python gateway/web_server/browser_tool files absent from Ultra. Rust gateway/process handling is separate.",
+      "owner": "rust-runtime"
     },
     "e80754647c90": {
       "disposition": "superseded",
@@ -5714,8 +6964,8 @@
     },
     "e92b5c6af8": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Applicable OpenRouter-compatible image generation is implemented in Rust with provider config, reference grounding, data-URI save, and mocked request tests. Desktop pet/Atlas/global notification pieces are non-applicable without apps/desktop."
+      "notes": "Applicable OpenRouter-compatible image generation is implemented in Rust with provider config, reference grounding, data-URI save, and mocked request tests. Desktop pet/Atlas/global notification pieces are non-applicable without apps/desktop.",
+      "owner": "rust-runtime"
     },
     "e93bfc6c93bf": {
       "disposition": "superseded",
@@ -5733,6 +6983,11 @@
       "disposition": "superseded",
       "notes": "Upstream served dashboard token adoption targets Electron child-process dashboard websocket auth. Hermes Agent Ultra does not ship that Electron backend launcher; Rust gateway/session auth is handled by typed Rust services and CLI config rather than desktop dashboard-token.cjs."
     },
+    "e971dc1e9d2afb307d3cea3e576b8de9614baaf7": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "e97a4c8f3795": {
       "disposition": "ported",
       "notes": "README.md and local Chinese README now include the upstream Nous Portal setup/status section adapted to hermes-agent-ultra command names."
@@ -5743,17 +6998,27 @@
     },
     "e9b86f352fc7": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust Discord command diff planner now deletes obsolete application commands before create/update/recreate mutations, preserving the upstream fix for Discord 100-command cap; the focused command-sync test asserts delete-before-create ordering."
+      "notes": "Rust Discord command diff planner now deletes obsolete application commands before create/update/recreate mutations, preserving the upstream fix for Discord 100-command cap; the focused command-sync test asserts delete-before-create ordering.",
+      "owner": "rust-runtime"
     },
     "e9b8dd236c79": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
+    "e9b95dfd19b5046ffd633e6ce2dfd87e504a372b": {
+      "disposition": "superseded",
+      "notes": "Upstream dashboard Docker image delta depends on apps/shared and web inputs that are absent here; the Rust multi-stage Dockerfile and its packaging/PID-1 contracts are the shipped container surface.",
+      "owner": "rust-runtime"
+    },
     "e9b95dfd19b5399385c5f8d0f4512c97f3e3d8f8": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream dashboard Docker delta depends on apps/shared/web dashboard image inputs that are absent here; Hermes Agent Ultra ships a distinct Rust multi-stage Dockerfile with container contracts, so the dashboard-web image inclusion patch is not a Rust runtime port target."
+      "notes": "Upstream dashboard Docker delta depends on apps/shared/web dashboard image inputs that are absent here; Hermes Agent Ultra ships a distinct Rust multi-stage Dockerfile with container contracts, so the dashboard-web image inclusion patch is not a Rust runtime port target.",
+      "owner": "rust-runtime"
+    },
+    "e9bceb5ae0c46234c0c66e136ced2c791dcc90d8": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
     },
     "e9c47c70422d": {
       "disposition": "ported",
@@ -5761,8 +7026,8 @@
     },
     "e9cd8c5bf3ea": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust intentionally keeps the delivery cap constant with no new HERMES_DELIVERY_MAX_PLATFORM_OUTPUT env knob; verified Rust chunking adapters (Discord, Telegram, Slack, WhatsApp, Weixin) opt into splits_long_messages, while non-chunking Rust adapters remain conservative and protected by truncation plus full-output audit files. The upstream-only Teams/Yuanbao/WhatsApp Cloud adapter flags have no Rust files in this tree."
+      "notes": "Rust intentionally keeps the delivery cap constant with no new HERMES_DELIVERY_MAX_PLATFORM_OUTPUT env knob; verified Rust chunking adapters (Discord, Telegram, Slack, WhatsApp, Weixin) opt into splits_long_messages, while non-chunking Rust adapters remain conservative and protected by truncation plus full-output audit files. The upstream-only Teams/Yuanbao/WhatsApp Cloud adapter flags have no Rust files in this tree.",
+      "owner": "rust-runtime"
     },
     "ea01bdcebe1f": {
       "disposition": "superseded",
@@ -5787,8 +7052,8 @@
     },
     "ea5fa505d9743d1f6e0036480a36eaebc60d79af": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "ea8e608821b1": {
       "disposition": "ported",
@@ -5815,6 +7080,11 @@
       "disposition": "ported",
       "notes": "Rust exposes image_generate as a first-class tool with schema/handler coverage and FalImageGenBackend direct/managed transport tests for payload shape, auth routing, model override, and unconfigured errors."
     },
+    "ebb81f10cb70c4c37a2d00ef58a8aea37e7971f2": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
+    },
     "ebf2ea584ab2": {
       "disposition": "superseded",
       "notes": "example-config upstream delta superseded by rust setup/auth/provider workflows and local config schema"
@@ -5835,6 +7105,11 @@
       "disposition": "superseded",
       "notes": "upstream delta reviewed and superseded under rust-only parity policy (behavior covered or intentionally divergent)"
     },
+    "ecffd290a3f115b33f921505b5190228d1323387": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Codex image backend: OpenAI Codex Responses payloads now accept input_image parts from image_url/reference_image_urls and report image modality/source count.",
+      "owner": "rust-runtime"
+    },
     "ed1e2533b73d": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
@@ -5844,14 +7119,19 @@
       "notes": "Ported by Rust explicit model switching: crates/hermes-cli/src/tui.rs provider/model modal calls App::switch_model directly, allowing operator-selected models to escape stale config defaults.",
       "owner": "rust-runtime"
     },
+    "ed47f2b4aa43c9b280bd84798d4a6cbf9ac889f4": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
     "ed81cfe3def7": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
     "ed81f0b633c7c2ee9526b63be34fe0e5b13ab701": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported by eliminating the silent fallback path in Rust: session.title returns an explicit JSON-RPC error for missing sessions and empty titles, while successful live-session title updates emit an observable session_info_update event and persist through the Rust manager callback."
+      "notes": "Ported by eliminating the silent fallback path in Rust: session.title returns an explicit JSON-RPC error for missing sessions and empty titles, while successful live-session title updates emit an observable session_info_update event and persist through the Rust manager callback.",
+      "owner": "rust-runtime"
     },
     "eda1c97a1ef8c7d8505f40be1839929e130ad4c4": {
       "disposition": "ported",
@@ -5874,14 +7154,24 @@
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
+    "ede5c09f3b1a16a9eacc69da69cfa02bd89e1b35": {
+      "disposition": "ported",
+      "notes": "Ported in Rust disk_cleanup: exact protected cron path behavior is enforced by is_protected_cron_path and regression-tested rather than only documented.",
+      "owner": "rust-runtime"
+    },
     "edff2fbe7efd": {
       "disposition": "ported",
       "notes": "Rust Hindsight supports bank_id_template with profile/workspace/platform/user/session placeholders, sanitization tests, schema exposure, and README coverage."
     },
     "ee0de638d719": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Desktop API-key search and priority-sorted provider lists are React settings UI behavior. Rust runtime provider configuration is handled through typed config/auth/provider paths instead."
+      "notes": "Desktop API-key search and priority-sorted provider lists are React settings UI behavior. Rust runtime provider configuration is handled through typed config/auth/provider paths instead.",
+      "owner": "rust-runtime"
+    },
+    "ee22d853eb131ecdce3a8ba54a9a1c39ee5ca4a1": {
+      "disposition": "superseded",
+      "notes": "Upstream fix targets a Python/TUI pdftoppm subprocess. Hermes Agent Ultra has no Rust pdftoppm PDF attach subprocess surface; the broader Rust helper subprocess chokepoint now covers actual shipped helper spawns that can flash on Windows.",
+      "owner": "rust-runtime"
     },
     "ee41aa0c1a0a": {
       "disposition": "superseded",
@@ -5890,13 +7180,23 @@
     },
     "eec9c1d84ebdfd5117de0084c0b1c7bcc3ba4cb3": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Documentation-only upstream delta is superseded by local Rust-first docs/parity/release surfaces; it does not add or change a shipped Rust runtime behavior. Skills/docs/config-mixed items remain pending for separate evidence."
+      "notes": "Documentation-only upstream delta is superseded by local Rust-first docs/parity/release surfaces; it does not add or change a shipped Rust runtime behavior. Skills/docs/config-mixed items remain pending for separate evidence.",
+      "owner": "rust-runtime"
+    },
+    "eeca59f489194a4ce288b31de12b46c20d05cd48": {
+      "disposition": "ported",
+      "notes": "Ported/superseded by Rust helper coverage for the analogous remaining backend legs: TTS command/Piper, video and Teams ffmpeg, computer-use/cua-driver, MCP stdio, gateway Matrix decrypt FFI, and WhatsApp/Discord Python adapter legs are absent from the Rust runtime.",
+      "owner": "rust-runtime"
     },
     "eed78d6ebb51": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Floating composer peel-off placement, panels, and chip editing are Electron desktop UI polish, outside the Rust terminal/TUI surface."
+      "notes": "Floating composer peel-off placement, panels, and chip editing are Electron desktop UI polish, outside the Rust terminal/TUI surface.",
+      "owner": "rust-runtime"
+    },
+    "ef17cd204d7583c31fe1ace9255077f8c736b47e": {
+      "disposition": "ported",
+      "notes": "Ported as a Rust-native Windows subprocess no-window chokepoint: hermes-core exposes CommandNoWindowExt for std and tokio commands, backend helper spawns opt into CREATE_NO_WINDOW on Windows, and hermes-source-parity-tests covers the helper plus key runtime surfaces. The Python CI footgun script is superseded by compiled Rust source-contract coverage.",
+      "owner": "rust-runtime"
     },
     "ef5eaf8d8757a5e75fa571042abc287430192f53": {
       "disposition": "ported",
@@ -5926,24 +7226,34 @@
       "disposition": "ported",
       "notes": "Initial Python RL training tools and loop are ported as Rust rl_* ToolHandler implementations backed by hermes_intelligence::rl run/config/status/metrics types, registered as built-in tools under the rl_training toolset with lifecycle and inference tests."
     },
+    "f019a999d85c4fe6408858fbd7c022122ab4c373": {
+      "disposition": "superseded",
+      "notes": "Upstream desktop-dashboard documentation delta is superseded by local repo shape: apps/desktop is absent and Rust CLI/TUI/gateway docs own the shipped operator surfaces.",
+      "owner": "rust-runtime"
+    },
     "f019a999d85ca18e3aa8a6a7f092e518df4e9541": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/desktop/dashboard-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, web, or Electron desktop runtime tree, while Rust CLI/TUI/gateway/install paths own the applicable behavior. Mixed Rust/runtime/provider/platform commits remain pending for separate evidence."
+      "notes": "Upstream Electron/desktop/dashboard-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, web, or Electron desktop runtime tree, while Rust CLI/TUI/gateway/install paths own the applicable behavior. Mixed Rust/runtime/provider/platform commits remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "f033b7dbfbe8": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
+    "f03823014b01b7b85a6777040e1bb02a68cf8877": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Telegram polling: 409/getUpdates conflict detection now marks the adapter unhealthy immediately instead of backing off in a conflict loop; mock Bot API coverage asserts the poll loop disarms after one conflict.",
+      "owner": "rust-runtime"
+    },
     "f06508836dd4e5c56ffc14912725c12c6d941291": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Documentation-only upstream delta is superseded by local Rust-first docs/parity/release surfaces; it does not add or change a shipped Rust runtime behavior. Skills/docs/config-mixed items remain pending for separate evidence."
+      "notes": "Documentation-only upstream delta is superseded by local Rust-first docs/parity/release surfaces; it does not add or change a shipped Rust runtime behavior. Skills/docs/config-mixed items remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "f0cb04921709b473b1e8f3a979b7fc384db37f11": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Python/Electron CI or Docker-test orchestration delta is superseded by Hermes Agent Ultra's Rust-first CI surface: the local workflows build/test the Rust workspace, run parity gates, and use the distinct Rust Docker image/entrypoint contracts rather than upstream uv/s6/Electron docker jobs."
+      "notes": "Upstream Python/Electron CI or Docker-test orchestration delta is superseded by Hermes Agent Ultra's Rust-first CI surface: the local workflows build/test the Rust workspace, run parity gates, and use the distinct Rust Docker image/entrypoint contracts rather than upstream uv/s6/Electron docker jobs.",
+      "owner": "rust-runtime"
     },
     "f15d2cb5e424": {
       "disposition": "superseded",
@@ -5951,8 +7261,8 @@
     },
     "f168631be0": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream verify-on-stop nudge gate targets Python agent/verification_stop.py and cli-config.yaml.example. Ultra has no verify_on_stop nudge surface; Rust verification evidence is passive/tool-led and messaging surfaces do not emit that nudge."
+      "notes": "Upstream verify-on-stop nudge gate targets Python agent/verification_stop.py and cli-config.yaml.example. Ultra has no verify_on_stop nudge surface; Rust verification evidence is passive/tool-led and messaging surfaces do not emit that nudge.",
+      "owner": "rust-runtime"
     },
     "f18a9dbefc59": {
       "disposition": "superseded",
@@ -5961,6 +7271,11 @@
     "f1ba2f0c0b06": {
       "disposition": "ported",
       "notes": "Rust Hindsight request clients for auto-recall, auto-retain, and tool calls all use the configured timeout_secs value."
+    },
+    "f1cbe4308f54215cec248eba94444a6fb8f1caef": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Gateway route handling: agent processing errors now trigger a best-effort user error notification, notification-send failures are logged with the original error preserved, and focused tests cover user notice delivery plus send-failure preservation.",
+      "owner": "rust-runtime"
     },
     "f1fe29d1c368": {
       "disposition": "ported",
@@ -5976,17 +7291,22 @@
     },
     "f2c45e2c816d6e9e51416fa22436f29bcf97dc06": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "f2e37549c673": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust: hermes-tools now exposes a first-class computer_use tool backed by cua-driver MCP over stdio, with manifest-based MCP invocation discovery, HERMES_CUA_DRIVER_CMD support, cross-platform action schema, type_text/hotkey/set_value/drag/capture/list/focus/doctor/raw-call routing, safety hardblocks, capture_after, explicit computer_use toolset, and CLI status/doctor/manifest/install-hint commands."
+      "notes": "Ported in Rust: hermes-tools now exposes a first-class computer_use tool backed by cua-driver MCP over stdio, with manifest-based MCP invocation discovery, HERMES_CUA_DRIVER_CMD support, cross-platform action schema, type_text/hotkey/set_value/drag/capture/list/focus/doctor/raw-call routing, safety hardblocks, capture_after, explicit computer_use toolset, and CLI status/doctor/manifest/install-hint commands.",
+      "owner": "rust-runtime"
     },
     "f2e8ed240536": {
       "disposition": "superseded",
       "notes": "example-config upstream delta superseded by rust setup/auth/provider workflows and local config schema"
+    },
+    "f341cadb71843d021f87724062e551da2403e6d1": {
+      "disposition": "ported",
+      "notes": "Discord response reads are structural reqwest chunk reads with explicit byte caps; no Python/mock-module body sniffing is used on the Rust path.",
+      "owner": "rust-runtime"
     },
     "f38f7a387013": {
       "disposition": "superseded",
@@ -6003,6 +7323,16 @@
     "f3b32e9f5220": {
       "disposition": "superseded",
       "notes": "Upstream Electron desktop-only delta is superseded by Hermes Ultra's Rust-first operator surfaces: crates/hermes-cli/src/tui.rs, crates/hermes-gateway/src/gateway.rs, and ui-tui parity contracts. The local repo intentionally does not ship apps/desktop, so this TS/Electron UI commit has no Rust runtime port target."
+    },
+    "f3cd744f5c40ab70e5a10ffc7c993f049ca1c70c": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
+    },
+    "f3d2dfbec670cd520bf23fe6ec1f4ce918d286bd": {
+      "disposition": "superseded",
+      "notes": "Superseded by Rust OAuth URL construction: hermes-auth does not impose the upstream self-hosted localhost-only http redirect_uri restriction, and the regression test proves arbitrary http:// host callback URLs are preserved in authorization URLs.",
+      "owner": "rust-runtime"
     },
     "f3d6d9bbd335": {
       "disposition": "ported",
@@ -6024,8 +7354,8 @@
     },
     "f44415e71a26": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust startup/gateway provider construction now applies init-time fallback selection before building the agent/provider when the primary model has no configured credentials, while preserving local no-key backends and OAuth auth-store resolver credentials. Covered by provider-runtime, CLI startup-model, and HTTP provider alias/config tests."
+      "notes": "Rust startup/gateway provider construction now applies init-time fallback selection before building the agent/provider when the primary model has no configured credentials, while preserving local no-key backends and OAuth auth-store resolver credentials. Covered by provider-runtime, CLI startup-model, and HTTP provider alias/config tests.",
+      "owner": "rust-runtime"
     },
     "f45d7dee7d25": {
       "disposition": "superseded",
@@ -6034,6 +7364,11 @@
     "f4612785a485": {
       "disposition": "superseded",
       "notes": "rust anthropic normalization path is already typed and test-covered; Python adapter refactor not directly portable to Rust architecture"
+    },
+    "f47459cdbdee7bc312024f46a6ab03120e3c0c71": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
     },
     "f4ef70f6fc62": {
       "disposition": "ported",
@@ -6047,8 +7382,8 @@
     },
     "f53b184c48712bcbb98556a6314cd1f240fc104d": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Python/Electron CI or Docker-test orchestration delta is superseded by Hermes Agent Ultra's Rust-first CI surface: the local workflows build/test the Rust workspace, run parity gates, and use the distinct Rust Docker image/entrypoint contracts rather than upstream uv/s6/Electron docker jobs."
+      "notes": "Upstream Python/Electron CI or Docker-test orchestration delta is superseded by Hermes Agent Ultra's Rust-first CI surface: the local workflows build/test the Rust workspace, run parity gates, and use the distinct Rust Docker image/entrypoint contracts rather than upstream uv/s6/Electron docker jobs.",
+      "owner": "rust-runtime"
     },
     "f583c6ebd5bd": {
       "disposition": "superseded",
@@ -6056,17 +7391,22 @@
     },
     "f5af6520d0bf": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Rust ToolCall includes extra_content and OpenAI-compatible response parsing preserves Gemini thought_signature payloads; provider test_parse_openai_response_with_tool_call_extra_content covers the behavior."
+      "notes": "Rust ToolCall includes extra_content and OpenAI-compatible response parsing preserves Gemini thought_signature payloads; provider test_parse_openai_response_with_tool_call_extra_content covers the behavior.",
+      "owner": "rust-runtime"
     },
     "f5be6177b231": {
       "disposition": "ported",
       "notes": "rust text_to_speech/tts_premium tools, MultiTtsBackend providers, gateway voice send surfaces, and voice-compatible media tags cover the upstream TTS product surface; new registry/schema contract proves first-class TTS exposure"
     },
+    "f5eb4c307bfdbfa5f24c5bff59881295f17b17ac": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
+    },
     "f6275a59e790477092e6c70b06ba4a5d1d882615": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Documentation-only upstream delta is superseded by local Rust-first docs/parity/release surfaces; it does not add or change a shipped Rust runtime behavior. Skills/docs/config-mixed items remain pending for separate evidence."
+      "notes": "Documentation-only upstream delta is superseded by local Rust-first docs/parity/release surfaces; it does not add or change a shipped Rust runtime behavior. Skills/docs/config-mixed items remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "f6574978de39": {
       "disposition": "ported",
@@ -6076,15 +7416,20 @@
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
     },
+    "f67c0b3e60ba91b92ca1d07826d873b4b8f36849": {
+      "disposition": "superseded",
+      "notes": "Upstream bundled skill documentation refresh is non-runtime for this Rust repo; local skills/parity/release docs own Rust behavior and no Python skill runtime port is required.",
+      "owner": "rust-runtime"
+    },
     "f697c97e02f0": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Floating composer radius polish is Electron desktop CSS/UI behavior with no Rust TUI runtime equivalent."
+      "notes": "Floating composer radius polish is Electron desktop CSS/UI behavior with no Rust TUI runtime equivalent.",
+      "owner": "rust-runtime"
     },
     "f72690825e76fd205b3f475bdac75643e42bcf49": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
     },
     "f736d2be86b8": {
       "disposition": "ported",
@@ -6097,6 +7442,11 @@
     "f764b0400ad7": {
       "disposition": "superseded",
       "notes": "Deleting the active profile fallback is a desktop profile-switcher/delete-dialog behavior. Rust CLI profile delete already clears the active marker when deleting the active profile and does not maintain an Electron active-profile rail."
+    },
+    "f76899facf8fc6d88da429adcf6f65be0494597e": {
+      "disposition": "ported",
+      "notes": "Ported in Rust CLI sessions export: --session-id, --format html self-contained transcript output, --only user-prompts for jsonl/md, output path/stdout handling, prefix resolution, and redaction. Covered by cli_sessions_export_renders_prompt_only_jsonl_and_markdown, cli_sessions_export_html_is_self_contained_and_escaped, cli_sessions_export_redacts_secret_fields_and_text_tokens, and cli_sessions_export_command_writes_html_file_with_session_id_alias.",
+      "owner": "rust-runtime"
     },
     "f79e0a7060d0": {
       "disposition": "ported",
@@ -6119,8 +7469,8 @@
     },
     "f80088f035de303d6e8c1e59764d2008571ca01a": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Documentation-only upstream delta is superseded by local Rust-first docs/parity/release surfaces; it does not add or change a shipped Rust runtime behavior. Skills/docs/config-mixed items remain pending for separate evidence."
+      "notes": "Documentation-only upstream delta is superseded by local Rust-first docs/parity/release surfaces; it does not add or change a shipped Rust runtime behavior. Skills/docs/config-mixed items remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "f8098c6b6fe5": {
       "disposition": "superseded",
@@ -6133,8 +7483,8 @@
     },
     "f8604928422ff3461d4004ae6f71fdfdea9923a2": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "f92298fe955fe2ddbea27f4c504ce310ec46545b": {
       "disposition": "ported",
@@ -6158,13 +7508,13 @@
     },
     "f9ffe0bc3f61": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Notification-click stored session-id recovery is Electron desktop route/resume behavior. Rust CLI/TUI/gateway sessions are not resumed through desktop notifications or renderer route state."
+      "notes": "Notification-click stored session-id recovery is Electron desktop route/resume behavior. Rust CLI/TUI/gateway sessions are not resumed through desktop notifications or renderer route state.",
+      "owner": "rust-runtime"
     },
     "fa3dba4b30b2802c87c8733fcb359d906f60b4b2": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Documentation/infographic-only upstream delta is superseded by Hermes Agent Ultra's Rust-first docs/parity/release surfaces for this batch; it does not add or change a shipped Rust runtime behavior. Runtime, provider, platform, and install changes remain pending for separate evidence."
+      "notes": "Documentation/infographic-only upstream delta is superseded by Hermes Agent Ultra's Rust-first docs/parity/release surfaces for this batch; it does not add or change a shipped Rust runtime behavior. Runtime, provider, platform, and install changes remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "fa42ac094dca": {
       "disposition": "superseded",
@@ -6177,6 +7527,11 @@
     "fa582749e165": {
       "disposition": "superseded",
       "notes": "kanban/achievements dashboard JS-dist deltas are superseded by rust-first plugin/dashboard surface and local parity patches already applied"
+    },
+    "fa7bce0789d80fa99080a2be231fcc754fd2af3c": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
     },
     "fabca0bdd82b": {
       "disposition": "ported",
@@ -6197,13 +7552,18 @@
     },
     "fb1dd1bf910c68f6199329d46dce8cce01a6535d": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Python/Electron CI or Docker-test orchestration delta is superseded by Hermes Agent Ultra's Rust-first CI surface: the local workflows build/test the Rust workspace, run parity gates, and use the distinct Rust Docker image/entrypoint contracts rather than upstream uv/s6/Electron docker jobs."
+      "notes": "Upstream Python/Electron CI or Docker-test orchestration delta is superseded by Hermes Agent Ultra's Rust-first CI surface: the local workflows build/test the Rust workspace, run parity gates, and use the distinct Rust Docker image/entrypoint contracts rather than upstream uv/s6/Electron docker jobs.",
+      "owner": "rust-runtime"
     },
     "fb3d31ba8b772bbca130f829423df7e61afd7820": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence."
+      "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
+      "owner": "rust-runtime"
+    },
+    "fb44b519d712e7c8452112dbfcaa5071d56c66e4": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
     },
     "fbabf438a17c": {
       "disposition": "superseded",
@@ -6217,6 +7577,21 @@
       "disposition": "superseded",
       "notes": "Desktop chrome localization only updates apps/desktop UI strings, voice-recorder hooks, and React components. Rust CLI/TUI/gateway chrome is independent and not driven by the upstream desktop i18n catalog."
     },
+    "fbf748b2824703f11a55bcf4b5ba7a5909c00865": {
+      "disposition": "superseded",
+      "notes": "Superseded by Rust runtime scope: this upstream row patches Python dashboard_auth self-hosted OIDC discovery with httpx follow_redirects. The shipped Rust runtime has no first-class dashboard-auth OIDC discovery/login flow to patch; Python plugin trees remain tracked but outside the Rust runtime surface.",
+      "owner": "rust-runtime"
+    },
+    "fc70d023d82b93778a337f741da05335550e7bb7": {
+      "disposition": "ported",
+      "notes": "Ported in Rust Telegram adapter/config bridge: TelegramConfig now receives direct/admin/group user allowlists from PlatformConfig aliases and should_process_update applies adapter-level user/bot auth before parse/batch/event construction. Callback taps authorize CallbackQuery.from rather than the bot-authored message. Focused Telegram and CLI config tests cover normal, group, callback, and sender_chat cases.",
+      "owner": "rust-runtime"
+    },
+    "fc86e35764f7b339d505092dbad3686cfa44c576": {
+      "disposition": "superseded",
+      "notes": "Superseded by local Rust-first product shape: upstream remote desktop git cockpit depends on apps/desktop React stores and Python web_git/web_server endpoints absent from the shipped Rust runtime. Rust CLI/TUI/tool surfaces own git and project workflows without the Electron cockpit.",
+      "owner": "rust-runtime"
+    },
     "fcac0f94d4844f904a6eaa8a2b667299408b9f92": {
       "disposition": "ported",
       "notes": "Ported in Rust OpenViking memory plugin: recall-tool skip tracking only records non-empty tool ids, so an empty OpenViking recall result cannot poison the skip set for unrelated empty-id tool results. The sync trace env toggle uses the canonical truthy set {1,true,yes,on}. Regression test covers empty-id recall plus non-recall tool result preservation.",
@@ -6228,8 +7603,8 @@
     },
     "fcdc05c89145f5e16e8d4641e5b83dd2e3014306": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence."
+      "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
+      "owner": "rust-runtime"
     },
     "fce58cbe2e02": {
       "disposition": "ported",
@@ -6237,8 +7612,13 @@
     },
     "fd2a35b1691138b79b606e7961d3c78f7019722b": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust display surfaces: CLI /usage, generic usage stats, and session-insights terminal/gateway renderers keep provider-agnostic token counts while hiding unreliable estimated cost and cache-read/write reporting; Nous credits/billing and internal cost guards remain intact."
+      "notes": "Ported in Rust display surfaces: CLI /usage, generic usage stats, and session-insights terminal/gateway renderers keep provider-agnostic token counts while hiding unreliable estimated cost and cache-read/write reporting; Nous credits/billing and internal cost guards remain intact.",
+      "owner": "rust-runtime"
+    },
+    "fd324562d3ad43df7631428df4585cf9de8154f2": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
+      "owner": "rust-runtime"
     },
     "fd674af47fa6": {
       "disposition": "superseded",
@@ -6265,6 +7645,11 @@
       "disposition": "superseded",
       "notes": "Unsafe red-team skill relocation is not imported into the Rust runtime defaults. Local skill catalog already tracks red-team and mlops skills under approved optional governance."
     },
+    "fde1c8570ffe1bcd1d352efffb4eeafdfd975f0c": {
+      "disposition": "superseded",
+      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
+      "owner": "rust-runtime"
+    },
     "fe2942a5aab7": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
@@ -6273,10 +7658,15 @@
       "disposition": "superseded",
       "notes": "Upstream desktop React trigger-popover text wrapping has no matching Rust runtime file. Hermes Agent Ultra renders slash completions through the Rust Ratatui popup in crates/hermes-cli/src/tui.rs, so the TS/CSS truncation fix is superseded by the local TUI surface."
     },
+    "fe82b3a774d97db0c4e948217a89f2b055ce73bc": {
+      "disposition": "superseded",
+      "notes": "Upstream Electron/React desktop remote-mode delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop as a runtime product.",
+      "owner": "rust-runtime"
+    },
     "ff08e60c63ada076aecc0c3243e2cfc9258db4f8": {
       "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Cloudflare temporary deploy optional skill is ported as a Rust-loaded web-development skill. The upstream Python output parser is replaced by the Rust-native `hermes cloudflare parse-temporary-deploy-output` CLI helper with parser unit tests and generated docs."
+      "notes": "Cloudflare temporary deploy optional skill is ported as a Rust-loaded web-development skill. The upstream Python output parser is replaced by the Rust-native `hermes cloudflare parse-temporary-deploy-output` CLI helper with parser unit tests and generated docs.",
+      "owner": "rust-runtime"
     },
     "ff0985323509": {
       "disposition": "superseded",
@@ -6284,8 +7674,8 @@
     },
     "ff81365988": {
       "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "In-app spot editor for file preview pane is Electron desktop UI and package-lock behavior. Ultra has no apps/desktop preview pane."
+      "notes": "In-app spot editor for file preview pane is Electron desktop UI and package-lock behavior. Ultra has no apps/desktop preview pane.",
+      "owner": "rust-runtime"
     },
     "ff85af3fc7d3": {
       "disposition": "ported",
@@ -6303,1241 +7693,6 @@
     "fff0561441d2": {
       "disposition": "superseded",
       "notes": "Google Chat OAuth client-secret anchoring is Python adapter-only in upstream; this Rust gateway surface has no Google Chat platform adapter or OAuth helper under crates/hermes-gateway, so no Rust runtime path exists to port."
-    },
-    "6fb25f86ac4946b7f50238c68b545f77b57fd9f4": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Telegram routing: should_process_message rejects messages from the configured bot_username when the sender is a bot before private/group acceptance; regression coverage proves own-bot messages are filtered and other bots are not over-blocked."
-    },
-    "ab1f9b94c5055f859a3b0183f6bdd0ff4d93d65a": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Telegram delivery: encoded chat_id splitting now accepts @username bases for topic-thread delivery while preserving malformed IDs unsplit; telegram_username_gateway_chat_id_sends_to_topic_thread covers the Bot API payload shape."
-    },
-    "dbc925b7550c2224631d6fb1a2fa0ec236d76beb": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Telegram inbound media parsing: Video metadata is first-class, unknown/oversized videos are rejected before file IDs reach downstream download paths, and tests cover normal videos plus oversized current and replied videos."
-    },
-    "f03823014b01b7b85a6777040e1bb02a68cf8877": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Telegram polling: 409/getUpdates conflict detection now marks the adapter unhealthy immediately instead of backing off in a conflict loop; mock Bot API coverage asserts the poll loop disarms after one conflict."
-    },
-    "97640fd9adf532d6ce4ebc63ec817137ba685157": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Electron titlebar/window-control overlay delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: apps/desktop is absent locally, and CLI/TUI/gateway surfaces do not ship Electron WCO behavior."
-    },
-    "2d206a3a42429465f6bb99c9425e3f7316273782": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream desktop Electron bundling/native-deps delta is superseded by the local Rust-first distribution: apps/desktop and nix desktop packaging are absent, while Rust installer/Docker/CLI paths own shipped runtime startup."
-    },
-    "b508d4296e045c2754f075628ec80761b86f7126": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Python parallel-test timeout plus infographic delta is superseded by local Rust/pytest targeted verification and WD-Black cargo target policy; scripts/run_tests_parallel.py is not a shipped Rust runtime surface."
-    },
-    "376d021feef9cb27e6f5a750d6a423221e49f6c8": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream macOS Electron update/uninstall handoff delta is superseded because apps/desktop is absent; Hermes Agent Ultra ships Rust CLI/TUI/gateway lifecycle paths instead of Electron app-exit handoff code."
-    },
-    "e9b95dfd19b5046ffd633e6ce2dfd87e504a372b": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream dashboard Docker image delta depends on apps/shared and web inputs that are absent here; the Rust multi-stage Dockerfile and its packaging/PID-1 contracts are the shipped container surface."
-    },
-    "f019a999d85c4fe6408858fbd7c022122ab4c373": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream desktop-dashboard documentation delta is superseded by local repo shape: apps/desktop is absent and Rust CLI/TUI/gateway docs own the shipped operator surfaces."
-    },
-    "e684b808adf4c4865a10e77f057535b2fd785f64": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream old-Electron-runtime dashboard fallback is superseded because no Electron desktop runtime is shipped locally; Rust CLI/TUI/gateway startup paths are the runtime surface."
-    },
-    "43eaf79ae6451e10dacba3342d28230e6fef87de": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream committed-infographic cleanup is superseded by local repo state: no top-level infographic artifact tree is shipped, and parity/release documentation is generated under docs/website surfaces."
-    },
-    "e3c9924b8b358e4b7b0a600178426fd70e6f9481": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust auth/runtime hints: stale Nous re-authentication guidance now consistently says `hermes auth add nous` across Chronos and agent 401 diagnostics; focused agent diagnostic test asserts the new hint and source search leaves no stale Rust hints."
-    },
-    "64972b64038b97cf9af095dd5f107723a2ee6ab3": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust config compatibility: nested model blocks now canonicalize model.default, model.name, and model.model into the root model string with default precedence, covered by python_yaml_compat alias and precedence tests."
-    },
-    "c1c179a2395a19c3a8e4fb5dae7ef527227da07a": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust terminal runtime: foreground command stdout/stderr are sanitized at the formatting boundary using assignment redaction plus credential_guard fallback line redaction, so env dumps and process output do not return secret values. Terminal formatter tests cover key=value and bare-token redaction."
-    },
-    "74541beb9ce32fcb1b8d89d698120d4b59d34ca8": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust WeCom callback adapter: POST callback requests now enforce a 64 KiB body limit from Content-Length and from buffered body length before Encrypt XML extraction/decrypt, returning 413 for oversized unauthenticated payloads. Focused wecom-callback tests cover oversized declared length, oversized buffered body, and normal callback envelopes."
-    },
-    "d836b2bac4447c099475a38c90b5f577a952d4ef": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Matrix and Mattermost adapters. Matrix invite auto-join now filters invite-state senders when an allowlist is configured while preserving default/no-allowlist behavior and allow-all escape hatch. Mattermost dynamic REST post/thread ids reject traversal path segments before interpolation. Focused matrix and mattermost feature tests cover both hardenings."
-    },
-    "9e490138a009c9c9aa64ac90fd6804928a6646b8": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by Rust architecture and existing guards: the local Feishu adapter has no internet-facing webhook rate-limiter table matching the upstream Python bypass surface, and the local WhatsApp adapter is Cloud API based rather than a Baileys bridge returning absolute cache paths. Native file/media delivery goes through gateway/media validation and canonicalization before adapter send, with existing tests for unsafe media marker and file delivery rejection."
-    },
-    "fc70d023d82b93778a337f741da05335550e7bb7": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Telegram adapter/config bridge: TelegramConfig now receives direct/admin/group user allowlists from PlatformConfig aliases and should_process_update applies adapter-level user/bot auth before parse/batch/event construction. Callback taps authorize CallbackQuery.from rather than the bot-authored message. Focused Telegram and CLI config tests cover normal, group, callback, and sender_chat cases."
-    },
-    "c648ecdca526f8c421d8c8c00e1aa9b330bbcb5e": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Telegram intake: unauthorized users are rejected in should_process_update before TelegramAdapter::parse_update and before CLI text batching/route_message. The model now includes sender_chat for from-less channel-post authorization, and tests cover unauthorized users, allowed group senders, callback tap users, and sender_chat allowlists."
-    },
-    "e55ddc3e33b28cf036371b8d81c73109521ac3f1": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported as Rust MCP background-discovery noninteractive guard: McpManager::connect_all_parallel now marks spawned discovery configs with a runtime-only suppress_interactive_oauth flag, and StdioTransport injects HERMES_MCP_BACKGROUND_DISCOVERY/HERMES_MCP_SUPPRESS_INTERACTIVE_OAUTH/MCP_NONINTERACTIVE into child env without changing normal explicit MCP connect/login paths. Transport test covers marker isolation."
-    },
-    "11b0be8d15fc18f6a6741317cbb3f197ac7df989": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Matrix sync: pending invite rooms are scheduled as detached, deduped auto-join tasks with a timeout instead of blocking sync_once/gateway readiness. Wiremock test proves sync_once returns before a delayed join finishes and duplicate pending joins only issue one join request."
-    },
-    "14baeefe1d0b80e67429ffb47934acc4cd399fd1": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Matrix invite handling: direct invite metadata from invite_state is carried into the detached join request, and successful direct invite joins persist m.direct account data for the inviter/room so future identity classification can use direct-room account state. Focused test covers m.direct append/write behavior."
-    },
-    "244a6f2ceb7f58c16b3cb2186584c39524e37874": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by local Rust-first product shape: upstream fixes an Electron desktop Open setup guide button plus Python web_server route, but this repo has no apps/desktop or shipped Python web_server runtime. Rust CLI/TUI/gateway docs and setup surfaces own plugin setup guidance."
-    },
-    "fc86e35764f7b339d505092dbad3686cfa44c576": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by local Rust-first product shape: upstream remote desktop git cockpit depends on apps/desktop React stores and Python web_git/web_server endpoints absent from the shipped Rust runtime. Rust CLI/TUI/tool surfaces own git and project workflows without the Electron cockpit."
-    },
-    "4e9439cc3b33d74ad511f320dc1c5c0a66423127": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by local Rust-first product shape: upstream composer context picking through remote-aware desktop FS is an apps/desktop React behavior. This repo has no apps/desktop runtime; Rust CLI/TUI context and file access are mediated through typed tools and session state instead."
-    },
-    "453f134b3bc213f05db52b22c6a0eb18ef115339": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by local Rust-first product shape: upstream centralizes desktop remote-git REST routing across apps/desktop and Python web_server surfaces that are absent from the shipped Rust runtime. Rust project/git operations remain CLI/TUI/tool owned."
-    },
-    "db16854f343c67548933ac2e0e1d4d586bdeaaa6": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by Rust Telegram inbound-media design: the adapter does not silently download/cache user attachments before dispatch. It preserves Telegram file IDs and bounded metadata on IncomingMessage, and oversized documents/videos are dropped by size gates with tests, so the upstream Python empty-turn-on-download-failure path is absent."
-    },
-    "3f543229f28c6a0fb588a73f093b85a183d86595": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by Rust gateway clarify shape: Telegram does not implement the upstream cl:<id> clarify inline-button protocol, so there is no stale clarify button tap to expire. Rust gateway clarify is queued through ChannelClarifyBackend and answered by the next user message, while Telegram approval callbacks already alert when no pending approval exists."
-    },
-    "2ecb6f7fe60f6a240d632bbd51bcbb25ad22c161": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by Rust direct Bot API polling: there is no PTB _send_path_degraded flag or deferred heartbeat gate. Successful getUpdates clears Rust backoff/error counters immediately, while sustained polling failures or 409 conflicts mark the adapter unhealthy for the gateway watcher."
-    },
-    "7e2ca7f68da63a29e1695b5e24901cc57e32f2ac": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by Rust Telegram HTTP transport: outbound sends use a reqwest client and do not expose PTB's bot._request[1] general request pool that can be shutdown/reinitialized after a Python pool timeout. No Rust send pool reset hook exists or is needed for that Python-specific failure mode."
-    },
-    "d5ba374c038a99db99e3036d938271e70a6930fd": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by Rust direct polling: there is no PTB updater.running=true/consumer-task-dead split. Rust owns the getUpdates request directly with a timeout bounded by TELEGRAM_POLL_STALL_GRACE_SECONDS, exponential backoff, consecutive-error health gates, and immediate 409 conflict fail-closed tests."
-    },
-    "dbe734beff0caf5e8ee2acbe4277db7f6cf84a21": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by Rust runtime scope: this upstream row patches Python dashboard_auth interactive login/provider registry behavior for the drain-secret plugin. Hermes Ultra does not expose a Rust dashboard-auth provider registry or /auth/login surface; token/service credential access is not presented as an interactive Rust login provider."
-    },
-    "fbf748b2824703f11a55bcf4b5ba7a5909c00865": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by Rust runtime scope: this upstream row patches Python dashboard_auth self-hosted OIDC discovery with httpx follow_redirects. The shipped Rust runtime has no first-class dashboard-auth OIDC discovery/login flow to patch; Python plugin trees remain tracked but outside the Rust runtime surface."
-    },
-    "1b75b3fd90d32e9111607c6331ace49fdc47287a": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported with a higher-quality Rust Supermemory setup surface: setup now supports hermes memory setup supermemory, persists owner-only supermemory.json, exposes the app.supermemory.ai integration URL plus auto_recall/auto_capture schema knobs, prints a deterministic setup summary, and initialize now actually loads api_key from supermemory.json instead of only env."
-    },
-    "52a09d8faf6b3a44da5f3eff3e17f85a4f5ea90c": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust ByteRover: byterover.json and HERMES_BYTEROVER_AUTO_EXTRACT/BYTEROVER_AUTO_EXTRACT now control auto_extract, disabling background turn, explicit memory, and pre-compression curation while leaving brv_curate/brv_query tools available. CLI setup persists owner-only ByteRover config and tests cover config coercion/schema/setup."
-    },
-    "7c0a5def58fbec985ace8c887ca3484f7b8cf584": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported/already covered in Rust Holographic memory: shutdown deterministically drops the rusqlite Connection by clearing the guarded Option instead of relying on later process teardown. Added a focused regression test that initialized connections are gone after shutdown."
-    },
-    "b296915c82c9da02bd6edacf52490e68f85e1f16": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported as a Rust-native Feishu lifecycle guard instead of Python executor plumbing: the adapter has no blocking SDK executor, but stop() now marks the runtime closing and outbound API/token/file/image-url paths refuse work before network or local file IO until start/reconnect re-arms the adapter."
-    },
-    "7ee0b689739e80c75d7c32f42cf2a79a2207c0a0": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Feishu shutdown semantics: real stop() sets a closing guard so post-shutdown calls cannot resurrect outbound work, while start() clears the guard before reconnect token refresh. Focused async tests cover refusal and re-arm state."
-    },
-    "a10727a555ad5e5c4155b3b74d19959c36c436db": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported as Rust CDP diagnostics rather than Python agent-browser daemon plumbing: local browser commands now have bounded CDP timeouts, first-navigation open timeout floors, endpoint/remote-debugging hints, sandbox hints, and browser_navigate failures labeled as Failed to open."
-    },
-    "7bb8aa3bd55d0d4b39bc9e026d780d92fe0b306a": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported with Rust tests for browser open-timeout floors, timeout diagnostics, sandbox hint formatting, bounded CDP timeout behavior, and failed-navigate labeling. The upstream desktop chip text is represented in the Rust tool error surface because this repo does not ship the Electron chip UI."
-    },
-    "290fa7fd2baaa842856000143bc5028dcedd4185": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust DeliveryRouter: confirmed-dead platform targets are persisted under HERMES_HOME/gateway/dead_targets.json after whole-chat Forbidden or chat-level NotFound send failures, skipped on later deliveries to avoid flood-control burn, and thread/topic/message not-found plus transient errors are not marked dead. Focused tests cover persistence, corrupt-store fallback, marking, skipping, and non-dead errors."
-    },
-    "1289f12812a9c6a3f3e6fbdf39e39ed7e1b7bd50": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by Rust-native memory providers: Mem0 and Supermemory use direct reqwest HTTP clients and compiled Rust code, not optional Python SDK imports. There is no runtime SDK lazy-install step to add; Supermemory setup/config activation was strengthened separately in Rust."
-    },
-    "6f1a176b3309d0474e0ef329834b622603c60471": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust DiscordAdapter: configurable REST liveness probe uses Discord users/@me through reqwest, honors liveness_interval_seconds/liveness_failure_threshold config knobs, marks the adapter unhealthy after repeated failures so the existing platform_reconnect_watcher restarts it, gates outbound REST sends while unhealthy, and supports api_base_url for deterministic tests. Focused Rust tests cover authenticated /users/@me probing, unhealthy transition, and disabled zero-knob behavior."
-    },
-    "c9df4bc094fb27ddfc8b278380d9598dc534587b": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by Rust gateway lifecycle: Hermes Agent Ultra has no configurable restart_drain_timeout/systemd drain window. Gateway::stop_all finalizes active sessions and stops adapters immediately, avoiding the stale systemd TimeoutStopSec crash-loop class entirely; existing hook_lifecycle coverage proves stop_all emits shutdown finalization for active sessions."
-    },
-    "61622bb56a7a24c0fc39e8a5a46537dfd2b2d9b6": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by Rust model-switch architecture: CLI/TUI and gateway model switches update runtime config/defaults without appending a model-switch marker into model-facing history, so strict providers never see a mid-conversation system message. Added gateway_model_switch_does_not_inject_mid_history_system_marker regression coverage."
-    },
-    "9c6229ce249e4bbd86a22463be73ac2986db6324": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported with shared Rust subprocess environment policy: hermes_core::subprocess_env strips provider credentials by default, always strips tier-1 live tokens/gateway secrets, preserves safe env vars, normalizes PATH, and is used by gateway command hooks and quick exec. Focused tests cover helper policy plus hook and quick-exec child environments."
-    },
-    "34e616e778d065acea1477ddc6933c30378def89": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust SlackAdapter: startup performs a best-effort auth.test scope audit, warns once per workspace when direct-message scopes exist but mpim:history/message.mpim coverage is missing, and continues startup if the audit fails. Unit and wiremock tests cover stale installs, once-only warnings, auth.test header parsing, and mpim-present suppression."
-    },
-    "3a55f66602898b53524a232e3dbadea3ed9b0cf8": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported with Rust relay/session scope_id migration support: scope_id is canonical, guild_id remains a deprecated alias, relay helpers dual-read and dual-write both keys, SessionSource exposes with_scope/with_guild_id compatibility, and docs/tests cover the wire-contract behavior."
-    },
-    "f3d2dfbec670cd520bf23fe6ec1f4ce918d286bd": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Superseded by Rust OAuth URL construction: hermes-auth does not impose the upstream self-hosted localhost-only http redirect_uri restriction, and the regression test proves arbitrary http:// host callback URLs are preserved in authorization URLs."
-    },
-    "f1cbe4308f54215cec248eba94444a6fb8f1caef": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust Gateway route handling: agent processing errors now trigger a best-effort user error notification, notification-send failures are logged with the original error preserved, and focused tests cover user notice delivery plus send-failure preservation."
-    },
-    "53a75f147f641d10ac678092e8a67700d7edf2a7": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in hermes-auth: OAuth2Endpoints supports optional client_secret with RFC form-encoded client_secret_basic or client_secret_post token endpoint auth, while preserving public-client PKCE behavior. Focused Rust tests cover authorization-code Basic auth and refresh-token POST secret flows."
-    },
-    "184c10cf97002c95b233830d62d6fb355a82708a": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust SlackAdapter: startup auth.test health audit warns once when Slack returns user_id without bot_id, preserving the existing group-DM scope audit in a single auth.test call. Unit and wiremock tests cover user-token detection, bot-token suppression, once-only warning, and combined auth.test warning behavior."
-    },
-    "b7322f946db6ac22353714a136ae3d7950b38745": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream desktop pet roam behavior is an Electron/React-only UX delta under apps/desktop. Hermes Agent Ultra does not ship that desktop pet runtime; Rust CLI/TUI/gateway surfaces own the shipped interactive UX, so no Rust runtime port is applicable."
-    },
-    "30cd39dc5609a91d5eeee85f78495ffdbecdd157": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream stroll-direction coin refactor only changes the absent Electron desktop pet roam implementation. Hermes Agent Ultra has no apps/desktop pet surface, so the Rust product boundary supersedes this non-shipped GUI-only delta."
-    },
-    "05ac16778bda321bd4726c17bd7061b110255582": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust platform config: PlatformConfig exposes a first-class typing_indicator flag defaulting true, merge/deserialization preserve explicit false, Python-style root platform blocks lift the key under platforms, and tests cover default, explicit-disable, compatibility lift, and JSON/YAML roundtrip behavior. Rust has no generic Python-style keep-typing loop to spawn, so this is the applicable runtime gate contract."
-    },
-    "481caa66f23c75eede53867e99a68400012cf501": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust display/gateway surfaces: hermes-cli-ui and hermes-intelligence build friendly human-phrased labels for built-in tools, display.friendly_tool_labels defaults on with env/config-set opt-out, gateway tool-start events and progress messages use the label path, verbose mode remains raw/debug-oriented, and focused Rust tests cover default labels plus legacy-off behavior."
-    },
-    "04639adace67c7765eb14a32c78ae4fb62da7fe6": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream already-installed theme picker flags are confined to the absent Electron desktop app under apps/desktop. Hermes Agent Ultra does not ship that theme marketplace/install picker surface; Rust CLI/gateway/TUI UX is the shipped product boundary, so no Rust runtime port applies."
-    },
-    "5636c22828b0be1eadaf8968c7033efb27f705fa": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Photon Spectrum TS sidecar upgrade is confined to the Python/Node Photon plugin bridge. Hermes Agent Ultra does not ship the Photon sidecar in the Rust runtime; shipped Rust gateway adapters cover first-class platform integrations without vendoring this JS bridge."
-    },
-    "4345b3e767c73405e143b2f03a1e4e7773c2b472": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Photon Spectrum TS v8 sidecar upgrade only changes the absent Python/Node Photon bridge. There is no Rust Photon sidecar/package-lock surface to update, so the Rust product boundary supersedes this dependency churn."
-    },
-    "882730026739c51e6ae5c7cbe47e9b64a920a065": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Photon tapback correlation targets the absent Photon adapter and Spectrum TS sidecar. Hermes Agent Ultra does not ship that bridge; Rust gateway reaction/media behavior is owned by the compiled platform adapters instead."
-    },
-    "cd592c105cbbc0bbf927b30ee9d061b1dd7b0b1b": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported/superseded in Rust WhatsApp gateway: PlatformAdapter::send_file uploads local media to WhatsApp Cloud API, maps extension categories to native image/video/audio/document payloads, then sends the uploaded media id. This batch adds api_base_url configurability and a wiremock test proving upload-then-native-image send with caption through the Rust adapter and gateway media path."
-    },
-    "520212cc593dd8bc0472002877e31d7310bd295b": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream live agent terminal streaming changes are Electron desktop right-sidebar UI code. Hermes Agent Ultra does not ship the Electron desktop terminal tab surface; Rust CLI/gateway/TUI terminal execution and streaming surfaces are the product boundary."
-    },
-    "e117cfdff08b7e43b7d0b7f7e661be7b710e7a4f": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream live agent terminals and agent-driven tab close are Electron desktop UI changes. The Rust runtime has no apps/desktop tab lifecycle to port; CLI/gateway session lifecycle is implemented in compiled Rust."
-    },
-    "adacb16d624336f18380a0a40b4b704c699c3f10": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream readable agent terminal tab fixes are limited to the absent Electron desktop terminal UI. Hermes Agent Ultra's shipped runtime uses Rust CLI/gateway/TUI surfaces, so no Rust port applies."
-    },
-    "e5d22ab80d979d38d8062e666af418ed847618a9": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream Daytona fix quotes a Python SDK shell mkdir in the single-upload path. Hermes Agent Ultra's Rust DaytonaBackend does not run mkdir for writes; it sends PUT /workspace/{id}/file with the remote path URL-encoded, so the shell-metacharacter injection class is absent."
-    },
-    "5a3d7fb99d1f23d3156e17575cabc664fc7fe593": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported/superseded by Rust binary image handling: xAI/OpenRouter-compatible image references use std::fs::read/tokio::fs::read byte reads before base64 data-URL encoding, never text decoding. Existing Rust image/video generation tests cover local image paths encoded as data URLs, so the Python windows-footgun suppression is not needed."
-    },
-    "ef17cd204d7583c31fe1ace9255077f8c736b47e": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported as a Rust-native Windows subprocess no-window chokepoint: hermes-core exposes CommandNoWindowExt for std and tokio commands, backend helper spawns opt into CREATE_NO_WINDOW on Windows, and hermes-source-parity-tests covers the helper plus key runtime surfaces. The Python CI footgun script is superseded by compiled Rust source-contract coverage."
-    },
-    "5db1430af9ecd7ecc1e5eba93e7e1e965af59927": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust by routing background/helper spawns through CommandNoWindowExt across local/Docker/Singularity/SSH environments, MCP stdio, gateway hooks, cron, CLI probes, plugin git operations, computer-use, code execution, TTS, video/ffmpeg, Teams ffmpeg, and project/context git probes. Foreground terminal semantics stay unchanged while Windows background console flashes are suppressed."
-    },
-    "2ecca1e7d3e7c387b4d350f99dc699e2f43f73c5": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported as a real Rust chokepoint rather than relying on stdout/stderr capture: helper processes explicitly call suppress_windows_console before spawn/output/status, and source parity tests require the no-window helper on the primary backend subprocess surfaces."
-    },
-    "d3d621f7c38bb801d9d734cb2898bd4f9b134709": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream reverted earlier Python no-window wrappers. Hermes Agent Ultra does not inherit those reverted Python helper layers; the Rust runtime now implements the final behavior directly through hermes-core CommandNoWindowExt and explicit source-contract tests."
-    },
-    "cb982ad997c5e04c6b647c4cbb3d1b020ec383fb": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust for backend git/bash/helper spawns: coding context, context references, project workspace facts, plugin clone/update, specpatch git probes, doctor bash probes, background triage self-invocation, and quick exec all route through the no-window helper where applicable."
-    },
-    "1ffa01f35fb8bc0bf8825117788092ff0e08421f": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported with Rust source-contract coverage in crates/hermes-source-parity-tests/tests/windows_subprocess_no_window_contract.rs, proving the std/tokio helper chokepoints exist and key backend subprocess surfaces opt into them."
-    },
-    "eeca59f489194a4ce288b31de12b46c20d05cd48": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported/superseded by Rust helper coverage for the analogous remaining backend legs: TTS command/Piper, video and Teams ffmpeg, computer-use/cua-driver, MCP stdio, gateway Matrix decrypt FFI, and WhatsApp/Discord Python adapter legs are absent from the Rust runtime."
-    },
-    "9a0010fd469f0de6c7e2146f955ed9980d02b397": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported for remaining Rust backend spawn legs, including environment backends, gateway hooks/routing, cron, CLI probes, plugin git operations, source-contract tests, and Chrome debug launch preserving detached/process-group flags while adding CREATE_NO_WINDOW through windows_no_window_creation_flags."
-    },
-    "ee22d853eb131ecdce3a8ba54a9a1c39ee5ca4a1": {
-      "disposition": "superseded",
-      "owner": "rust-runtime",
-      "notes": "Upstream fix targets a Python/TUI pdftoppm subprocess. Hermes Agent Ultra has no Rust pdftoppm PDF attach subprocess surface; the broader Rust helper subprocess chokepoint now covers actual shipped helper spawns that can flash on Windows."
-    },
-    "50f685521734237faf0d902fa7d347492d9ea96a": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust: /moa is a one-shot slash command that requires a prompt, routes exactly one turn through the default virtual MoA preset, preserves the model-picker path for sticky moa:default selection, and restores the prior model after the turn even when inference fails. Covered by CLI command usage and app one-shot restore tests."
-    },
-    "163cb24d45d83e551d65da74678c191ceabecd5c": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust: MoA/quorum fan-out emits structured moa_reference stream events with index/count/model/text for successful reference voters, TUI consumes them as visible reference activity/thinking, and the mixture_of_agents tool returns reference_responses with model labels and content for downstream renderers. Covered by TUI stream-event and MoA tool mock HTTP tests."
-    },
-    "917f6bdb00b8b4d0f1c678702c639a5bc966a8eb": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust: vision_analyze no longer depends solely on HERMES_OPENAI_API_KEY/OPENAI_API_KEY. The OpenAI-compatible vision backend resolves AUXILIARY_VISION_PROVIDER/MODEL/BASE_URL/API_KEY, supports custom endpoints and provider keys such as OpenRouter/Nous/Gemini/xAI/Z.ai/GMI/HuggingFace, and builtin registration advertises those env surfaces. Covered by vision endpoint resolver tests."
-    },
-    "9e96e709951824be8336c5a733bb0d98d6ab32da": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust: /prompt and /compose are first-class CLI/TUI slash commands that open $VISUAL/$EDITOR on a temporary markdown draft, strip #! instruction lines, cancel empty buffers, and queue the saved prompt as the next normal agent turn. Covered by fake-editor command tests for readback, header stripping, initial text, alias, and empty-buffer cancellation."
-    },
-    "5ff11a689b561fdb1404aede3fafa543bbbb86bf": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust: /timestamps and /ts are registered slash commands; the interactive TUI supports on/off/toggle/status without mutating prompt text and non-TUI surfaces return an explicit TUI-control message. Covered by TUI state tests and split-module slash parity gates."
-    },
-    "e32ebc6aa26fff446bcc7e11a254d2d4c671f3b2": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported in Rust: /learn is a first-class slash command that records an objective learning ledger entry, queues a next-turn system note to distill reusable project knowledge/skill guidance, and is exposed in CLI command catalogs. Covered by command tests for ledger capture and next-turn note queuing."
-    },
-    "1fe013ee16f19f6390f2efce39397447e7ec2f67": {
-      "disposition": "ported",
-      "owner": "rust-runtime",
-      "notes": "Ported/superseded in Rust: /hatch and /generate-pet are first-class slash commands that capture a petdex hatch request, enable the Rust TUI pet, infer known species/mood from the description, persist pet settings, and queue a next-turn companion design brief instead of shipping upstream Electron/Python hatch UI internals. Covered by command tests for species/mood persistence and queued design brief."
-    },
-    "00694b935fb360bf5a93b1d3034a115ec09f08cd": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "018009bc382de86f864e3fa8af3982c2f0aa7bfb": {
-      "disposition": "superseded",
-      "notes": "Upstream Python runtime delta is superseded by Hermes Ultra Rust-native agent/provider/tool architecture and existing deterministic Rust tests; the Python module path is not shipped in the Rust runtime.",
-      "owner": "rust-runtime"
-    },
-    "0198713c3364f7a16603fa684e78671b1392941d": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "019950560d43f1058d0966b95480d73ed8daf034": {
-      "disposition": "ported",
-      "notes": "Ported in Rust Codex image backend: local/data source images use a Codex-specific raster allowlist; SVG/non-raster inputs are rejected before request.",
-      "owner": "rust-runtime"
-    },
-    "03311abe498da34ab4dbd2402935cf641fce1431": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "03406ae2553e802f11399129c3f376a096bbec4f": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "03bbd37dd7fbef796d2f9d9e8c54ee190d2ccc57": {
-      "disposition": "superseded",
-      "notes": "Upstream Python runtime delta is superseded by Hermes Ultra Rust-native agent/provider/tool architecture and existing deterministic Rust tests; the Python module path is not shipped in the Rust runtime.",
-      "owner": "rust-runtime"
-    },
-    "05ed553c538092904e5e1d61dc9753ac5ea911e4": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "086343854dbf723acfc529d2580c260cc3713d0b": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "08be8e5ef7a07e1bce9910b379b6a5fe48f40763": {
-      "disposition": "superseded",
-      "notes": "Upstream Python/Electron /journey timeline UI is superseded by Hermes Ultra Rust SOTA workflow replay and ContextLattice-backed memory/skills evidence surfaces; no Python journey module or desktop star-map runtime is shipped.",
-      "owner": "rust-runtime"
-    },
-    "08c83d055509a8d61bef0b8648df39d136b3e60b": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "09dbe76955dd65b102827bdbed48a3d08394e856": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "1324add563ca0a90fd4dd8ba07e3a0dd9cf365c6": {
-      "disposition": "ported",
-      "notes": "Ported in Rust image_gen: OpenRouter/Nous model resolution falls back to top-level image_gen.model when provider-scoped model and env are absent.",
-      "owner": "rust-runtime"
-    },
-    "16414418377ba7ca32fae372726966f81fa9c7ca": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "18a9467fca1a750e83c7579ee0cd422c082fd77d": {
-      "disposition": "superseded",
-      "notes": "Upstream Python runtime delta is superseded by Hermes Ultra Rust-native agent/provider/tool architecture and existing deterministic Rust tests; the Python module path is not shipped in the Rust runtime.",
-      "owner": "rust-runtime"
-    },
-    "18d54bf0fd307e02f1ca3f877bcd8a26651297fc": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "1a0c5768135c0565712140eba76e1e7d566bedf6": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "1b3768558e02071b629d1014941ed7b2a0024c34": {
-      "disposition": "ported",
-      "notes": "Ported in Rust image_gen tests/config contract: OpenRouter/Nous model precedence is enforced by provider_config_payloads and covered by focused tests.",
-      "owner": "rust-runtime"
-    },
-    "1f1d346ceda2b133f9bb4f5758e31b6190a211fe": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "217b3c283a8277ab8a78bd3bfc52a53f6ddeadf4": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "259e6b87a73911eca0e71a33a81381801364868a": {
-      "disposition": "ported",
-      "notes": "Ported in Rust Teams pipeline: dot-only and separator-only recording names fall back to recording.mp4, with regression coverage.",
-      "owner": "rust-runtime"
-    },
-    "25c7900fb58239552c530fd6cf8be28e5efbcec4": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "275e293f5431fcac4118d1fcd03bb65f6dd7953e": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "2a84bcb1499005d36f028d430225b2aca1554ac3": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "2e12401ed436309b59e813bf9444c8323ef05171": {
-      "disposition": "superseded",
-      "notes": "Upstream Python runtime delta is superseded by Hermes Ultra Rust-native agent/provider/tool architecture and existing deterministic Rust tests; the Python module path is not shipped in the Rust runtime.",
-      "owner": "rust-runtime"
-    },
-    "2f46fde3f51db2db1cb0854ce1bd2b5c07c16a0d": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "2f7b6cf298a3b64b39b0c9e5a102707e018eacbd": {
-      "disposition": "superseded",
-      "notes": "Upstream Python/Electron /journey timeline UI is superseded by Hermes Ultra Rust SOTA workflow replay and ContextLattice-backed memory/skills evidence surfaces; no Python journey module or desktop star-map runtime is shipped.",
-      "owner": "rust-runtime"
-    },
-    "322138df51c3d965e52d4be7477e596332195479": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "3362bdb4e5c9d01521feb3f8d6b4390ee8e95dd5": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "33d91029b26680a466cf057844df2fcb5fb87b15": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "3590543312a12334b06dabbc47d623406999a9c2": {
-      "disposition": "ported",
-      "notes": "Ported in Rust Teams pipeline: recording display names are reduced to the final path component and normalized before joining the run directory, preventing traversal.",
-      "owner": "rust-runtime"
-    },
-    "36b7e5e9cc9821a1366f88c7e488b443736373e8": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "36bfe3a4490259eb8f89a84b7a9cad2a7c4de8ab": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "39bff67957e11ae5ceca7ee8b7d6a057dfd1ac97": {
-      "disposition": "ported",
-      "notes": "Ported in Rust gateway: display.tool_progress supports runtime command control and log/all-style progress visibility through gateway slash command methods and tests.",
-      "owner": "rust-runtime"
-    },
-    "3e7ed0c53b59174c86cd7ff945c745a35e8c4e51": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "3f19df2a5b71a0d68cb46e299d108c793634e98c": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "41c85fb9469bbde7c5446cc5386b2e2438936fb5": {
-      "disposition": "superseded",
-      "notes": "AGENTS.md subprocess isolation documentation is policy/docs-only and does not change Hermes Ultra Rust runtime behavior.",
-      "owner": "rust-runtime"
-    },
-    "42ca4381316c54394f7e3e078dfc75119fcde9ae": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "43edbae638b5068e428ca82b7f9d6c1266050e25": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "460235d5848b1467cf7351cd6bd82078abe53edc": {
-      "disposition": "ported",
-      "notes": "Ported in Rust Codex image backend: Codex reference images are capped at CODEX_MAX_SOURCE_IMAGES with payload-shape regression coverage.",
-      "owner": "rust-runtime"
-    },
-    "46273a55a860995a6e326c905f7f06dfa980b642": {
-      "disposition": "superseded",
-      "notes": "Upstream docs/skills/website-only delta is superseded by local Rust-first docs, release notes, and parity evidence; no Rust runtime implementation is required for this queue row.",
-      "owner": "rust-runtime"
-    },
-    "46ab06c238472d87506b654729b2f7f01f5b2033": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "476875acb9f00b00f659dd6f71c843fb2f08aac2": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "4a09b692ecc385ad48f00694a1e315b8eed120cd": {
-      "disposition": "ported",
-      "notes": "Ported in Rust API server: inbound requests carry model/provider/personality overrides and merge_request_runtime_overrides applies per-client runtime routing before agent execution.",
-      "owner": "rust-runtime"
-    },
-    "4b4349eb9a904d9babf519e0a580f960311c6035": {
-      "disposition": "superseded",
-      "notes": "Upstream docs/skills/website-only delta is superseded by local Rust-first docs, release notes, and parity evidence; no Rust runtime implementation is required for this queue row.",
-      "owner": "rust-runtime"
-    },
-    "4c2c54c78c3731c3f78787b6c7882eb4aea378d7": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "4c4b790f110be2c34fdfdb72575efe2d1f8ba632": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "500c2b1e46e46684ddfb1f3464a4fe3a0fb060a0": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "50a7dce6bd509ff430dce88de8a3c342ced07f3c": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "51a710e57e931c65a6e44eed694ca437af5ae06d": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "5317993a6dca17f2269cbf79bff88cc912ba92a8": {
-      "disposition": "superseded",
-      "notes": "Upstream Python runtime delta is superseded by Hermes Ultra Rust-native agent/provider/tool architecture and existing deterministic Rust tests; the Python module path is not shipped in the Rust runtime.",
-      "owner": "rust-runtime"
-    },
-    "5505dbbf43a480a31e35ac4500f0584519e2484d": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "57462341f4cac5b86558c179aa5a329272d9f950": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "57dd86f247637a080b9c2c42ae8240379f5b5c49": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "5c2c85c5452f227e6f3b79d90d2c50f7adaddf8f": {
-      "disposition": "superseded",
-      "notes": "Upstream Python runtime delta is superseded by Hermes Ultra Rust-native agent/provider/tool architecture and existing deterministic Rust tests; the Python module path is not shipped in the Rust runtime.",
-      "owner": "rust-runtime"
-    },
-    "5e51f9c689d15440fe6f0242c4a34d0278089788": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "5fdc2acedcf9caa2dffc01a0410ca74b1b28d369": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "608e8a6062271661ac2f2f27375ef9ad7eb32b12": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "638d2e7bfcad1be6e779c0d1af95481a6e92d811": {
-      "disposition": "ported",
-      "notes": "Ported in Rust holographic memory: search_facts uses the same sanitized FTS/LIKE path as retrieval and tests cover special-character fallback plus category filters.",
-      "owner": "rust-runtime"
-    },
-    "66ba9e06d92542268c97c500d5312100c299d973": {
-      "disposition": "superseded",
-      "notes": "Upstream GitHub Actions/CI-only delta is superseded by Hermes Ultra local Rust deterministic gates and release workflow; it does not add shipped Rust runtime behavior.",
-      "owner": "rust-runtime"
-    },
-    "69f08c2eb5a2a68a072debd3e7f274141b6b98bf": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "6d879d486b19716f8b09bd47bffb0b6e5b690431": {
-      "disposition": "superseded",
-      "notes": "Upstream Python runtime delta is superseded by Hermes Ultra Rust-native agent/provider/tool architecture and existing deterministic Rust tests; the Python module path is not shipped in the Rust runtime.",
-      "owner": "rust-runtime"
-    },
-    "729bbb7a309a3d13d8cc7d1cd2fbab79e7d969f7": {
-      "disposition": "superseded",
-      "notes": "Upstream docs/skills/website-only delta is superseded by local Rust-first docs, release notes, and parity evidence; no Rust runtime implementation is required for this queue row.",
-      "owner": "rust-runtime"
-    },
-    "7337248a4c182d65b6c101acac1e21be5101c4cc": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "7548910ecec412b84cb92e180f0e6017f176f0eb": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "773a3703bfc1f8ff2f3aef40d7a565e7f4fe1404": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "7a2369718a126f624357430a3defce1a1aec668d": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "7c1a029553d87c43ecff8a3821336bc95872213b": {
-      "disposition": "superseded",
-      "notes": "Upstream release metadata commit for v0.18.0 is superseded by local Hermes Ultra release/tag history and does not represent a runtime patch.",
-      "owner": "rust-runtime"
-    },
-    "7c7b489813184c54dc3d57a0a7d1c37182c4d8ff": {
-      "disposition": "ported",
-      "notes": "Ported in Rust Slack adapter: Block Kit rendering is first-class and native table/block structures are represented by the Rust socket_blocks model and tests.",
-      "owner": "rust-runtime"
-    },
-    "808ba82125e2ccaca9d0df1d5557a173e5242504": {
-      "disposition": "superseded",
-      "notes": "Upstream GitHub Actions/CI-only delta is superseded by Hermes Ultra local Rust deterministic gates and release workflow; it does not add shipped Rust runtime behavior.",
-      "owner": "rust-runtime"
-    },
-    "821d9f709f365453abde7ca71445bc0aad9bdaa1": {
-      "disposition": "ported",
-      "notes": "Ported/superseded by Rust prompt config: AgentConfig exposes system_prompt plus coding_context auto/focus/on/off, and build_system_prompt injects deterministic coding guidance only on coding tool/workspace surfaces.",
-      "owner": "rust-runtime"
-    },
-    "83b7c52ece76b73ee878e9336722572e7d273cab": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "83e10a6777f93ba2dfb2b344314912bb9f969202": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "84f350efe06be9f0c2e9b05471acad5db91b0e7b": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "8795dfa33169b82f6cae7ec22632c430778182d0": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "88bd1c01e1956ef6ed35ac6cce00e02ec7cf29bb": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "88c9dfecb23c372c20e760057e44856188b91566": {
-      "disposition": "ported",
-      "notes": "Ported in Rust Slack adapter: Block Kit docs/runtime contract is represented directly by typed Rust builders rather than Python docstrings.",
-      "owner": "rust-runtime"
-    },
-    "88e29e35bd327c51306edad22d700d79b4b97f40": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "89cf65ab63988656124770e43cf8defd1ec8799b": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "8ad15ff7dde90dc7f05114133cc3b553947018e6": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "8da0a56ba86a713a49b6fd61c79004aad7580a19": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "8dcbc910bfd131dcfa7b83bf61e11e4807dce4ec": {
-      "disposition": "superseded",
-      "notes": "Upstream Python runtime delta is superseded by Hermes Ultra Rust-native agent/provider/tool architecture and existing deterministic Rust tests; the Python module path is not shipped in the Rust runtime.",
-      "owner": "rust-runtime"
-    },
-    "8e94e8f8821986b5e94200936c1b6bc2b603487f": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "8fe8c2d6c476d50d4aaed13a924329fabd57a190": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "9048457eabb4ec95ec0321ba580fc32b4cfa7b67": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "931e2356af9bdc7ee0996e25ff9afc51216763ad": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "94d70dee54c4f9c54d9681b0f49d629c08e275f1": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "9738870489d04ee168f87263d85922ae2a858d42": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "9998ff4cbebc9812aec66a7d0839665fa7fbfa36": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "9be292f1e678437644396b47b3410b433ba3433f": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "9ce79cd642125eb0997d31310fe12cb0fddd6ba5": {
-      "disposition": "ported",
-      "notes": "Ported in Rust media tools: xAI image generation stores public_url/file_output when present, xAI image edits use quality model/image fields, and xAI video generation supports text/image-to-video with reference images, duration caps, and auth-store/env credentials.",
-      "owner": "rust-runtime"
-    },
-    "9d10dcd490e68eae94849496586242defbede058": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "9e4ed4d7a922844710a5ebd9e551a72e5090eca2": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "9ee7333e5b36633993c3898a01a26f0b189b81bc": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "9f0309504496a82d15b07aef30f8f7bf84cab660": {
-      "disposition": "superseded",
-      "notes": "Upstream docs/skills/website-only delta is superseded by local Rust-first docs, release notes, and parity evidence; no Rust runtime implementation is required for this queue row.",
-      "owner": "rust-runtime"
-    },
-    "a10113658b6033c5902bbe873bfe2e1f05815339": {
-      "disposition": "superseded",
-      "notes": "Upstream Python pre_verify/verify-on-stop hook plugin is superseded by Hermes Ultra Rust execution discipline, deterministic verification gates, ContextLattice checkpoint policy, and explicit shell/test verification workflow; no Python hook plugin runtime is shipped.",
-      "owner": "rust-runtime"
-    },
-    "a40f22798ec6b5877958f6dbe5aeda8468e7d628": {
-      "disposition": "superseded",
-      "notes": "Upstream installer managed-clone reset is shell/PowerShell installer behavior; Hermes Ultra release/install flow is Rust-first and handled by local installer scripts outside the Rust runtime queue.",
-      "owner": "rust-runtime"
-    },
-    "a488fcf107d1c61400db4274c0baf357b908c772": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "a56aa9ac47b0fd52e50a40b1812728ee16bee873": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "a61cf774ce925964d679f5ad04966251e37444ca": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "a682091044955167c9a728f9641ff279c96a73a7": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "a8a97c358feee4ee546670691f6f72e8812f9d3a": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "a8c862900b9c24a1706cbcb17c2b9968c88f277c": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "a8f9d089f124c7e8ab6689585eb33f9f6565890b": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "a94f657a505962cc046b29322750e03450c55645": {
-      "disposition": "superseded",
-      "notes": "Upstream Python runtime delta is superseded by Hermes Ultra Rust-native agent/provider/tool architecture and existing deterministic Rust tests; the Python module path is not shipped in the Rust runtime.",
-      "owner": "rust-runtime"
-    },
-    "aa07400e1a8f37e835714d8a68c1b72e634e3793": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "af5cea04ab77352209a0495b25e5c5c295a73395": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "b080b93ad87428221f7bf40360d11fc13e837727": {
-      "disposition": "ported",
-      "notes": "Ported in Rust Slack adapter: SlackAdapter exposes Block Kit message builders and post_blocks/post_block_kit paths, with Block Kit builder/round-trip tests.",
-      "owner": "rust-runtime"
-    },
-    "b31b0b9d95d1dbaae0197b9f3f7d3f3d0d4efc28": {
-      "disposition": "superseded",
-      "notes": "Documentation reconciliation commit targets upstream Python/website surfaces; Hermes Ultra tracks Rust docs and parity gates separately, with no shipped Rust runtime delta.",
-      "owner": "rust-runtime"
-    },
-    "b48fcfa8bd93268647c77113900f603ac7f7a93b": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "b6045170bb7bad85c9a361054bf69b4d7f0722f2": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "b6d8fc41c8d186116531df6cf9bd1cc25ce4e602": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "b6e57e215bf08fdf2308881af48d4b97761319d2": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "b98baa3039e357d97ccb8d84e6d70b1902a03582": {
-      "disposition": "ported",
-      "notes": "Ported in Rust providers: GenericProvider extra_headers, OpenRouter profile headers, and provider_profiles extra_headers_for_profile carry configured provider-specific HTTP headers into LLM API calls with Rust tests.",
-      "owner": "rust-runtime"
-    },
-    "ba0bc01d1f740c562b55925e404b82a48809c364": {
-      "disposition": "ported",
-      "notes": "Ported in Rust delegation: delegate_task no longer exposes model-facing toolset schema; subagents inherit parent tools while internal compatibility remains.",
-      "owner": "rust-runtime"
-    },
-    "babbefb16438ef28e061690117a1dad08e71ff54": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "bb304b491407054a847a6fae6eef6db688efb7bf": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "bb67dad07a8c1540032e36f8ed10d76d2b186062": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "bd1d354fc3c509b622853f5b6205fff1007c66dd": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "bd53230739da3bacbf58211f79a56cebcbfb4e06": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "c0b308e1fedd3c681adc0953276b6632f0ee3c03": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "c2fb651c5e0073ac749b90cfe44ab5ec4add884f": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "c6ba4b229ed138dcf636322487c968d2ffe4b999": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "c6eb7f9e7284c5268ceed0c3fc92e1f2a5d892c7": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "c73e74386b20164fa218414131fe8b03f07b3e7c": {
-      "disposition": "superseded",
-      "notes": "Upstream Vertex provider is superseded by Hermes Ultra generic/OpenAI-compatible provider routing, Gemini/OpenAI-compatible setup, custom base_url/headers, and OAuth provider surfaces; no dedicated Python vertex_adapter runtime is shipped.",
-      "owner": "rust-runtime"
-    },
-    "c8e5f999c2b02c45c8d4531bd7721b745bbd4702": {
-      "disposition": "ported",
-      "notes": "Ported in Rust quick-command/terminal surfaces: command execution sanitizes credential environment and strips ANSI/redacts sensitive output before returning gateway/TUI-visible text.",
-      "owner": "rust-runtime"
-    },
-    "cb6d6d46ab6b20b173c8215a1f066b53847e9ee5": {
-      "disposition": "ported",
-      "notes": "Ported in Rust holographic memory: SQLite FTS5 recall sanitizes natural-language queries, falls back safely when FTS is unavailable, scores trusted category matches, and has focused tests.",
-      "owner": "rust-runtime"
-    },
-    "cb9308f0a65ff2f0a5880c54f67203946d0dc317": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "cb9d18c759417f0bf0ff94fb932a423c74d706d5": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "cc1e4c32c0227e808821822a4f6206d317973528": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "cc7d20d6838343f8acc70aecf207bae22dde4a88": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "cca8b4ef4e3f8bac1708bd5951450b645d8c20a3": {
-      "disposition": "superseded",
-      "notes": "Upstream GitHub Actions/CI-only delta is superseded by Hermes Ultra local Rust deterministic gates and release workflow; it does not add shipped Rust runtime behavior.",
-      "owner": "rust-runtime"
-    },
-    "cf05b38683ebe2035d41f9eb7c39c735092e8f68": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "d173e8c3a76bcd8ca86df6861fb1e1349872e560": {
-      "disposition": "ported",
-      "notes": "Ported in Rust disk_cleanup: cleanup skips protected cron roots even when auto-delete categories match, with focused protection tests.",
-      "owner": "rust-runtime"
-    },
-    "d2de9580e181b3cabb3b84c6e970bd3902eb13d3": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "d3c866746234ed3de27732de696328c328317fb9": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "d43e0cf304a14c9a3c98ff0506a1f79cf4938e99": {
-      "disposition": "ported",
-      "notes": "Ported in Rust agent loop: codex acknowledgement continuations are handled in both non-streaming and streaming run paths with bounded retry counters, independent of Python api_mode branching.",
-      "owner": "rust-runtime"
-    },
-    "d4c14011ebbc59d1479a53c207692933b79d0287": {
-      "disposition": "superseded",
-      "notes": "Claude-design skill/web docs are optional prompt-skill content and not a Rust runtime gap; local skill index work is tracked separately from upstream Python queue parity.",
-      "owner": "rust-runtime"
-    },
-    "d68d2716a7492db6853a81632de4d7e8acd69160": {
-      "disposition": "superseded",
-      "notes": "Upstream Python runtime delta is superseded by Hermes Ultra Rust-native agent/provider/tool architecture and existing deterministic Rust tests; the Python module path is not shipped in the Rust runtime.",
-      "owner": "rust-runtime"
-    },
-    "dd659c8d175858bab96012b52b4201e381cd19cc": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "dec44994a5be54d835060f593079f0c732567e80": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "dff491a2b993e9e9db43d1834ac5d46c2f87173e": {
-      "disposition": "ported",
-      "notes": "Ported in Rust CLI: hermes serve is a first-class alias for the headless dashboard/API backend with host/port/no-open/insecure flags and parser coverage.",
-      "owner": "rust-runtime"
-    },
-    "e009ba57ac4feac11e326db8f4c7da95d9028485": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "e0a78336c1e3d3ea2216510154430f6142f4464a": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "e5253d852b24f87af91d77b66141cc5c0b9e6f69": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "e55e9fad2c2e2de6181e12c65d3a12baf718d759": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "e774d7fbf9be43beb7577498cb6125da1e47159e": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "e971dc1e9d2afb307d3cea3e576b8de9614baaf7": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "e9bceb5ae0c46234c0c66e136ced2c791dcc90d8": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "ebb81f10cb70c4c37a2d00ef58a8aea37e7971f2": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "ecffd290a3f115b33f921505b5190228d1323387": {
-      "disposition": "ported",
-      "notes": "Ported in Rust Codex image backend: OpenAI Codex Responses payloads now accept input_image parts from image_url/reference_image_urls and report image modality/source count.",
-      "owner": "rust-runtime"
-    },
-    "ed47f2b4aa43c9b280bd84798d4a6cbf9ac889f4": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "ede5c09f3b1a16a9eacc69da69cfa02bd89e1b35": {
-      "disposition": "ported",
-      "notes": "Ported in Rust disk_cleanup: exact protected cron path behavior is enforced by is_protected_cron_path and regression-tested rather than only documented.",
-      "owner": "rust-runtime"
-    },
-    "f3cd744f5c40ab70e5a10ffc7c993f049ca1c70c": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "f47459cdbdee7bc312024f46a6ab03120e3c0c71": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "f5eb4c307bfdbfa5f24c5bff59881295f17b17ac": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "f67c0b3e60ba91b92ca1d07826d873b4b8f36849": {
-      "disposition": "superseded",
-      "notes": "Upstream bundled skill documentation refresh is non-runtime for this Rust repo; local skills/parity/release docs own Rust behavior and no Python skill runtime port is required.",
-      "owner": "rust-runtime"
-    },
-    "fa7bce0789d80fa99080a2be231fcc754fd2af3c": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "fb44b519d712e7c8452112dbfcaa5071d56c66e4": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "fd324562d3ad43df7631428df4585cf9de8154f2": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
-      "owner": "rust-runtime"
-    },
-    "fde1c8570ffe1bcd1d352efffb4eeafdfd975f0c": {
-      "disposition": "superseded",
-      "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
-      "owner": "rust-runtime"
-    },
-    "c19bfb50ad6fc6368635cb0df8ec81bb820160bb": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React desktop remote-mode delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop as a runtime product.",
-      "owner": "rust-runtime"
-    },
-    "fe82b3a774d97db0c4e948217a89f2b055ce73bc": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React desktop remote-mode delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop as a runtime product.",
-      "owner": "rust-runtime"
-    },
-    "a9b5598909585b851b1ed65f05034033676d1a86": {
-      "disposition": "superseded",
-      "notes": "Upstream Electron/React desktop remote-mode delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop as a runtime product.",
-      "owner": "rust-runtime"
     }
   },
   "subject_patterns": [

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -27,7 +27,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "595569a82fa0adea9efb72530b1135d947c2a391",
+      "upstream_blob": "ab60120165362316152e412fbec9d3f30efa2334",
       "workstream": "WS6"
     },
     {
@@ -57,7 +57,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "c820e0a55106ef586c58c94079a0c5593dc9d55d",
+      "upstream_blob": "e4240ea36e754fe6e6035b787f9713b57d3457d1",
       "workstream": "WS8"
     },
     {
@@ -72,7 +72,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "e89c819844e6a61dc1dc7c8c3d01ed201bc70f2d",
+      "upstream_blob": "e1dbaaa5c43c129f3de8a0e40098e602fd4e40e1",
       "workstream": "WS8"
     },
     {
@@ -87,7 +87,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "bad33481c745e2092d849c26201d0cee1d3bd923",
+      "upstream_blob": "46581d820037d2abd46ddd2b0d74c0b39190596d",
       "workstream": "WS8"
     },
     {
@@ -125,7 +125,7 @@
       "classification": "intentional_divergence",
       "classification_path": "README.md",
       "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "6f19299d645b8c96cfa8eccc9cfc75eacc957a51",
+      "local_blob": "9f519632dd2d7b684b1d6f412ab9319a900f6e83",
       "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "README.md",
@@ -282,7 +282,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 305,
-      "upstream_blob": "1c1d0b78922b62fddbb92e7820bb694b575d414a",
+      "upstream_blob": "8715490be1d4de3aa59a4f405403b272429c0c8b",
       "workstream": "WS8"
     },
     {
@@ -417,7 +417,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "aa4e067ae82a3ff62eff46fddc1803e794d940c8",
+      "upstream_blob": "7ea146adc137d115bef207c54c4b97c383a0bdd0",
       "workstream": "WS4"
     },
     {
@@ -462,7 +462,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "2ce65fd336e775696e5853d60084c26acbc87f62",
+      "upstream_blob": "d353855b669fdeb9aabe551a4356c31985dfd23c",
       "workstream": "WS4"
     },
     {
@@ -492,7 +492,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "d9d53a97a2405475841f0481afc38a96bd953896",
+      "upstream_blob": "c108a99ea5a6d1abe8bf5e7e2a811d82d19e7d6d",
       "workstream": "WS4"
     },
     {
@@ -717,7 +717,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "9f13aebb4c6cafca2bc2226511a4609265b691a3",
+      "upstream_blob": "7650c54f570d9bb51bf31939ed81cc3c39152edf",
       "workstream": "WS3"
     },
     {
@@ -732,7 +732,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 304,
-      "upstream_blob": "e721c037c814c7f91c928f5ae0d893d54e226fb9",
+      "upstream_blob": "1ab0c0fd73dbb5d0ced87896cf032326c3b0e3ec",
       "workstream": "WS3"
     },
     {
@@ -762,7 +762,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 304,
-      "upstream_blob": "255b851ba6a7d9232ee3bdbba3cba6a1dc0ae39b",
+      "upstream_blob": "ac2b08ac5860c445b1f783387d38644601025d39",
       "workstream": "WS3"
     },
     {
@@ -942,7 +942,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 304,
-      "upstream_blob": "d932bb1d24f62537e528cb841ca9e591bccc3b31",
+      "upstream_blob": "a801a87327c0b8c619218b8e27a2e43949b77a70",
       "workstream": "WS3"
     },
     {
@@ -957,7 +957,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 304,
-      "upstream_blob": "6b396b2612ef41f36b3613059d270f559294a18a",
+      "upstream_blob": "8f2a43c295ffd06cdf27d14d3a3bc370102c2867",
       "workstream": "WS3"
     },
     {
@@ -1137,7 +1137,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 304,
-      "upstream_blob": "8fc37448fd4622234fd3ad3926cd4176bb2b4650",
+      "upstream_blob": "3db0cc3fd684fd012e81b802b612904aa2ea15b5",
       "workstream": "WS3"
     },
     {
@@ -1182,7 +1182,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "53046b08e3a3798dd0a917b13176a85a9115b673",
+      "upstream_blob": "c5c39f2bc49f6bf0b1b01d5e9ccb57c08bb79f3b",
       "workstream": "WS3"
     },
     {
@@ -1197,7 +1197,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 304,
-      "upstream_blob": "3647496375d9e8618398fcb07b364ba19212c258",
+      "upstream_blob": "35f413ed37a72985f9c819e23c283f5a9847d4f3",
       "workstream": "WS3"
     },
     {
@@ -1212,7 +1212,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "ef06b0f37f71c549abe295521a7a4545e0568b45",
+      "upstream_blob": "c6ae10acca8dda674d1ffe732c523e5a31572d72",
       "workstream": "WS3"
     },
     {
@@ -1242,7 +1242,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "c6ea6bc1d7c3c814accf14c0fec758f04ddd75f1",
+      "upstream_blob": "5aef3b908503bd94aee6236f3c44922910890c18",
       "workstream": "WS3"
     },
     {
@@ -1258,6 +1258,21 @@
       "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "18b8ea78741548dac1d4e52df7ad130ef84bc848",
+      "workstream": "WS3"
+    },
+    {
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "plugins/memory/retaindb/__init__.py",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "62121410d41c7b4dcee5605de4728037e7ca1684",
+      "necessity": "approved_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/memory/retaindb/__init__.py",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 25,
+      "upstream_blob": "a777ccbd55ee9110e6484240d29e5fe8be90a361",
       "workstream": "WS3"
     },
     {
@@ -1392,7 +1407,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "e893be95b279ff7eb30b78247d48092bfcd86769",
+      "upstream_blob": "2847d161adf0d936d474670bebce3a5e3750810c",
       "workstream": "WS3"
     },
     {
@@ -1482,7 +1497,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "ebf3b9274d6ff7be772740826493da8af9805537",
+      "upstream_blob": "f8cbcc1baf3284a3bd93cf498e77d5c8c4d94275",
       "workstream": "WS3"
     },
     {
@@ -1527,7 +1542,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "7a53ec166c109de5d87bec20d24e1145130afe1c",
+      "upstream_blob": "a4c022ff85539339e89b265407d65dfda1f96b70",
       "workstream": "WS3"
     },
     {
@@ -1557,7 +1572,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 304,
-      "upstream_blob": "bfe4724504109dca63aa208b0e222aab29326df2",
+      "upstream_blob": "8a83f8805ed9afafa4fed5a39404e0be7e1396ab",
       "workstream": "WS3"
     },
     {
@@ -1572,7 +1587,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 304,
-      "upstream_blob": "5deb0e5af4c3a6bddde3e6d7bc9c90b11857a9b8",
+      "upstream_blob": "f63efeabebdee645708cf3494c70af764d8d8a9a",
       "workstream": "WS3"
     },
     {
@@ -1587,7 +1602,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 304,
-      "upstream_blob": "3d481b3ead7ba133594a16ba6202aedd22514b67",
+      "upstream_blob": "277b2396f0c517de5d1f2a263926e34f02d25569",
       "workstream": "WS3"
     },
     {
@@ -1692,7 +1707,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "d6e627f667bc6f1aa99939bd6df6c82b5a843e04",
+      "upstream_blob": "27df34ecf2c4dcbfd907ef6eaf020800175fdb2d",
       "workstream": "WS3"
     },
     {
@@ -1842,7 +1857,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 304,
-      "upstream_blob": "bc204b98b38ec51712cd53009b0de12fb430d09f",
+      "upstream_blob": "432300983795619ac1d3099f2c544e525fc0661a",
       "workstream": "WS3"
     },
     {
@@ -1983,6 +1998,21 @@
     {
       "action": "No vendoring; verify approved divergence remains current.",
       "classification": "intentional_divergence",
+      "classification_path": "plugins/web/brave_free/provider.py",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "df4584f7732c1a8e2cf89259b082f67dff4de014",
+      "necessity": "approved_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/web/brave_free/provider.py",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 25,
+      "upstream_blob": "0da8d11c991243ca9265344c101645e7eeb877ba",
+      "workstream": "WS3"
+    },
+    {
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
       "classification_path": "plugins/web/ddgs/provider.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "e8846236a24db13e0736fc0aeaf79a17de7ce8fb",
@@ -1998,6 +2028,21 @@
     {
       "action": "No vendoring; verify approved divergence remains current.",
       "classification": "intentional_divergence",
+      "classification_path": "plugins/web/exa/provider.py",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "0fea6fb5a8b79d0177b00f1db240c2916cf0e94f",
+      "necessity": "approved_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/web/exa/provider.py",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 25,
+      "upstream_blob": "17ce665dc18a566545977e5f6ceacdecd17cdfa8",
+      "workstream": "WS3"
+    },
+    {
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
       "classification_path": "plugins/web/firecrawl/provider.py",
       "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "bcc574ffca39807de3f33e45843d03dd2749fc3e",
@@ -2007,7 +2052,22 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "97718a6cae2924b495b0d115078ef47b46f75f4a",
+      "upstream_blob": "ae02b43a6eb7ce360e40825ae08f22ccf1479ed7",
+      "workstream": "WS3"
+    },
+    {
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "plugins/web/parallel/provider.py",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "38578e6b52c34a7b18f95656188e9971ccda3352",
+      "necessity": "approved_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/web/parallel/provider.py",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 25,
+      "upstream_blob": "028f5df3fc37b350edfaa9e612fb474514b598d3",
       "workstream": "WS3"
     },
     {
@@ -2052,7 +2112,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "fe161a4a0964a1c3139284b715e48aa2dafa12a5",
+      "upstream_blob": "e2a9d7b40f185162c9d26a25ef4c34d510690270",
       "workstream": "WS3"
     },
     {
@@ -2128,6 +2188,21 @@
       "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "d67fa6ce1bad06f97330dcfe480f57dc81e247a8",
+      "workstream": "WS4"
+    },
+    {
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "skills/media/youtube-content/scripts/fetch_transcript.py",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "6160339038dd3ba8b54882703ed779d0c8f3eced",
+      "necessity": "approved_divergence",
+      "owner": "sheawinkler",
+      "path": "skills/media/youtube-content/scripts/fetch_transcript.py",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 25,
+      "upstream_blob": "73c305cee5474a5881d1ea150e06979a1c3f7914",
       "workstream": "WS4"
     },
     {
@@ -2502,7 +2577,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "9610f7fb57cb57bbe8649f6b35736e5de00430b6",
+      "upstream_blob": "1393d71ab8594b06e1e2173b47fb1ea852b446e5",
       "workstream": "WS6"
     },
     {
@@ -2532,7 +2607,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "91a5fa743bb580545ed7f062bb63a790a674e6a3",
+      "upstream_blob": "96a8fe9ff04cb8e953f8b3004054127d6d760f57",
       "workstream": "WS6"
     },
     {
@@ -2547,7 +2622,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "b5901391ee95fcfec94e330793a654d65ff1014f",
+      "upstream_blob": "5e18fa73a1f831005a96206327ed840df6d9b176",
       "workstream": "WS6"
     },
     {
@@ -2577,7 +2652,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "0b8b0a04462a137d2f51cdba5b18a7725a318ccd",
+      "upstream_blob": "935bb04371d8b36d43fd3eb0715ee5715316e10d",
       "workstream": "WS6"
     },
     {
@@ -2592,7 +2667,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "afceeec02d94bd96451161beeb8bbca9f3e17ed5",
+      "upstream_blob": "fe4a8c34d3706ae23f429361e6e30f4da84a0619",
       "workstream": "WS6"
     },
     {
@@ -2652,7 +2727,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "65df149e528d939d011df1ac2af165bd5787d693",
+      "upstream_blob": "d8840bc979e4f0aa0d8adbaf81580191d05e2615",
       "workstream": "WS6"
     },
     {
@@ -2712,7 +2787,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "231f8b4077fb17d07c9591f1f8b06944134fdaf3",
+      "upstream_blob": "75b22bb8a80d756ca8b9ed662bfa094379388146",
       "workstream": "WS6"
     },
     {
@@ -2795,6 +2870,21 @@
       "classification": "intentional_divergence",
       "classification_path": "tests/agent",
       "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "8477fdb646a89dce472d4ec84bc327b92b8861cc",
+      "necessity": "approved_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/agent/test_credential_pool_routing.py",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 25,
+      "upstream_blob": "9c7c047305151fe3d1be82aaafdbb2cbd9b35eca",
+      "workstream": "WS6"
+    },
+    {
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/agent",
+      "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "be8d51cea8c9b198f1b2e21a3c18be8682330bce",
       "necessity": "approved_divergence",
       "owner": "sheawinkler",
@@ -2847,7 +2937,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "804e5a65ecc68581072b77a31afcc3e4148e7f58",
+      "upstream_blob": "5c3414d0edb611fd74459a217fefce1bd5948663",
       "workstream": "WS6"
     },
     {
@@ -2907,7 +2997,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "6c533089986ceb739db76986f25dde019f59f39a",
+      "upstream_blob": "baadfa7e196af7248195a83621d99549f9cbe61c",
       "workstream": "WS6"
     },
     {
@@ -2952,7 +3042,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "4439eec1e074468d3ba3d2d54c9c46ee06430b2d",
+      "upstream_blob": "66c809008a69c04c5c5aef3a10b729553a79043f",
       "workstream": "WS6"
     },
     {
@@ -3012,7 +3102,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "675823112cff467363789e4c9b75a271c9537a29",
+      "upstream_blob": "671e6aaa18dd450d2faa414e7a669cccf22a46ea",
       "workstream": "WS6"
     },
     {
@@ -3207,7 +3297,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "499ffc765a41485367bac53f325c113e9a318ecd",
+      "upstream_blob": "7a1c0495e1b335f05dd60502e4ac0e9d86285ce1",
       "workstream": "WS6"
     },
     {
@@ -3237,7 +3327,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "ed7e42558874af6d8006bb24f269755b0bd5dcc4",
+      "upstream_blob": "57956a383b0e87a61a41ad8e74ee4c5d658ec946",
       "workstream": "WS6"
     },
     {
@@ -3282,7 +3372,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "192ad0d0b353f0f58359e9a462cf07973eb8a3be",
+      "upstream_blob": "08fe9f41b4fe8450466a3a125c42cf10671647cb",
       "workstream": "WS6"
     },
     {
@@ -3312,7 +3402,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "ab3cfe280aeee5cdf9fe3d7711427f5d82b601f5",
+      "upstream_blob": "347d1b667c7a053cff7517feea20f5e2960267f4",
       "workstream": "WS6"
     },
     {
@@ -3867,7 +3957,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "5091256a399038c1783f2c00dfa479849054edfe",
+      "upstream_blob": "08185689e73c42596c5f53ee3f932d455986ab07",
       "workstream": "WS6"
     },
     {
@@ -4077,7 +4167,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "ee02d043017fbfb78647c1979ab8cda3141a14e7",
+      "upstream_blob": "1033fb1ee4ffb14d813a1a5dbe4de7109ebb6d76",
       "workstream": "WS6"
     },
     {
@@ -4092,7 +4182,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "d8efdfb4855aff7e8e0794b4562b4f1c2673a380",
+      "upstream_blob": "253bde4769bb3455fead67c8b956c446500d8124",
       "workstream": "WS6"
     },
     {
@@ -4122,7 +4212,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "50eb7ab7770bff74b11b527e97bd0dd40bd64a06",
+      "upstream_blob": "d0adf7ed1bd1fcc5c936eb6d78d5499af5e29cca",
       "workstream": "WS6"
     },
     {
@@ -4137,7 +4227,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "54445e7054c77294c4bb947124dc2860612698c2",
+      "upstream_blob": "8cb81cb6177a835caa1febed9de95c4d3bb7f5dd",
       "workstream": "WS6"
     },
     {
@@ -4167,7 +4257,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "193f7f125d8a41fe1235950daf0dadf42bcd3b14",
+      "upstream_blob": "46c98b5d08438d7716e063bafe5b6ed6c031400e",
       "workstream": "WS6"
     },
     {
@@ -4212,7 +4302,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "d1f47c700b226f026197749899c0a13b8269e9db",
+      "upstream_blob": "3546b09cc7544f37cfd414998a265a561a533db5",
       "workstream": "WS6"
     },
     {
@@ -4272,7 +4362,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 302,
-      "upstream_blob": "73a4941db3f448a1fb4d61b323a5db98024fb495",
+      "upstream_blob": "81264fa37c9d9197ce4c66f996a1e95cfdf67480",
       "workstream": "WS6"
     },
     {
@@ -4407,7 +4497,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "6d50a31be2eb4dde591dc60a64658590a8f4917a",
+      "upstream_blob": "f5ac3b8c40ba2b7a374fde25b1eed9af87f48154",
       "workstream": "WS6"
     },
     {
@@ -4512,7 +4602,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 302,
-      "upstream_blob": "a77c527d2e9b2048e6c256ff14f1c030df6c901e",
+      "upstream_blob": "66c4672f21c34d56b1748df1f0419c159fd6527c",
       "workstream": "WS6"
     },
     {
@@ -4602,7 +4692,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "88e53e212effdcb9daec616f46122fc73621eba9",
+      "upstream_blob": "e8e8d582887609a3f953011473b1b1cc4aa6b46e",
       "workstream": "WS6"
     },
     {
@@ -4647,7 +4737,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "3f787403bd860d4e92afc64556e9fb753792ed4e",
+      "upstream_blob": "b9d4993b5f0604905b08daf6e8de9b13af2baecf",
       "workstream": "WS6"
     },
     {
@@ -4662,7 +4752,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "299b7e6b3bef19b533629225bfd9a78d01949028",
+      "upstream_blob": "ca449b94b62b9c9b42cbb3b7abcf3cd9806d69c9",
       "workstream": "WS6"
     },
     {
@@ -4827,7 +4917,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "5c77c8e13b861b7e86b3edd5fd559a4f1c661142",
+      "upstream_blob": "7acad309ad33edb38e8c450a99bcc2b2a7a74d35",
       "workstream": "WS6"
     },
     {
@@ -4917,7 +5007,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "86025f4e4291f50a782170253d3e118eb40aefe1",
+      "upstream_blob": "369dcb9a977b68fede5f71c3bc14c0ba2ba6dc75",
       "workstream": "WS6"
     },
     {
@@ -5037,7 +5127,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "5ef6812f5375104baa6bc1ab446b8b36f9abe071",
+      "upstream_blob": "f35ca2fa94549d8c47f694270f3c9fa983af5e88",
       "workstream": "WS6"
     },
     {
@@ -5082,7 +5172,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "81bbc912fab877e3cdee0cb3f58772e111e806e0",
+      "upstream_blob": "d05807e41a79cc322fc7063d644602253f7921bc",
       "workstream": "WS6"
     },
     {
@@ -5202,7 +5292,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 302,
-      "upstream_blob": "c1000094007007f565f03b3852ed43cee4af64ec",
+      "upstream_blob": "a5b07c89880d1e7b84c3e86ccc4a1a64b543d673",
       "workstream": "WS6"
     },
     {
@@ -5217,7 +5307,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "bb97c7e72be17f85d7917c7fc386f94385fc329f",
+      "upstream_blob": "58d7bb888722b9eb9c3ab77bca84aca96bf4b027",
       "workstream": "WS6"
     },
     {
@@ -5562,7 +5652,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "1fedb30a019ffbf9a04941ab92a89c49d78817f0",
+      "upstream_blob": "808180ba144c6950adf2f7732b4f89b7978862ed",
       "workstream": "WS6"
     },
     {
@@ -5667,7 +5757,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "caa141c6a444296e7eabec9ac6eeea95f6dd52a1",
+      "upstream_blob": "ca9d603c697e8eb42aec03754477da933549cf59",
       "workstream": "WS6"
     },
     {
@@ -5712,7 +5802,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "74e718f181a5aafaa1fe501fcb5c1b1d185386aa",
+      "upstream_blob": "ef1037692e6b04ea99c160376f97057f901ff52d",
       "workstream": "WS6"
     },
     {
@@ -5847,7 +5937,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "0c7fa80a0ba0bb24f826991da0f008053e248d35",
+      "upstream_blob": "be98f7eb9acbdc13fcdcb038a4f3482cdc9bda9e",
       "workstream": "WS6"
     },
     {
@@ -5877,7 +5967,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "ec1b0dedc83d7072dcdf87fbc0e133328b4d0755",
+      "upstream_blob": "857da98da71c1976a2278bf91b39d0b9449e4aee",
       "workstream": "WS6"
     },
     {
@@ -5952,7 +6042,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "35135cfc4481978ce232fcf96900b1090e5fc5e3",
+      "upstream_blob": "0dc217d39d9479f525e0b7fdd9215af55bcbdf1a",
       "workstream": "WS6"
     },
     {
@@ -6012,7 +6102,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "dfa065bc3a8b876d881b28951ed511b24bf70dc7",
+      "upstream_blob": "b7f08713b1df04cc73b57041e2a21007770ca5a9",
       "workstream": "WS6"
     },
     {
@@ -6177,7 +6267,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "9ec0860a5d01037c1d5b611de0e7d5f37f8aa927",
+      "upstream_blob": "4f47d0ff638bbe33fe2cfd59cbf00dea42613b81",
       "workstream": "WS6"
     },
     {
@@ -6192,7 +6282,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "9831e636c2025a525e608c1c03e4c6be248e6e2c",
+      "upstream_blob": "58eb449adf9f34930d78f40c50200599ebf6e21d",
       "workstream": "WS6"
     },
     {
@@ -6267,7 +6357,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "ec05b31b7359b83b30dafe51a298885e620efbd6",
+      "upstream_blob": "5f93a3820aae51723e8ad85c125ed7ea3496621f",
       "workstream": "WS6"
     },
     {
@@ -6447,7 +6537,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "b101151d9f2fb34f31fbc9cd7d8576208652cb43",
+      "upstream_blob": "de3edf2db272eb8ff61febb5094660c9f9896118",
       "workstream": "WS6"
     },
     {
@@ -6507,7 +6597,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "85a9501f06ab7da9e89e3261d161b58bed02d759",
+      "upstream_blob": "bfb70289b75d1b6b53f66b678f9c37958796e391",
       "workstream": "WS6"
     },
     {
@@ -6552,7 +6642,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "ab4c941574372db2002946ac0382c03ed16b28ba",
+      "upstream_blob": "780bf8efc5168d6530c0ea7f30e5cdbfe991abeb",
       "workstream": "WS6"
     },
     {
@@ -6717,7 +6807,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "697356f66a05c54edef2b11998442571f3740fc4",
+      "upstream_blob": "5868a0c56ff53b4e3d42a9e10a5d86983274d224",
       "workstream": "WS6"
     },
     {
@@ -6747,7 +6837,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "a39c28c3d669ae5eefb99faf263d76f10ebbda8c",
+      "upstream_blob": "18dec441ecedeef6ef23e1d4f933831466032627",
       "workstream": "WS6"
     },
     {
@@ -6792,7 +6882,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "57950d0fb61f66b7e7f325d370926a39e8c0cedb",
+      "upstream_blob": "cede492fe5bded015ab31280d9d9f773b1827f0e",
       "workstream": "WS6"
     },
     {
@@ -6807,7 +6897,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "4a06340446342d16a2b6d43a034962d82b1f41e3",
+      "upstream_blob": "0016b0e32e75062f9c81f941de1de16da6364037",
       "workstream": "WS6"
     },
     {
@@ -6897,7 +6987,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "3f5b7da420ca08d64693e2083cde1d7bc471f296",
+      "upstream_blob": "41dbcc001d3c06959ebcc0e2c090e15a88b50271",
       "workstream": "WS6"
     },
     {
@@ -6912,7 +7002,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "97ef78d4fdb11a870fe60ed9cf66a8b503991aeb",
+      "upstream_blob": "c309a328d5184f923a0fabfa9f11265e757226cb",
       "workstream": "WS6"
     },
     {
@@ -7062,7 +7152,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 302,
-      "upstream_blob": "a5da0e1143815666236a7e9710a6113d6558b3d2",
+      "upstream_blob": "b420a16047d65acc5673cc1e407ef170437d974e",
       "workstream": "WS6"
     },
     {
@@ -7122,7 +7212,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "9e5340042ee3a3d3f9b77a8d7ccc2964b27be5e1",
+      "upstream_blob": "a1e235f46e6302784a5fbafc319c179be849c3b5",
       "workstream": "WS6"
     },
     {
@@ -7242,7 +7332,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "5f2fae26c5e52cc20887e184abf88c14b954ebe9",
+      "upstream_blob": "3692fe5a12d480b861ce76509fdcc03c7126f62a",
       "workstream": "WS6"
     },
     {
@@ -7707,7 +7797,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "d357a7c89a6a187b6742b56ff7cfb1c4324eb2b7",
+      "upstream_blob": "969ff559366e3f647a33b01dc957217baca5ae22",
       "workstream": "WS6"
     },
     {
@@ -7737,7 +7827,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "37740c2ea759d08b6229f136a63f33904dae6828",
+      "upstream_blob": "06bc395214f7ee7c5645c8307555837ba3ad3dc4",
       "workstream": "WS6"
     },
     {
@@ -7752,7 +7842,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 302,
-      "upstream_blob": "435a47668780d10bb2007c22c0a4f736dd0260a5",
+      "upstream_blob": "acc41da7c46a7aa8ea89e0b0b75b697f3d6d4a82",
       "workstream": "WS6"
     },
     {
@@ -7782,7 +7872,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "3d0b0bdeb722f781b6dd3ddeb5898fa64d785bbe",
+      "upstream_blob": "b658584f30295c5d9a978a2cbde4d3e3745ad0f3",
       "workstream": "WS6"
     },
     {
@@ -7827,7 +7917,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "14e97e5c325de81ecd3be0ac8302f166f9092e8e",
+      "upstream_blob": "1ce36a1740d264bc2ab2c2aec4a6f69147cbdd8c",
       "workstream": "WS6"
     },
     {
@@ -7857,7 +7947,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "4dfd019ed68b32603eb0aebb4d90f5c3ce929150",
+      "upstream_blob": "e778a30b2ca85f33e08b4b80d4d017486a93edb9",
       "workstream": "WS6"
     },
     {
@@ -8067,7 +8157,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "7470165928f29acd2ab40a852779b13841e5809c",
+      "upstream_blob": "c2d03625dc36f77f88a3185430ff031db5888224",
       "workstream": "WS6"
     },
     {
@@ -8307,7 +8397,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "2e7a3f2de0ccb174dd1d0b68c23153d9f09fb9ed",
+      "upstream_blob": "6fbd95510ccbf90e662c4f39dae808213dc43b4a",
       "workstream": "WS6"
     },
     {
@@ -8322,7 +8412,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "3986fe712003d5b1e51c0e17d64d33a5d4c6b387",
+      "upstream_blob": "e88f04960406a06f18b6ea957faab5f84ac2fc8b",
       "workstream": "WS6"
     },
     {
@@ -8420,6 +8510,21 @@
       "classification": "intentional_divergence",
       "classification_path": "tests/hermes_cli",
       "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "cb6275af09302c89437f8c6d5c6752d5781b8a17",
+      "necessity": "approved_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/hermes_cli/test_model_switch_context_display.py",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 25,
+      "upstream_blob": "b30ed9024fdc75d27f4e96c51998c7acf9fd2ecb",
+      "workstream": "WS6"
+    },
+    {
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/hermes_cli",
+      "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "84734e622d5f44ceaf577b8d16fdfeac40d524ef",
       "necessity": "approved_divergence",
       "owner": "sheawinkler",
@@ -8427,7 +8532,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "bfffa0474debfa17db4985a6d0484ecc87e9a1c1",
+      "upstream_blob": "4d80469b975b773256ecf12e1c7b1dd4288976f8",
       "workstream": "WS6"
     },
     {
@@ -8682,7 +8787,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "91a13dd761a466ea60fc0f1e6b2ee0ec98e59c13",
+      "upstream_blob": "c61bc36dd4be5cc6502178de98fa7007e246f91c",
       "workstream": "WS6"
     },
     {
@@ -8712,7 +8817,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "43b9cb38121d5dfe2ec1ef696bbcc27c752ab886",
+      "upstream_blob": "e8892ae7846a0e728c08e15bd70dfdc9a5468980",
       "workstream": "WS6"
     },
     {
@@ -8788,6 +8893,21 @@
       "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "833729973ae55410fe8a807cface404ae67ca76d",
+      "workstream": "WS6"
+    },
+    {
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/hermes_cli",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "7b3b8a9add25bb619ccfb4bcb6d20737b34afe55",
+      "necessity": "approved_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/hermes_cli/test_sessions_delete.py",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 25,
+      "upstream_blob": "0c54da1cf15b47211c4b006983f9a8fe3ddc5823",
       "workstream": "WS6"
     },
     {
@@ -9252,7 +9372,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "2b6305ac8a30cfabb94f01a92bea20bd027f1a81",
+      "upstream_blob": "34de95b826d2fd46989299194254a376586901b8",
       "workstream": "WS6"
     },
     {
@@ -9357,7 +9477,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "7797be6317777350b67056099edea7146f7ece44",
+      "upstream_blob": "18f5facbb6b64c808d3f43c839dbc7185cd9616b",
       "workstream": "WS6"
     },
     {
@@ -9515,6 +9635,21 @@
       "classification": "intentional_divergence",
       "classification_path": "tests/integration",
       "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "85565ae6e49cf8893f23c82b730a5bbf74b398d4",
+      "necessity": "approved_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/integration/test_batch_runner.py",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 25,
+      "upstream_blob": "793006062397da60fc153b93c64fd3f2bef0555e",
+      "workstream": "WS6"
+    },
+    {
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/integration",
+      "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "a5b1a2aa99ff4549cf124963739ef395da094f37",
       "necessity": "approved_divergence",
       "owner": "sheawinkler",
@@ -9522,7 +9657,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "739f0452fe3f273296efc4f7014ead6a55797c4a",
+      "upstream_blob": "5a4820a88a4e22f3050122da472902a7c0de676a",
       "workstream": "WS6"
     },
     {
@@ -9538,6 +9673,21 @@
       "status": "cleared_intentional_divergence",
       "ticket": 25,
       "upstream_blob": "4b619816972734f0c2855644b4cca4bdf1c0bd8b",
+      "workstream": "WS6"
+    },
+    {
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/integration",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "a4fc26996d5b9dd0aacfed9af57e0863d266dd7e",
+      "necessity": "approved_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/integration/test_modal_terminal.py",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 25,
+      "upstream_blob": "40c7164ffdce9f684164bffb807f1e8891212116",
       "workstream": "WS6"
     },
     {
@@ -9567,7 +9717,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "6be64b6b2a62a427efcd9edc315167d57f9aabfa",
+      "upstream_blob": "11fade5ee16f0e977dca63c3999b92d3945a5238",
       "workstream": "WS6"
     },
     {
@@ -9657,7 +9807,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "f8991e3e76680bfc2d4237cf7764c8fb0acf1b29",
+      "upstream_blob": "98a99755bfcb8433bd0242807e7679d2426d480c",
       "workstream": "WS6"
     },
     {
@@ -9747,7 +9897,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "92815553922da619a5c46acf42182e687d9b6fd8",
+      "upstream_blob": "028bf59efbe40da77ca055a1d2207d2d4a6e63b5",
       "workstream": "WS6"
     },
     {
@@ -10182,7 +10332,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "494a4919e88d2b70e6b9d10d97bcec98755f6e4e",
+      "upstream_blob": "408db5e5f34ac4239bf0e2336914de5086321b3f",
       "workstream": "WS6"
     },
     {
@@ -10302,7 +10452,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "27d3bff91c0594cd8c8c3fed2176e5e3a9e45df4",
+      "upstream_blob": "78975a7395af6227a01aa4f955fc917699335003",
       "workstream": "WS6"
     },
     {
@@ -10437,7 +10587,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "93e65193756db5b9b936720dde638b0bf506761b",
+      "upstream_blob": "816af59fd891f9a4a4caf7a6ea0f3df52c5e98c6",
       "workstream": "WS6"
     },
     {
@@ -10482,7 +10632,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "7285cb1f625c902cc3c7f434a70f3444dbafab88",
+      "upstream_blob": "2c7e53e13497706fa0b35121e2adebfdd5f187a3",
       "workstream": "WS6"
     },
     {
@@ -10602,7 +10752,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "575a9700ac30e7a0f9151202be706622f2ee62d9",
+      "upstream_blob": "da8a446bf8d8aee905b7383c1cdcf506ebfe2eb0",
       "workstream": "WS6"
     },
     {
@@ -10617,7 +10767,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "1d355c65543667811de5b005b74c3fdfbc10f4d0",
+      "upstream_blob": "0c24adc4ed6c8c5167de648aeaa67e18614a68db",
       "workstream": "WS6"
     },
     {
@@ -10782,7 +10932,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "e5bbdd93d808b1400f86a8032ffd899bdf949af7",
+      "upstream_blob": "5b80fea40654713bbf988ab9eeef3ffd435e5c08",
       "workstream": "WS6"
     },
     {
@@ -10962,7 +11112,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "d667a97a7cbdd64f05334ede8e13f91f7564ac6b",
+      "upstream_blob": "936dbaf5baf61f37051891081a68771559c8bb19",
       "workstream": "WS6"
     },
     {
@@ -10977,7 +11127,22 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "f5695e4bde13b3ac1e673eadeef14bdc787c54c2",
+      "upstream_blob": "80d9183003a527eef6a22501cb7ebfae982ea895",
+      "workstream": "WS6"
+    },
+    {
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/stress",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "b468cd957ef648d5c2789e963f93311e68e686df",
+      "necessity": "approved_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/stress/test_concurrency_reclaim_race.py",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 25,
+      "upstream_blob": "6a636de72efa66f2f7b503fa9fa5aee8a12a7871",
       "workstream": "WS6"
     },
     {
@@ -11157,7 +11322,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "f23bed43ab8a0115c3def52bbaa90c15f0b24e97",
+      "upstream_blob": "e4b064ed947ed5587c21ca0b5fd978f304e63c95",
       "workstream": "WS6"
     },
     {
@@ -11172,7 +11337,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "ca0b13ff5dab33f938e28c19f1c989dac9b1fa33",
+      "upstream_blob": "6d05def051f431069c7d6ace03282106b627ea00",
       "workstream": "WS6"
     },
     {
@@ -11187,7 +11352,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "eb884129bc56f4904fbf2711824c9db3d7becdc2",
+      "upstream_blob": "4ad888442afcfe327565776ebb06ee9391c9da29",
       "workstream": "WS6"
     },
     {
@@ -11307,7 +11472,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "0ae403370d69b0b32f2d90616ba5887b6f05fe0c",
+      "upstream_blob": "9c002925b20ce9fa1d1b6f494895daeaa4c20783",
       "workstream": "WS6"
     },
     {
@@ -11352,7 +11517,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "9eff5c5b2d334251f55a0a2e7db5e6da81176e4b",
+      "upstream_blob": "469b8a6921e9594fb3ee1ea2c69e6eb77f7fabf9",
       "workstream": "WS6"
     },
     {
@@ -11457,7 +11622,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "ff08d3a40625101817adf358d9012c85f09fd9c7",
+      "upstream_blob": "49bdb09ec0ba68ffc721819134c99976b2abc848",
       "workstream": "WS6"
     },
     {
@@ -11532,7 +11697,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "f9e4969b7beaaa649c0beaa0b87916f820eec326",
+      "upstream_blob": "3f99554561ea84dbdc0045e7500abc9e8701cad7",
       "workstream": "WS6"
     },
     {
@@ -11592,7 +11757,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "6d39a252cfe9bc1d8bf27364b75aa0283f141922",
+      "upstream_blob": "3286363dfd23f76f7776909afd2f8cb936113c14",
       "workstream": "WS6"
     },
     {
@@ -11622,7 +11787,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "53613abd1ec908548e04911b874175403d04c050",
+      "upstream_blob": "d55dad7e007f94b92771024549b44384817c15cc",
       "workstream": "WS6"
     },
     {
@@ -11667,7 +11832,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "ec0406c9eba8d462da4cf204e4dbbc8f0fc5e5a1",
+      "upstream_blob": "e364dcd3be0b00f6282a4f6064bc144bc8532f53",
       "workstream": "WS6"
     },
     {
@@ -11712,7 +11877,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "8d6e6ab7328847a6096b3167703b58797c159de4",
+      "upstream_blob": "d629d95ea29997f8010cdf4629ce480941bc88e5",
       "workstream": "WS6"
     },
     {
@@ -12087,7 +12252,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "85f62e4e3c788a2a3bb06a9643cd669bddaa23c0",
+      "upstream_blob": "9f4a6a5ca051396c16ae6f7b4b40dd414e79bad7",
       "workstream": "WS6"
     },
     {
@@ -12267,7 +12432,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "ac94ce5e75168226c19531bbd7d5a76afb722468",
+      "upstream_blob": "2a7d2793aaaf0ba58c933f02abe6048ac9d51691",
       "workstream": "WS6"
     },
     {
@@ -12387,7 +12552,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "861ebc4936f22a3d4883ea3f2a9b1b95e77a7e15",
+      "upstream_blob": "23aa53d2b1408ba0f02775d5fb4416ccb60afd27",
       "workstream": "WS6"
     },
     {
@@ -12507,7 +12672,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "e084e61fe8f4e19daf9f1b83eac750236a4fa94b",
+      "upstream_blob": "38f9d4d7a842996cd2286b274e76f52f616ebc93",
       "workstream": "WS6"
     },
     {
@@ -12597,7 +12762,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "5d614f62bc54053aad957f0ceabf8f9b5d4dd00a",
+      "upstream_blob": "8c71f10ffd97d4842f79ad9fd9ecb57f589eb17a",
       "workstream": "WS6"
     },
     {
@@ -12777,7 +12942,22 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "4f5a89477d05ec1dadfa7400c3d5cc10bfc60ee0",
+      "upstream_blob": "116af9397cdfa80a8867215477eb6e343e9f89b5",
+      "workstream": "WS6"
+    },
+    {
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "tests/tools",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "c9adf545ed5ca92b25d670314800f115ddbff6ea",
+      "necessity": "approved_divergence",
+      "owner": "sheawinkler",
+      "path": "tests/tools/test_mcp_dynamic_discovery.py",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 25,
+      "upstream_blob": "f7eac572b8db32f8b45629a172122dd59fe9e956",
       "workstream": "WS6"
     },
     {
@@ -12822,7 +13002,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "b5265b6adb9f2cad4dfe8e3664c48a1999e0ad72",
+      "upstream_blob": "8f3f58ca9fbacce22c1292a60373e2e18cf09d1c",
       "workstream": "WS6"
     },
     {
@@ -12882,7 +13062,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "494ebbbe024ffbafea656b7a084b8b99f7a4f368",
+      "upstream_blob": "796dbed913d20aba49b229962653664b132841f4",
       "workstream": "WS6"
     },
     {
@@ -12912,7 +13092,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "9b130268181b7535cc31f0f3499cf06c9b35a26c",
+      "upstream_blob": "eeeeef7e48cbd087e0f2b9cef7e228d5a1d228bc",
       "workstream": "WS6"
     },
     {
@@ -12942,7 +13122,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "b17e6484aabd876871607737f003bd2d2d866420",
+      "upstream_blob": "6a693d5aaf89f1ec6017f201f351062285dd198b",
       "workstream": "WS6"
     },
     {
@@ -12972,7 +13152,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "a7c822cb18db0f3aad38ca15e36abda123c5ed13",
+      "upstream_blob": "c2903f375c6d36613c225789462451059473fd0e",
       "workstream": "WS6"
     },
     {
@@ -13137,7 +13317,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "360457de2b2aa7c873532fefbe683dc9ff42e299",
+      "upstream_blob": "90a6ffa3c048b7d9e799b94ff8dc33ce6957f269",
       "workstream": "WS6"
     },
     {
@@ -13182,7 +13362,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "5d28b8b2065ae55cbbc12106f02ccc8b2dc0c071",
+      "upstream_blob": "ed04233226326218f1b725abef333cbfc7adc755",
       "workstream": "WS6"
     },
     {
@@ -13362,7 +13542,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "2c807e5846607ccf9a8f35da27b7c57e0f0150d0",
+      "upstream_blob": "a4c244de033f1955e7a930b88f587e7b08ffbda6",
       "workstream": "WS6"
     },
     {
@@ -13377,7 +13557,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "987995066ff8ebd0694b81f3c9e8be8027e2b344",
+      "upstream_blob": "b1310e8535984ecc248d0305f95892a8591867cb",
       "workstream": "WS6"
     },
     {
@@ -13587,7 +13767,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "aac71feccc4074c9af916f4a4a58b6c5280fb152",
+      "upstream_blob": "8182a46b729f487858e1f798de72ada911329407",
       "workstream": "WS6"
     },
     {
@@ -13842,7 +14022,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "1745d98d026df42ae1dbfea7169dddad5fab89c8",
+      "upstream_blob": "b3386f092a6faefdce39726ef81b92712aac805f",
       "workstream": "WS6"
     },
     {
@@ -13857,7 +14037,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "1294ab8f55813b1b4a1491f05e47480fed4b38e6",
+      "upstream_blob": "35da27d260562c27e6855bc1049229f5f7c31d67",
       "workstream": "WS6"
     },
     {
@@ -13872,7 +14052,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "bb396c05dc36dd17b31b92e87398001eff6530b8",
+      "upstream_blob": "d66b52aec365fc9239cc26da588a0f3d622199e4",
       "workstream": "WS6"
     },
     {
@@ -13887,7 +14067,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "73cc672a6ed31adac9076c7b8f2cf4976c58fe6d",
+      "upstream_blob": "571560339781870b9298de61d583581c42687b10",
       "workstream": "WS6"
     },
     {
@@ -13902,7 +14082,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "f43eb97c96de99ae7f2a8330097c126fb4f09dc5",
+      "upstream_blob": "dc6f2061f2c7842982c90348277132a00289d946",
       "workstream": "WS6"
     },
     {
@@ -13947,7 +14127,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 306,
-      "upstream_blob": "f71b1f3b7d8ac26460b0f3262486aad3d95e015b",
+      "upstream_blob": "8a62093b0a7d97eddeecb54899a3511537dc5217",
       "workstream": "WS6"
     },
     {
@@ -14007,7 +14187,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 306,
-      "upstream_blob": "6466e615f04b4dbf379dea1a83ac72276248a020",
+      "upstream_blob": "535f930e0808d19e5393188f34aa52ed26d50141",
       "workstream": "WS6"
     },
     {
@@ -14697,7 +14877,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "c0487fad0536de17d1c67b528ff73c9c32b6d30e",
+      "upstream_blob": "ca1af4cd9abedcfd60bb646f028e6ca610e9c7f7",
       "workstream": "WS5"
     },
     {
@@ -15072,7 +15252,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "65285467d9afc89bfd9e984afa94e7a9219f3578",
+      "upstream_blob": "85586f66aaa7f7dcf1b982aef43b4dc720060903",
       "workstream": "WS5"
     },
     {
@@ -15132,7 +15312,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "94e1b38c5de48316a7d690631d69e333236be96d",
+      "upstream_blob": "6b1fe55481bc2d8234239e356b4934ac19d708c9",
       "workstream": "WS5"
     },
     {
@@ -15357,7 +15537,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "9ab568f32ea6dd58cfed53063a75a4b597b0e46f",
+      "upstream_blob": "24b45d33e2480699ef0e3fe919b03983f5c38d80",
       "workstream": "WS5"
     },
     {
@@ -15432,7 +15612,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "c36a1505908df35bbe3474935f5105b0913f23ed",
+      "upstream_blob": "8752dd371a23a5335746c361012d7e4654c5309f",
       "workstream": "WS5"
     },
     {
@@ -16092,7 +16272,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "0fe6d795ae479a39d9bdeb3baba26cae082b881a",
+      "upstream_blob": "975bdaca0603d6f961da0cbaff63f8a40f95ff00",
       "workstream": "WS5"
     },
     {
@@ -16122,7 +16302,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "f3698f8e52a302d382a2a9e44982ca5a7bcdd3e4",
+      "upstream_blob": "6d6ec8695ae4739184d9433c24552509734483f3",
       "workstream": "WS5"
     },
     {
@@ -16130,7 +16310,7 @@
       "classification": "policy_only",
       "classification_path": "website/docs",
       "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "ba26d579bbbbefcf34cfb8cd3e886437badb3515",
+      "local_blob": "06257602a8d77f5d4944ea9519373d04d8ef0940",
       "necessity": "not_runtime_required",
       "owner": "sheawinkler",
       "path": "website/docs/developer-guide/browser-supervisor.md",
@@ -16152,7 +16332,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "93240a486c007ccc49f248ae0ab169e37c4b8d1c",
+      "upstream_blob": "aa817190c1746365b35a64af02357bd35936ff9e",
       "workstream": "WS5"
     },
     {
@@ -16182,7 +16362,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "e61100a609d3dc3eb242b5d0ca81a7db9152d4d2",
+      "upstream_blob": "52ec92d28ad46ba56ec94d73a34c1593dd663cb0",
       "workstream": "WS5"
     },
     {
@@ -16242,7 +16422,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "b746ce82229cfe73b0e204b11259608453b23d62",
+      "upstream_blob": "66179cfa5c0b69ef30952582642ddd22254c917e",
       "workstream": "WS5"
     },
     {
@@ -16272,7 +16452,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "f12ed3abf3365e77a5f1cb559e21a580538c1773",
+      "upstream_blob": "6c20a66be425554da70c142cf08e78f9a21bff00",
       "workstream": "WS5"
     },
     {
@@ -16362,7 +16542,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "619e2010394ad9c1564a5f44f2be3ec22503ce6e",
+      "upstream_blob": "a643267637a00f9796cb46bd54b0f27c96cf1809",
       "workstream": "WS5"
     },
     {
@@ -16490,21 +16670,6 @@
       "classification": "policy_only",
       "classification_path": "website/docs",
       "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "cda37809a691e9af5831da33557ea7b691058ab8",
-      "necessity": "not_runtime_required",
-      "owner": "sheawinkler",
-      "path": "website/docs/guides/build-a-hermes-plugin.md",
-      "rust_requirement": "not_required_for_runtime",
-      "status": "cleared_non_runtime",
-      "ticket": 25,
-      "upstream_blob": "90361a76348dbbb3afdc948ea55d2a241d3bbb5c",
-      "workstream": "WS5"
-    },
-    {
-      "action": "No runtime implementation; keep rationale current.",
-      "classification": "policy_only",
-      "classification_path": "website/docs",
-      "existing_coverage": "claimed_by_shared_diff_classification",
       "local_blob": "5863412f565780ba9554facdcb858d65b8b076c1",
       "necessity": "not_runtime_required",
       "owner": "sheawinkler",
@@ -16572,7 +16737,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "b5fe0a525b28b99fd66cb2995840eed7bf7cb424",
+      "upstream_blob": "f45684973bd45028efc2c8e2291998a024705b71",
       "workstream": "WS5"
     },
     {
@@ -16707,7 +16872,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "ea7670ace5056b51d9403bdbc1e1ba2e6bb68cce",
+      "upstream_blob": "fd4501080a0d5e045a32818faa3209ac9b5e8606",
       "workstream": "WS5"
     },
     {
@@ -16767,7 +16932,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "f3f3666e2c41718e56e2ce4a9d00aa4a369f505e",
+      "upstream_blob": "8c0551a5af1773eb85abb522fd8b3ace19d3aeb5",
       "workstream": "WS5"
     },
     {
@@ -16782,7 +16947,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "331558924e0278e8d0473cb693bd3a68d365c874",
+      "upstream_blob": "f191ff146d11b28a680fbac38a6d4c1db08a25b7",
       "workstream": "WS5"
     },
     {
@@ -16797,7 +16962,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "e3389b33abda0a22fb6092777ea2330ec78ea69a",
+      "upstream_blob": "90bd0a4042a61cba4c83858f91a9307e11424d29",
       "workstream": "WS5"
     },
     {
@@ -16827,7 +16992,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "2f35858ef04d1538cbe5e3a1768c2efa56666997",
+      "upstream_blob": "b8ace5b1912a3173b3b9bcfba1817a318568160d",
       "workstream": "WS5"
     },
     {
@@ -16842,7 +17007,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "9f4aa214453995ecfecacf51eeca938332ad2e5a",
+      "upstream_blob": "b7df6823837c03a6b8de91715c8f95460e7e3d7f",
       "workstream": "WS5"
     },
     {
@@ -16857,7 +17022,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "bddaf8b2ad48723c58dc8a0c6f7b8741b593b761",
+      "upstream_blob": "ad9a7140fd64ef51458d7b2d64704409739ae695",
       "workstream": "WS5"
     },
     {
@@ -16872,7 +17037,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "e7a35a5878bb4bda113ba75e6f2f85a507b19735",
+      "upstream_blob": "2809f709f2eabb4f4b68482fd3de9f9d25431ef7",
       "workstream": "WS5"
     },
     {
@@ -16947,7 +17112,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "1f4254667ca3ad73d1ed0c3f60512159d70fdd16",
+      "upstream_blob": "8b5786de5a553f449c52bf49b4bed211ab394ec3",
       "workstream": "WS5"
     },
     {
@@ -17007,7 +17172,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "0bcda2138a4590f56390c0cd11f56253686c702a",
+      "upstream_blob": "46afc11bcfd259fb5d207190e13567c700fe3344",
       "workstream": "WS5"
     },
     {
@@ -17022,7 +17187,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "f73d2b287696bbe295757a91198788a50f48e6f9",
+      "upstream_blob": "ec789c9c96e0a66eee406523983539be434303d4",
       "workstream": "WS5"
     },
     {
@@ -17112,7 +17277,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "b4c1d5ef080474e7f3f350b579b1905727e8032b",
+      "upstream_blob": "722105fcf67a00890ccb351c9d8e4400725c570e",
       "workstream": "WS5"
     },
     {
@@ -17172,7 +17337,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "80700057008af140fdfba05d9e10f43ddf41e7ea",
+      "upstream_blob": "5d8503b3a79106ca8ce4bc643683073a54c598c8",
       "workstream": "WS5"
     },
     {
@@ -17247,7 +17412,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "05629af590fce198cff9ed583afd7fb90fb76ce4",
+      "upstream_blob": "ff6cbf6f9ef04c68c6e941e0e208fc2a9dd84e0b",
       "workstream": "WS5"
     },
     {
@@ -17292,7 +17457,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "4a2fc06860619c0e1a7a3cc6ec74e8103317909c",
+      "upstream_blob": "224d20198b3039d358c2c42c57a1b25889f597d0",
       "workstream": "WS5"
     },
     {
@@ -17382,7 +17547,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "a2f5352e621cafbaf1170581ae9e185c24aa06a2",
+      "upstream_blob": "1c6ebf7c43f36b36a2e8989383b9b0bb70d81282",
       "workstream": "WS5"
     },
     {
@@ -17442,7 +17607,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "f543b5610a2ca8496ca746f71908c109dc60098c",
+      "upstream_blob": "ed8012325b6e52eb230288de55ec6511f5f4044c",
       "workstream": "WS5"
     },
     {
@@ -17472,7 +17637,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "18dd93c1262407d5551c274b64c1d04ea7bd3f1c",
+      "upstream_blob": "19fffb1f1b23727f8d13cd42ac7986716ad1cf93",
       "workstream": "WS5"
     },
     {
@@ -17555,7 +17720,7 @@
       "classification": "policy_only",
       "classification_path": "website/docs",
       "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "51cfe57bd1004aa10087c65c8d63ac11f2867a4b",
+      "local_blob": "e1a60d9fd5db54fec456c6e74e6159c682c21499",
       "necessity": "not_runtime_required",
       "owner": "sheawinkler",
       "path": "website/docs/user-guide/features/vision.md",
@@ -17577,7 +17742,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "f32d96d151c45dc3d8ca61ee1ef438e2f2caa7d2",
+      "upstream_blob": "14a4235e3e7cdeda4a580faab2ef6fa1b3776342",
       "workstream": "WS5"
     },
     {
@@ -17667,7 +17832,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "2ee4d9aaa2ec05030e4ab428a9224a4de3ceb94c",
+      "upstream_blob": "030e69681e5e64a22e431e9049aea7ae98f76e2f",
       "workstream": "WS5"
     },
     {
@@ -17742,7 +17907,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "0e9327f27028cd1b3a85b9ea17ad5e21fe5f15f6",
+      "upstream_blob": "8011191c89ff96b0f0d835d4e8175194ab3aee35",
       "workstream": "WS5"
     },
     {
@@ -17840,7 +18005,7 @@
       "classification": "policy_only",
       "classification_path": "website/docs",
       "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "acb607cfebe075b99b9512d23b51a9849ae9809e",
+      "local_blob": "c77f5b71e83f6d75b0d09f9f55811a1826c3d380",
       "necessity": "not_runtime_required",
       "owner": "sheawinkler",
       "path": "website/docs/user-guide/messaging/signal.md",
@@ -17937,7 +18102,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "98e8d06605641735fc9ba2a462eb3cf031248865",
+      "upstream_blob": "0a8296f0dc563cde0b25c2402de126ee5fba546f",
       "workstream": "WS5"
     },
     {
@@ -18057,7 +18222,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "c48c6db6b9d233c04bbd85041250af6c1c703cac",
+      "upstream_blob": "60eec972e281462bf039baad679537f45264ba3a",
       "workstream": "WS5"
     },
     {
@@ -18072,7 +18237,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "b1d6c903c4af65fb934f0634470ebda4250c0e87",
+      "upstream_blob": "e2ae75ea7d4adc977c6f7bde80b5d630a29a21ac",
       "workstream": "WS5"
     },
     {
@@ -18515,7 +18680,7 @@
       "classification": "policy_only",
       "classification_path": "website/docs",
       "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "5b424f3adc776f76b0fd619c0c94e5006189c661",
+      "local_blob": "87c924f7d899e2e9d2301d6077fd1f91de6b0e03",
       "necessity": "not_runtime_required",
       "owner": "sheawinkler",
       "path": "website/docs/user-guide/skills/bundled/software-development/software-development-test-driven-development.md",
@@ -18792,7 +18957,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "6b2e35aa86454779c75f1a5f7c4b248ebc51d85e",
+      "upstream_blob": "6243170a6b9169a66bf560959a2885db149e5b5b",
       "workstream": "WS5"
     },
     {
@@ -18912,7 +19077,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "b012354a532e97cc3223a82a7d884e72724a6963",
+      "upstream_blob": "1843a924eb76583bf5453b4076656a8ba1594fed",
       "workstream": "WS5"
     },
     {
@@ -18950,7 +19115,7 @@
       "classification": "policy_only",
       "classification_path": "website/src",
       "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "651589426ed1388a3d707c21bb1e86e36b33a98e",
+      "local_blob": "f8935aac02b545acebd70c028257f20fa0794395",
       "necessity": "not_runtime_required",
       "owner": "sheawinkler",
       "path": "website/src/data/userStories.json",
@@ -19021,37 +19186,37 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-07-04T06:47:44.628337+00:00",
+  "generated_at_utc": "2026-07-07T21:51:25.017721+00:00",
   "refs": {
     "local_ref": "HEAD",
-    "local_sha": "c905df14be39b3f43623d2ec17f98c587ea97a83",
+    "local_sha": "8c58db72e5e53c349a77cd59efe3e5b86b001adf",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "5445e42b87b9918d5b1bfa9f4eadd8e4bb10ff37"
+    "upstream_sha": "5e51b123f32b7f6a51fbd5759e89ba5146ce4003"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "intentional_divergence": 1043,
-      "policy_only": 224
+      "intentional_divergence": 1055,
+      "policy_only": 223
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 1268
+      "not_required_for_runtime": 1279
     },
     "by_status": {
-      "cleared_intentional_divergence": 1043,
-      "cleared_non_runtime": 225
+      "cleared_intentional_divergence": 1055,
+      "cleared_non_runtime": 224
     },
     "by_workstream": {
-      "WS3": 98,
-      "WS4": 38,
-      "WS5": 322,
-      "WS6": 791,
+      "WS3": 102,
+      "WS4": 39,
+      "WS5": 321,
+      "WS6": 798,
       "WS8": 19
     },
-    "cleared_intentional_divergence": 1043,
-    "cleared_non_runtime": 225,
+    "cleared_intentional_divergence": 1055,
+    "cleared_non_runtime": 224,
     "pending_classification": 0,
     "pending_review": 0,
-    "total_shared_different": 1268
+    "total_shared_different": 1279
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,30 +1,30 @@
 # Shared-Different Backlog
 
-Generated: `2026-07-04T06:47:44.628337+00:00`
+Generated: `2026-07-07T21:51:25.017721+00:00`
 
 ## Summary
 
-- Total shared-different paths: `1268`
+- Total shared-different paths: `1279`
 - Pending classification: `0`
 - Pending functional review: `0`
-- Cleared non-runtime: `225`
-- Cleared intentional divergence: `1043`
+- Cleared non-runtime: `224`
+- Cleared intentional divergence: `1055`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 1043 |
-| `cleared_non_runtime` | 225 |
+| `cleared_intentional_divergence` | 1055 |
+| `cleared_non_runtime` | 224 |
 
 ## Workstream Counts
 
 | Workstream | Count |
 | --- | ---: |
-| `WS3` | 98 |
-| `WS4` | 38 |
-| `WS5` | 322 |
-| `WS6` | 791 |
+| `WS3` | 102 |
+| `WS4` | 39 |
+| `WS5` | 321 |
+| `WS6` | 798 |
 | `WS8` | 19 |
 
 ## Pending Classification

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -478,6 +478,13 @@
       "ticket": 25
     },
     {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/memory/retaindb/__init__.py",
+      "rationale": "RetainDB runtime behavior is owned by the Rust RetainDbMemoryPlugin: core profile/search/context/remember/forget tools, shared file-store upload/list/read/ingest/delete tools, SOUL.md agent seeding, context plus user-synthesis/self-model prefetch, and durable SQLite queued turn ingest are implemented and covered by focused hermes-agent tests; the Python plugin remains reference-only in the Rust runtime.",
+      "ticket": 25
+    },
+    {
       "classification": "policy_only",
       "owner": "sheawinkler",
       "path": "plugins/memory/byterover/__init__.py",
@@ -937,6 +944,27 @@
       "owner": "sheawinkler",
       "path": "plugins/web",
       "rationale": "Web-search plugin differences affect provider routing, credential handling, and tool result behavior.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/web/brave_free/provider.py",
+      "rationale": "Brave free web search is implemented by Rust BraveFreeSearchBackend with BRAVE_SEARCH_API_KEY gating, free endpoint routing, X-Subscription-Token auth, count clamping, result normalization, explicit/generic backend aliases, auto-detect, and search-only extract/crawl error routing covered by web backend tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/web/exa/provider.py",
+      "rationale": "Exa search and extraction are implemented by Rust ExaSearchBackend and ExaExtractBackend with EXA_API_KEY/EXA_BASE_URL config, /search and /contents request contracts, source-quality result normalization, explicit/generic extract routing, auto-detect, and focused mocked web backend tests; the Python SDK plugin remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/web/parallel/provider.py",
+      "rationale": "Parallel search and extraction are implemented by Rust ParallelWebBackend with PARALLEL_API_KEY/PARALLEL_BASE_URL/PARALLEL_SEARCH_MODE config, /v1/search and /v1/extract REST payloads, full-content extraction, result/error normalization, explicit/generic backend routing, auto-detect, and focused mocked web backend tests; the Python SDK plugin remains reference-only.",
       "ticket": 25
     },
     {

--- a/docs/parity/test-coverage-audit.json
+++ b/docs/parity/test-coverage-audit.json
@@ -16,7 +16,7 @@
       "kind": "nonzero_tree_drift",
       "message": "max_files_only_upstream remains nonzero in parity matrix",
       "metric": "max_files_only_upstream",
-      "value": 3319.0
+      "value": 3422.0
     }
   ],
   "audit_gate": {
@@ -56,26 +56,26 @@
   ],
   "coverage_manifests": [
     {
-      "entries": 214,
+      "entries": 219,
       "missing_rust_test_refs": [],
       "missing_rust_tests_entries": [],
       "path": "docs/parity/python-test-suite-coverage.json",
-      "referenced_rust_tests": 107,
+      "referenced_rust_tests": 123,
       "status_counts": {
-        "covered_by_rust_test_suite_contracts": 214
+        "covered_by_rust_test_suite_contracts": 219
       },
-      "valid_entries_with_rust_tests": 214
+      "valid_entries_with_rust_tests": 219
     },
     {
-      "entries": 124,
+      "entries": 126,
       "missing_rust_test_refs": [],
       "missing_rust_tests_entries": [],
       "path": "docs/parity/hermes-cli-test-coverage.json",
-      "referenced_rust_tests": 83,
+      "referenced_rust_tests": 90,
       "status_counts": {
-        "covered_by_rust_contracts": 124
+        "covered_by_rust_contracts": 126
       },
-      "valid_entries_with_rust_tests": 124
+      "valid_entries_with_rust_tests": 126
     },
     {
       "entries": 122,
@@ -90,7 +90,7 @@
     }
   ],
   "critical_gaps": [],
-  "generated_at_utc": "2026-07-04T06:47:43.205545+00:00",
+  "generated_at_utc": "2026-07-07T21:51:23.613081+00:00",
   "intent_domains": [
     {
       "classification": "direct_rust_test",
@@ -156,7 +156,7 @@
     },
     {
       "classification": "direct_rust_test",
-      "direct_test_evidence_count": 98,
+      "direct_test_evidence_count": 100,
       "direct_test_evidence_sample": [
         "crates/hermes-tools/src/approval.rs",
         "crates/hermes-tools/src/approval/tests.rs",
@@ -184,7 +184,7 @@
         "crates/hermes-tools/src/backends/vision.rs",
         "crates/hermes-tools/src/backends/web.rs"
       ],
-      "evidence_count": 120,
+      "evidence_count": 122,
       "evidence_sample": [
         "crates/hermes-tools/src/approval.rs",
         "crates/hermes-tools/src/approval/patterns.rs",
@@ -221,7 +221,7 @@
     },
     {
       "classification": "direct_rust_test",
-      "direct_test_evidence_count": 45,
+      "direct_test_evidence_count": 47,
       "direct_test_evidence_sample": [
         "crates/hermes-app-runtime/src/lib.rs",
         "crates/hermes-app-runtime/src/lib_tests.rs",
@@ -239,15 +239,15 @@
         "crates/hermes-cli/src/cli.rs",
         "crates/hermes-cli/src/cli/tests.rs",
         "crates/hermes-cli/src/cloudflare.rs",
+        "crates/hermes-cli/src/commands/command_cli_plugins_memory_mcp.rs",
+        "crates/hermes-cli/src/commands/command_cli_plugins_memory_mcp/memory_setup.rs",
         "crates/hermes-cli/src/commands/command_tests.rs",
         "crates/hermes-cli/src/commands/mod.rs",
         "crates/hermes-cli/src/commands/tests/promoted_commands.rs",
         "crates/hermes-cli/src/commands/tests/runtime_parity_ops.rs",
         "crates/hermes-cli/src/commands/tests/skill_model_policy.rs",
         "crates/hermes-cli/src/commands/tests/surface_and_compression.rs",
-        "crates/hermes-cli/src/config_env.rs",
-        "crates/hermes-cli/src/kanban.rs",
-        "crates/hermes-cli/src/lumio.rs"
+        "crates/hermes-cli/src/config_env.rs"
       ],
       "evidence_count": 178,
       "evidence_sample": [
@@ -401,8 +401,10 @@
     },
     {
       "classification": "direct_rust_test",
-      "direct_test_evidence_count": 14,
+      "direct_test_evidence_count": 16,
       "direct_test_evidence_sample": [
+        "crates/hermes-cli/src/commands/command_cli_plugins_memory_mcp.rs",
+        "crates/hermes-cli/src/commands/command_cli_plugins_memory_mcp/memory_setup.rs",
         "crates/hermes-cli/src/commands/command_tests.rs",
         "crates/hermes-cli/src/commands/mod.rs",
         "crates/hermes-cli/src/commands/tests/promoted_commands.rs",
@@ -456,8 +458,10 @@
     },
     {
       "classification": "direct_rust_test",
-      "direct_test_evidence_count": 14,
+      "direct_test_evidence_count": 16,
       "direct_test_evidence_sample": [
+        "crates/hermes-cli/src/commands/command_cli_plugins_memory_mcp.rs",
+        "crates/hermes-cli/src/commands/command_cli_plugins_memory_mcp/memory_setup.rs",
         "crates/hermes-cli/src/commands/command_tests.rs",
         "crates/hermes-cli/src/commands/mod.rs",
         "crates/hermes-cli/src/commands/tests/promoted_commands.rs",
@@ -620,21 +624,21 @@
     "upstream_missing_queue": "docs/parity/upstream-missing-queue.json"
   },
   "summary": {
-    "coverage_manifest_entries": 460,
-    "coverage_manifest_entries_with_valid_rust_tests": 460,
-    "covered_behavior_rows": 470,
+    "coverage_manifest_entries": 467,
+    "coverage_manifest_entries_with_valid_rust_tests": 467,
+    "covered_behavior_rows": 477,
     "divergence_errors": 0,
     "divergence_review_overdue": 0,
     "divergence_unowned": 0,
     "missing_rust_test_refs": 0,
     "queue_pending": 0,
     "queue_total": 1,
-    "rust_test_files": 418,
-    "rust_test_functions": 7270,
+    "rust_test_files": 422,
+    "rust_test_functions": 7391,
     "test_intent_mapping_ratio": 1.0,
     "test_intents_mapped": 10,
     "test_intents_total": 10,
     "tracked_behavior_coverage_ratio": 1.0,
-    "tracked_behavior_rows": 470
+    "tracked_behavior_rows": 477
   }
 }

--- a/docs/parity/test-coverage-audit.md
+++ b/docs/parity/test-coverage-audit.md
@@ -1,6 +1,6 @@
 # Test Coverage Audit
 
-Generated: `2026-07-04T06:47:43.205545+00:00`
+Generated: `2026-07-07T21:51:23.613081+00:00`
 
 ## Gate
 
@@ -12,13 +12,13 @@ Generated: `2026-07-04T06:47:43.205545+00:00`
 
 | Metric | Value |
 | --- | ---: |
-| `tracked_behavior_rows` | 470 |
-| `covered_behavior_rows` | 470 |
+| `tracked_behavior_rows` | 477 |
+| `covered_behavior_rows` | 477 |
 | `tracked_behavior_coverage_ratio` | 1.0 |
-| `rust_test_files` | 418 |
-| `rust_test_functions` | 7270 |
-| `coverage_manifest_entries` | 460 |
-| `coverage_manifest_entries_with_valid_rust_tests` | 460 |
+| `rust_test_files` | 422 |
+| `rust_test_functions` | 7391 |
+| `coverage_manifest_entries` | 467 |
+| `coverage_manifest_entries_with_valid_rust_tests` | 467 |
 | `missing_rust_test_refs` | 0 |
 | `queue_pending` | 0 |
 | `queue_total` | 1 |
@@ -29,8 +29,8 @@ Generated: `2026-07-04T06:47:43.205545+00:00`
 
 | Manifest | Entries | Valid Rust-test entries | Referenced Rust tests | Missing refs |
 | --- | ---: | ---: | ---: | ---: |
-| `docs/parity/python-test-suite-coverage.json` | 214 | 214 | 107 | 0 |
-| `docs/parity/hermes-cli-test-coverage.json` | 124 | 124 | 83 | 0 |
+| `docs/parity/python-test-suite-coverage.json` | 219 | 219 | 123 | 0 |
+| `docs/parity/hermes-cli-test-coverage.json` | 126 | 126 | 90 | 0 |
 | `docs/parity/ui-tui-source-coverage.json` | 122 | 122 | 68 | 0 |
 
 ## Test Intent Domains
@@ -38,12 +38,12 @@ Generated: `2026-07-04T06:47:43.205545+00:00`
 | Intent | Classification | Evidence files | Direct test evidence |
 | --- | --- | ---: | ---: |
 | `gateway-platform-behavior` | `direct_rust_test` | 25 | 22 |
-| `tool-runtime-behavior` | `direct_rust_test` | 120 | 98 |
-| `cli-command-surface` | `direct_rust_test` | 178 | 45 |
+| `tool-runtime-behavior` | `direct_rust_test` | 122 | 100 |
+| `cli-command-surface` | `direct_rust_test` | 178 | 47 |
 | `agent-loop-and-runtime` | `direct_rust_test` | 106 | 71 |
 | `acp-protocol-and-transport` | `direct_rust_test` | 21 | 15 |
-| `skills-management-contract` | `direct_rust_test` | 69 | 14 |
-| `cron-and-scheduler-runtime` | `direct_rust_test` | 71 | 14 |
+| `skills-management-contract` | `direct_rust_test` | 69 | 16 |
+| `cron-and-scheduler-runtime` | `direct_rust_test` | 71 | 16 |
 | `memory-plugin-integration` | `direct_rust_test` | 12 | 12 |
 | `environment-lifecycle-contract` | `direct_rust_test` | 14 | 9 |
 | `tool-call-parser-contract` | `direct_rust_test` | 3 | 3 |

--- a/docs/parity/test-intent-mapping.json
+++ b/docs/parity/test-intent-mapping.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-07-04T06:47:42.617538+00:00",
+  "generated_at_utc": "2026-07-07T21:51:22.927789+00:00",
   "intent_unit": "domain_intent",
   "intents": [
     {
@@ -39,7 +39,7 @@
       ]
     },
     {
-      "evidence_count": 120,
+      "evidence_count": 122,
       "evidence_sample": [
         "crates/hermes-tools/src/approval.rs",
         "crates/hermes-tools/src/approval/patterns.rs",

--- a/docs/parity/test-intent-mapping.md
+++ b/docs/parity/test-intent-mapping.md
@@ -1,11 +1,11 @@
 # Test Intent Mapping
 
-Generated: `2026-07-04T06:47:42.617538+00:00`
+Generated: `2026-07-07T21:51:22.927789+00:00`
 
 | Intent | Mapped | Evidence Count |
 | --- | --- | ---: |
 | `gateway-platform-behavior` | yes | 25 |
-| `tool-runtime-behavior` | yes | 120 |
+| `tool-runtime-behavior` | yes | 122 |
 | `cli-command-surface` | yes | 178 |
 | `agent-loop-and-runtime` | yes | 106 |
 | `acp-protocol-and-transport` | yes | 21 |

--- a/docs/parity/upstream-missing-queue.json
+++ b/docs/parity/upstream-missing-queue.json
@@ -2,7 +2,7 @@
   "commits": [
     {
       "classification_rule": "sha_override",
-      "disposition": "superseded",
+      "disposition": "ported",
       "files_sample": [
         ".dockerignore",
         ".env.example",
@@ -25,8 +25,8 @@
         ".github/pr-screenshots/45449/billing-overview.png",
         ".github/pr-screenshots/telegram-overflow/topic-final-response-clipped.jpg"
       ],
-      "files_touched": 6057,
-      "notes": "Upstream PR #57969 / head 4bf749fd changed only Electron desktop copy-button tooltip and scrollbar-offset UI in apps/desktop/src/components/assistant-ui/tool/fallback.tsx and apps/desktop/src/components/ui/copy-button.tsx. Hermes Agent Ultra does not ship the Electron desktop app; Rust CLI/TUI/gateway/tool surfaces own copy/display behavior, so there is no Rust runtime port target.",
+      "files_touched": 6159,
+      "notes": "Ported in Rust Mem0 setup: hermes memory setup mem0 accepts --mode selfhosted --host ... [--api-key ...] [--dry-run], interactive prompts expose platform/selfhosted/oss, self-hosted hosts are persisted to mem0.json, optional secrets route to $HERMES_HOME/.env, reachability checks are non-fatal, and focused Rust tests plus a CLI dry-run prove the surface.",
       "owner": "rust-runtime",
       "rust_only_guard": {
         "allow_python_test_surfaces": false,
@@ -34,15 +34,15 @@
         "rust_primary_surface_only_commit": false,
         "superseded_by_guard": false
       },
-      "sha": "5445e42b87b9918d5b1bfa9f4eadd8e4bb10ff37",
-      "subject": "Merge pull request #57969 from alelpoan/fix/copy-button-tooltip",
+      "sha": "5e51b123f32b7f6a51fbd5759e89ba5146ce4003",
+      "subject": "feat(mem0): add self-hosted mode to the setup wizard",
       "target_ticket": 20,
       "target_ticket_name": "GPAR-01 tests+CI parity"
     }
   ],
-  "generated_at_utc": "2026-07-04T06:47:45.845372+00:00",
+  "generated_at_utc": "2026-07-07T21:51:26.151224+00:00",
   "refs": {
-    "baseline_start_sha": "19d4174454624a1ca91bc47b8f2a7ae8c3b4b5d3",
+    "baseline_start_sha": "5445e42b87b9918d5b1bfa9f4eadd8e4bb10ff37",
     "local_ref": "HEAD",
     "prior_ref": "HEAD",
     "prior_source": "HEAD",
@@ -52,7 +52,7 @@
   },
   "summary": {
     "by_disposition": {
-      "superseded": 1
+      "ported": 1
     },
     "by_target_ticket": {
       "20": 1

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-07-04T06:47:45.845372+00:00`
+Generated: `2026-07-07T21:51:26.151224+00:00`
 
 - Range: `HEAD..upstream/main`; total commits tracked: `1`.
 
@@ -10,7 +10,7 @@ Generated: `2026-07-04T06:47:45.845372+00:00`
 
 | Disposition | Commit Count |
 | --- | ---: |
-| superseded | 1 |
+| ported | 1 |
 
 ## First 100 Pending Commits
 

--- a/docs/parity/workstream-status.json
+++ b/docs/parity/workstream-status.json
@@ -1,12 +1,12 @@
 {
-  "generated_at_utc": "2026-07-03T15:57:55-06:00",
-  "head_sha": "c905df14be39b3f43623d2ec17f98c587ea97a83",
+  "generated_at_utc": "2026-07-06T03:37:43-06:00",
+  "head_sha": "8c58db72e5e53c349a77cd59efe3e5b86b001adf",
   "states": {
     "complete": 6,
     "in_progress": 1
   },
   "upstream_ref": "upstream/main",
-  "upstream_sha": "5445e42b87b9918d5b1bfa9f4eadd8e4bb10ff37",
+  "upstream_sha": "5e51b123f32b7f6a51fbd5759e89ba5146ce4003",
   "workstreams": [
     {
       "evidence": [

--- a/docs/parity/workstream-status.md
+++ b/docs/parity/workstream-status.md
@@ -1,7 +1,7 @@
 # Workstream Status
 
-- Local HEAD: `c905df14be39b3f43623d2ec17f98c587ea97a83`
-- Upstream: `upstream/main` (`5445e42b87b9918d5b1bfa9f4eadd8e4bb10ff37`)
+- Local HEAD: `8c58db72e5e53c349a77cd59efe3e5b86b001adf`
+- Upstream: `upstream/main` (`5e51b123f32b7f6a51fbd5759e89ba5146ce4003`)
 
 | Workstream | Title | State |
 | --- | --- | --- |

--- a/scripts/generate-shared-diff-backlog.py
+++ b/scripts/generate-shared-diff-backlog.py
@@ -77,7 +77,7 @@ def ensure_remote(repo_root: Path, remote: str, url: str) -> None:
 
 
 def fetch_remote_branch(repo_root: Path, remote: str, branch: str) -> None:
-    refspec = f"refs/heads/{branch}:refs/remotes/{remote}/{branch}"
+    refspec = f"+refs/heads/{branch}:refs/remotes/{remote}/{branch}"
     run_git(repo_root, ["fetch", "--no-tags", remote, refspec])
 
 

--- a/scripts/run-repo-ci.sh
+++ b/scripts/run-repo-ci.sh
@@ -58,7 +58,7 @@ refresh_upstream() {
   fi
   run git -C "${REPO_ROOT}" fetch --no-tags --depth=1 \
     "${UPSTREAM_REMOTE}" \
-    "refs/heads/main:refs/remotes/${UPSTREAM_REMOTE}/main"
+    "+refs/heads/main:refs/remotes/${UPSTREAM_REMOTE}/main"
 }
 
 cd "${REPO_ROOT}"

--- a/tests/test_generate_shared_diff_backlog.py
+++ b/tests/test_generate_shared_diff_backlog.py
@@ -25,6 +25,32 @@ def test_longest_prefix_match_prefers_specific_prefix():
     assert match["path"] == "tests/gateway"
 
 
+def test_fetch_remote_branch_force_updates_tracking_ref(monkeypatch, tmp_path):
+    mod = load_module()
+    calls = []
+
+    def fake_run_git(repo_root, args, check=True):
+        calls.append((repo_root, args, check))
+        return ""
+
+    monkeypatch.setattr(mod, "run_git", fake_run_git)
+
+    mod.fetch_remote_branch(tmp_path, "upstream", "main")
+
+    assert calls == [
+        (
+            tmp_path,
+            [
+                "fetch",
+                "--no-tags",
+                "upstream",
+                "+refs/heads/main:refs/remotes/upstream/main",
+            ],
+            True,
+        )
+    ]
+
+
 def test_build_ledger_classifies_shared_different_entries(monkeypatch, tmp_path):
     mod = load_module()
     local_tree = {

--- a/tests/test_repo_ci_contract.py
+++ b/tests/test_repo_ci_contract.py
@@ -11,7 +11,7 @@ def test_repo_ci_runner_exists_and_declares_authority() -> None:
     assert SCRIPT.exists()
     assert "repository-local CI contract" in text
     assert "hosted GitHub Actions are a convenience mirror" in text
-    assert "refs/heads/main:refs/remotes/${UPSTREAM_REMOTE}/main" in text
+    assert "+refs/heads/main:refs/remotes/${UPSTREAM_REMOTE}/main" in text
     assert "[repo-ci] PASS" in text
 
 


### PR DESCRIPTION
## What changed

- Added Rust-native RetainDB memory backend parity for file upload/list/read/ingest/delete routes, agent metadata, durable queueing, prefetch synthesis, and reasoning/SOUL paths.
- Added Rust Exa extract backend routing plus env/config coverage for web extract alongside existing search providers.
- Extended CLI runtime parity for provider context windows, dynamic config examples, session export formats/redaction/filtering, kanban archive coverage, and model-capability tests.
- Hardened auth writes with owner-only create-new temp files before token-store writes.
- Promoted Mem0 self-hosted setup to a first-class Rust CLI surface: `memory setup mem0 --mode selfhosted --host ... [--api-key ...] [--dry-run]`, with host config in `mem0.json`, optional secret routing to `$HERMES_HOME/.env`, and nonfatal reachability checks.
- Hardened Discord gateway behavior with UTF-16-safe labels/thread titles, bounded REST body reads, and session-title mirroring to platform thread names.
- Forced upstream tracking ref updates in repo-local parity scripts so stale shallow refs cannot hide or block the release queue.

## Why

This closes the remaining valuable Rust parity gaps surfaced by the upstream queue and shared-diff backlog while preserving Hermes Ultra's Rust-first runtime boundary where upstream changes are Python/Electron-only.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p hermes-cli mem0_setup -- --nocapture` -> 4 passed
- `cargo test -p hermes-agent mem0 -- --nocapture` -> 14 passed
- CLI dry-run: `hermes-ultra memory setup mem0 --mode selfhosted --host http://127.0.0.1:24220 --api-key local-secret --dry-run -y`
- `bash scripts/run-repo-ci.sh` -> `[repo-ci] PASS`
- Upstream queue: `max_queue_pending_commits actual=0.0 limit=0 status=pass`
- Release gate: `release_gate.pass=true`
