### PR TITLE
release: v0.22.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.21.3"
+version = "0.22.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/sheawinkler/hermes-agent-ultra"

--- a/docs/releases/v0.22.0.md
+++ b/docs/releases/v0.22.0.md
@@ -1,0 +1,84 @@
+# Hermes Agent Ultra v0.22.0
+
+Release date: 2026-07-07
+
+`v0.22.0` publishes the large Rust parity closeout after the `v0.21.x` hardening cycle. The practical result: the release gate is green, the upstream queue has zero pending commits, the shared-diff backlog has zero pending classification/review rows, and the newly added runtime surfaces are implemented in Rust with deterministic tests.
+
+## Release Snapshot
+
+| Signal | v0.22.0 State |
+| --- | ---: |
+| Workspace version | `0.22.0` |
+| Runtime closeout PR | `#717` |
+| Release gate | PASS |
+| Upstream queue pending | `0` |
+| Latest upstream queue disposition | `1 ported` |
+| Shared diff pending classification | `0` |
+| Shared diff pending review | `0` |
+| Shared diff rows covered by policy/runtime classification | `1,279` |
+| SOTA harness domain coverage ratio | `1.0` |
+| SOTA harness direct Rust tests | `12` |
+| Upstream surface coverage gate | `missing=0 checked=2382` |
+| Runtime language posture | Rust runtime; no Python runtime fallback added |
+
+## Minimal Flow
+
+```text
+upstream delta + local product pressure
+        |
+        v
+Rust runtime implementation
+  memory: RetainDB + Mem0 self-hosted setup
+  web: Exa extract provider routing
+  CLI: session export + provider context windows
+  gateway: Discord bounds/title mirroring
+  auth: owner-only token write hardening
+        |
+        v
+repo-local proof
+  queue pending = 0
+  shared pending = 0
+  release gate = PASS
+  surface missing = 0
+        |
+        v
+v0.22.0 release
+```
+
+## Behavioral And Functional Changes
+
+- Added Rust-native RetainDB memory provider parity for file upload/list/read/ingest/delete workflows, `agent_id` metadata, durable queueing, prefetch synthesis, self-model/SOUL seeding, and reasoning chooser behavior.
+- Added Rust Exa extract backend support through `/contents` with provider routing and env/config tests alongside existing web search/extract providers.
+- Extended CLI session exports with HTML, Markdown, JSON, JSONL, prompt-only, redaction, output-path, session-id, source, and prune-filter behavior.
+- Made provider context windows configurable and preserved the dynamic OpenAI/Codex model posture, including the Codex OAuth display context cap.
+- Added a root `cli-config.yaml.example` that keeps provider defaults dynamic and avoids stale model pinning.
+- Hardened auth token persistence with owner-only create-new temp files before atomic writes.
+- Promoted Mem0 self-hosted setup to first-class Rust CLI behavior: `hermes-ultra memory setup mem0 --mode selfhosted --host ... [--api-key ...] [--dry-run]`.
+- Stored Mem0 self-hosted hosts in `mem0.json`, routed optional Mem0 secrets to `$HERMES_HOME/.env`, accepted upstream `selfhosted` spelling, and made reachability checks nonfatal.
+- Hardened Discord gateway behavior with UTF-16-safe labels/thread titles, bounded REST body/error reads, and session-title mirroring into platform thread names.
+- Forced upstream tracking-ref updates in repo-local parity scripts so stale shallow refs cannot hide new upstream commits or leave the release queue contradictory.
+
+## Exceptional-To-Upstream Posture
+
+| Area | Why this is stronger than a direct port |
+| --- | --- |
+| Memory providers | RetainDB and Mem0 are compiled Rust runtime surfaces with owner-only persistence, deterministic tests, and no Python setup shim. |
+| Web extraction | Exa extract is provider-routed through the Rust web backend and covered by backend-selection tests. |
+| CLI sessions | Export/prune behavior is local, typed, redaction-aware, and test-covered across multiple formats. |
+| Gateway safety | Discord body reads are bounded and UTF-16 constraints are enforced before outbound API calls. |
+| Release governance | Repo-local CI forces upstream ref updates, regenerates queue/proof artifacts, and treats GitHub CI as a mirror rather than source of truth. |
+
+## Verification
+
+```bash
+export CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target
+export CARGO_INCREMENTAL=0
+cargo fmt --all --check
+git diff --check
+cargo test -p hermes-cli mem0_setup -- --nocapture
+cargo test -p hermes-agent mem0 -- --nocapture
+hermes-ultra memory setup mem0 --mode selfhosted --host http://127.0.0.1:24220 --api-key local-secret --dry-run -y
+bash scripts/run-repo-ci.sh
+```
+
+Final repo-local CI evidence: `[repo-ci] PASS`, upstream surface coverage `missing=0 checked=2382`, upstream slash parity `missing_unallowlisted=0 missing_total=0 local_extra=83`, and `max_queue_pending_commits actual=0.0 limit=0 status=pass`.


### PR DESCRIPTION
## What changed

- Bumped workspace version from `0.21.3` to `0.22.0`.
- Added `docs/releases/v0.22.0.md` with the parity closeout snapshot, runtime changes, release flow, exceptional-to-upstream posture, and verification evidence.

## Why

`main` now includes PR #717, which closed the valuable Rust parity/runtime gaps and restored the release gate to PASS with zero pending upstream queue commits. This publishes that work as the next minor release.

## Verification

- `cargo metadata --no-deps --format-version 1`
- `cargo fmt --all --check`
- `git diff --check`
- `python3 scripts/generate-release-readiness-summary.py --repo-root . --check` -> `release_readiness=PASS`
- Prior release payload gate on PR #717: `bash scripts/run-repo-ci.sh` -> `[repo-ci] PASS`
