### PR TITLE
release: update v0.22.0 lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,7 +1487,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-acp"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1544,7 +1544,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-app-runtime"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-auth"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -1582,7 +1582,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-cli"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "aes-gcm",
  "arboard",
@@ -1641,14 +1641,14 @@ dependencies = [
 
 [[package]]
 name = "hermes-cli-ui"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "hermes-config"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "chrono",
  "directories",
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-core"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1683,7 +1683,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-cron"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-environments"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "async-trait",
  "hermes-config",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-eval"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-gateway"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "aes",
  "async-trait",
@@ -1792,7 +1792,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-http"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-intelligence"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-mcp"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1866,7 +1866,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-parity-tests"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "hermes-core",
  "hermes-intelligence",
@@ -1878,7 +1878,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-protocol-parity-tests"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "async-trait",
  "hermes-acp",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-provider-runtime"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -1908,7 +1908,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-skills"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-source-parity-tests"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "regex",
  "serde",
@@ -1943,7 +1943,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-telemetry"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "base64",
  "once_cell",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-tool-planning"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "async-trait",
  "hermes-agent",
@@ -1973,7 +1973,7 @@ dependencies = [
 
 [[package]]
 name = "hermes-tools"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "async-trait",
  "base64",


### PR DESCRIPTION
## What changed

- Updated `Cargo.lock` workspace package entries from `0.21.3` to `0.22.0` after the final workspace build materialized the lockfile metadata.

## Why

The `v0.22.0` release commit needs `Cargo.toml`, release notes, and `Cargo.lock` to agree on the same workspace version.

## Verification

- `cargo metadata --no-deps --format-version 1`
- `git diff --check`
- `python3 scripts/generate-release-readiness-summary.py --repo-root . --check` -> `release_readiness=PASS`
- Prior final build with this lockfile content: `cargo build --workspace` -> finished successfully at `v0.22.0`
