### PR TITLE
feat(harness): add outcome and provider smoke gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,4 +190,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Smoke published release artifact
-        run: bash scripts/smoke-release-artifact.sh --version "${GITHUB_REF_NAME}"
+        run: |
+          mkdir -p .sync-reports
+          bash scripts/smoke-release-artifact.sh \
+            --version "${GITHUB_REF_NAME}" \
+            --output-json .sync-reports/release-artifact-smoke.json
+      - name: Upload release smoke report
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-artifact-smoke
+          path: .sync-reports/release-artifact-smoke.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,10 +1896,12 @@ name = "hermes-provider-runtime"
 version = "0.22.0"
 dependencies = [
  "async-trait",
+ "base64",
  "futures",
  "hermes-agent",
  "hermes-config",
  "hermes-core",
+ "serde",
  "serde_json",
  "tokio",
  "tracing",

--- a/crates/hermes-gateway/src/gateway.rs
+++ b/crates/hermes-gateway/src/gateway.rs
@@ -421,6 +421,8 @@ pub struct Gateway {
     hook_registry: RwLock<Option<Arc<HookRegistry>>>,
     /// Per-platform allowlist policy for group and slash-command traffic.
     platform_access_policies: RwLock<HashMap<String, PlatformAccessPolicy>>,
+    /// One-shot warnings for platform policies that fail closed by default.
+    fail_closed_default_warnings: RwLock<HashSet<String>>,
     /// Bounded duplicate guard for platform redeliveries/restarts.
     message_deduplicator: RwLock<MessageDeduplicator>,
     /// Active gateway sessions plus queued/steered busy follow-ups.

--- a/crates/hermes-gateway/src/gateway/lifecycle_methods.rs
+++ b/crates/hermes-gateway/src/gateway/lifecycle_methods.rs
@@ -26,6 +26,7 @@ impl Gateway {
             mcp_reload_generation: RwLock::new(0),
             hook_registry: RwLock::new(None),
             platform_access_policies: RwLock::new(HashMap::new()),
+            fail_closed_default_warnings: RwLock::new(HashSet::new()),
             message_deduplicator: RwLock::new(MessageDeduplicator::default()),
             busy_sessions: Arc::new(RwLock::new(BusySessionCoordinator::default())),
         }

--- a/crates/hermes-gateway/src/gateway/platform_access_policy.rs
+++ b/crates/hermes-gateway/src/gateway/platform_access_policy.rs
@@ -3,6 +3,28 @@ impl PlatformAccessPolicy {
         !self.allowed_users.is_empty() || !self.admin_users.is_empty()
     }
 
+    fn has_any_access_configuration(&self) -> bool {
+        self.has_allowlist()
+            || !self.allowed_channels.is_empty()
+            || !self.authorized_group_chats.is_empty()
+            || !self.ignored_channels.is_empty()
+    }
+
+    fn fail_closed_default_warning(&self, platform: &str) -> Option<&'static str> {
+        if !platform.eq_ignore_ascii_case("discord")
+            || self.group_mode != GroupAccessMode::Allowlist
+            || self.has_any_access_configuration()
+        {
+            return None;
+        }
+
+        Some(
+            "Discord messages are being denied because no allowlist is configured. Set \
+             DISCORD_ALLOWED_USERS, DISCORD_ALLOWED_ROLES, or DISCORD_ALLOWED_CHANNELS, \
+             or set DISCORD_ALLOW_ALL_USERS=true for open access.",
+        )
+    }
+
     fn user_matches_any(user_id: &str, set: &HashSet<String>) -> bool {
         let candidate = user_id.trim();
         if candidate.is_empty() {

--- a/crates/hermes-gateway/src/gateway/routing_methods.rs
+++ b/crates/hermes-gateway/src/gateway/routing_methods.rs
@@ -41,8 +41,17 @@ impl Gateway {
         let access_policy = self.platform_access_policy(&incoming.platform).await;
         let is_slash_command = incoming.text.trim_start().starts_with('/');
         if let Some(policy) = access_policy.as_ref() {
+            let source_authorized = {
+                let dm_manager = self.dm_manager.read().await;
+                dm_manager.is_authorized_source(
+                    &incoming.platform,
+                    &incoming.user_id,
+                    &incoming.chat_id,
+                    incoming.is_dm,
+                )
+            };
             let bypasses_user_allowlist =
-                policy.allows_sender_without_user_allowlist(incoming, sender);
+                source_authorized || policy.allows_sender_without_user_allowlist(incoming, sender);
             if !incoming.is_dm {
                 if policy.is_channel_ignored(&incoming.chat_id) {
                     debug!(
@@ -74,6 +83,8 @@ impl Gateway {
                             && !policy.is_user_allowed(&incoming.user_id)
                             && !policy.is_group_chat_authorized(&incoming.chat_id)
                         {
+                            self.warn_fail_closed_default_once(&incoming.platform, policy)
+                                .await;
                             debug!(
                                 platform = incoming.platform,
                                 user_id = incoming.user_id,
@@ -91,6 +102,8 @@ impl Gateway {
                 && !bypasses_user_allowlist
                 && !policy.is_user_allowed(&incoming.user_id)
             {
+                self.warn_fail_closed_default_once(&incoming.platform, policy)
+                    .await;
                 debug!(
                     platform = incoming.platform,
                     user_id = incoming.user_id,
@@ -317,6 +330,17 @@ impl Gateway {
         }
         processing_result?;
         Ok(pending)
+    }
+
+    async fn warn_fail_closed_default_once(&self, platform: &str, policy: &PlatformAccessPolicy) {
+        let Some(message) = policy.fail_closed_default_warning(platform) else {
+            return;
+        };
+        let key = format!("{}:{message}", platform.trim().to_ascii_lowercase());
+        let mut warned = self.fail_closed_default_warnings.write().await;
+        if warned.insert(key) {
+            warn!(platform = %platform, "{}", message);
+        }
     }
 
     async fn send_processing_error_notification(

--- a/crates/hermes-gateway/src/gateway/tests/status_profiles.rs
+++ b/crates/hermes-gateway/src/gateway/tests/status_profiles.rs
@@ -200,6 +200,39 @@ async fn gateway_group_allowlist_denies_unauthorized_user() {
 }
 
 #[tokio::test]
+async fn gateway_discord_group_allowlist_honors_authorized_source_pairing() {
+    let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
+    let mut dm_manager = DmManager::with_ignore_behavior();
+    dm_manager.authorize_user_for_platform("discord", "paired_user");
+    let gw = Gateway::new(session_mgr, dm_manager, GatewayConfig::default());
+    let mut policies = HashMap::new();
+    let mut policy = PlatformAccessPolicy {
+        group_mode: GroupAccessMode::Allowlist,
+        ..PlatformAccessPolicy::default()
+    };
+    policy.allowed_users.insert("allowed_user".to_string());
+    policies.insert("discord".to_string(), policy);
+    gw.set_platform_access_policies(policies).await;
+
+    let incoming = IncomingMessage {
+        platform: "discord".into(),
+        chat_id: "guild:42".into(),
+        user_id: "paired_user".into(),
+        text: "hello group".into(),
+        message_id: Some("m1".into()),
+        thread_id: None,
+        is_dm: false,
+    };
+
+    assert!(gw.route_message(&incoming).await.is_err());
+    assert_eq!(
+        gw.session_transcript_len("discord", "guild:42", "paired_user")
+            .await,
+        1
+    );
+}
+
+#[tokio::test]
 async fn gateway_group_allowlist_star_authorizes_any_sender() {
     let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
     let dm_manager = DmManager::with_ignore_behavior();
@@ -230,6 +263,33 @@ async fn gateway_group_allowlist_star_authorizes_any_sender() {
             .await,
         1
     );
+}
+
+#[test]
+fn discord_fail_closed_default_warning_is_precise() {
+    let fail_closed = PlatformAccessPolicy {
+        group_mode: GroupAccessMode::Allowlist,
+        ..PlatformAccessPolicy::default()
+    };
+    let message = fail_closed
+        .fail_closed_default_warning("discord")
+        .expect("discord allowlist mode without grants should warn");
+    assert!(message.contains("Discord messages are being denied"));
+    assert!(message.contains("DISCORD_ALLOW_ALL_USERS=true"));
+
+    let with_user = PlatformAccessPolicy {
+        group_mode: GroupAccessMode::Allowlist,
+        allowed_users: ["allowed_user"].into_iter().map(String::from).collect(),
+        ..PlatformAccessPolicy::default()
+    };
+    assert!(with_user.fail_closed_default_warning("discord").is_none());
+
+    let open_mode = PlatformAccessPolicy {
+        group_mode: GroupAccessMode::Open,
+        ..PlatformAccessPolicy::default()
+    };
+    assert!(open_mode.fail_closed_default_warning("discord").is_none());
+    assert!(fail_closed.fail_closed_default_warning("telegram").is_none());
 }
 
 #[tokio::test]
@@ -492,7 +552,8 @@ async fn gateway_discord_slash_requires_allowlist() {
         messages: sent.clone(),
     });
     let session_mgr = Arc::new(SessionManager::new(SessionConfig::default()));
-    let dm_manager = DmManager::with_ignore_behavior();
+    let mut dm_manager = DmManager::with_ignore_behavior();
+    dm_manager.authorize_user_for_platform("discord", "paired_user");
     let gw = Gateway::new(session_mgr, dm_manager, GatewayConfig::default());
     gw.register_adapter("discord", adapter).await;
 
@@ -536,6 +597,22 @@ async fn gateway_discord_slash_requires_allowlist() {
     assert_eq!(sent_msgs.len(), 1);
     assert_eq!(sent_msgs[0].0, "guild:1");
     assert!(!sent_msgs[0].1.trim().is_empty());
+    drop(sent_msgs);
+
+    let paired = IncomingMessage {
+        platform: "discord".into(),
+        chat_id: "guild:1".into(),
+        user_id: "paired_user".into(),
+        text: "/status".into(),
+        message_id: Some("m3".into()),
+        thread_id: None,
+        is_dm: false,
+    };
+    assert!(gw.route_message(&paired).await.is_ok());
+    let sent_msgs = sent.lock().unwrap();
+    assert_eq!(sent_msgs.len(), 2);
+    assert_eq!(sent_msgs[1].0, "guild:1");
+    assert!(!sent_msgs[1].1.trim().is_empty());
 }
 
 #[tokio::test]

--- a/crates/hermes-gateway/src/lib.rs
+++ b/crates/hermes-gateway/src/lib.rs
@@ -77,11 +77,14 @@ pub use dm::{DmDecision, DmManager};
 pub use mirror::MirrorManager;
 pub use pairing::{PairingManager, PairingState};
 pub use relay::{
-    relay_close_disposition, relay_dual_write_scope_id, relay_going_idle_frame,
+    relay_client_credentials_form, relay_close_disposition, relay_dual_write_scope_id,
+    relay_fetch_client_credentials_identity_token, relay_going_idle_frame,
+    relay_identity_provider_config_from_sources, relay_identity_token_mode,
     relay_inbound_ack_frame, relay_passthrough_forward_from_frame, relay_platform_state_for_close,
     relay_policy_url, relay_relevance_policy, relay_scope_id_from_source,
-    relay_wake_url_from_sources, RelayCloseDisposition, RelayPassthroughForward,
-    RelayRelevancePolicy, RELAY_UNAUTHORIZED_CLOSE_CODE,
+    relay_wake_url_from_sources, RelayCloseDisposition, RelayIdentityProviderConfig,
+    RelayIdentityTokenError, RelayIdentityTokenMode, RelayPassthroughForward, RelayRelevancePolicy,
+    RELAY_UNAUTHORIZED_CLOSE_CODE,
 };
 pub use sticker_cache::{StickerCache, StickerMeta};
 

--- a/crates/hermes-gateway/src/relay.rs
+++ b/crates/hermes-gateway/src/relay.rs
@@ -10,12 +10,78 @@ use serde_json::{json, Value};
 use url::Url;
 
 pub const RELAY_UNAUTHORIZED_CLOSE_CODE: u16 = 4401;
+const RELAY_CLIENT_CREDENTIALS_TIMEOUT_SECS: u64 = 15;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RelayCloseDisposition {
     Retryable,
     Disabled,
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelayIdentityTokenMode {
+    NousPortal,
+    GenericOidcClientCredentials,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct RelayIdentityProviderConfig {
+    pub token_url: String,
+    pub client_id: String,
+    pub client_secret: String,
+    pub scope: String,
+}
+
+impl RelayIdentityProviderConfig {
+    pub fn new(
+        token_url: impl Into<String>,
+        client_id: impl Into<String>,
+        client_secret: impl Into<String>,
+        scope: impl Into<String>,
+    ) -> Self {
+        Self {
+            token_url: token_url.into(),
+            client_id: client_id.into(),
+            client_secret: client_secret.into(),
+            scope: scope.into(),
+        }
+        .normalized()
+    }
+
+    pub fn normalized(mut self) -> Self {
+        self.token_url = self.token_url.trim().to_string();
+        self.client_id = self.client_id.trim().to_string();
+        self.client_secret = self.client_secret.trim().to_string();
+        self.scope = self.scope.trim().to_string();
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RelayIdentityTokenError {
+    MissingClientCredentials,
+    Request(String),
+    MissingAccessToken,
+}
+
+impl std::fmt::Display for RelayIdentityTokenError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingClientCredentials => {
+                write!(
+                    f,
+                    "gateway.idp.token_url configured but client_id/client_secret missing"
+                )
+            }
+            Self::Request(err) => write!(f, "IdP client_credentials request failed: {err}"),
+            Self::MissingAccessToken => {
+                write!(f, "IdP client_credentials response had no access_token")
+            }
+        }
+    }
+}
+
+impl std::error::Error for RelayIdentityTokenError {}
 
 /// Connector-forwarded passthrough-plane request (`passthrough_forward`).
 ///
@@ -114,6 +180,86 @@ pub fn relay_inbound_ack_frame(buffer_id: &str) -> Option<Value> {
     (!buffer_id.is_empty()).then(|| json!({"type": "inbound_ack", "bufferId": buffer_id}))
 }
 
+pub fn relay_identity_provider_config_from_sources(
+    env: RelayIdentityProviderConfig,
+    config: RelayIdentityProviderConfig,
+) -> RelayIdentityProviderConfig {
+    let env = env.normalized();
+    if !env.token_url.is_empty() {
+        return env;
+    }
+    let config = config.normalized();
+    RelayIdentityProviderConfig {
+        token_url: config.token_url,
+        client_id: first_nonempty(env.client_id, config.client_id),
+        client_secret: first_nonempty(env.client_secret, config.client_secret),
+        scope: first_nonempty(env.scope, config.scope),
+    }
+}
+
+pub fn relay_identity_token_mode(config: &RelayIdentityProviderConfig) -> RelayIdentityTokenMode {
+    if config.token_url.trim().is_empty() {
+        RelayIdentityTokenMode::NousPortal
+    } else {
+        RelayIdentityTokenMode::GenericOidcClientCredentials
+    }
+}
+
+pub fn relay_client_credentials_form(
+    config: &RelayIdentityProviderConfig,
+) -> Result<Vec<(String, String)>, RelayIdentityTokenError> {
+    let config = config.clone().normalized();
+    if config.client_id.is_empty() || config.client_secret.is_empty() {
+        return Err(RelayIdentityTokenError::MissingClientCredentials);
+    }
+    let mut form = vec![
+        ("grant_type".to_string(), "client_credentials".to_string()),
+        ("client_id".to_string(), config.client_id),
+        ("client_secret".to_string(), config.client_secret),
+    ];
+    if !config.scope.is_empty() {
+        form.push(("scope".to_string(), config.scope));
+    }
+    Ok(form)
+}
+
+pub async fn relay_fetch_client_credentials_identity_token(
+    config: &RelayIdentityProviderConfig,
+) -> Result<String, RelayIdentityTokenError> {
+    let config = config.clone().normalized();
+    let form = relay_client_credentials_form(&config)?;
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(
+            RELAY_CLIENT_CREDENTIALS_TIMEOUT_SECS,
+        ))
+        .build()
+        .map_err(|err| RelayIdentityTokenError::Request(err.to_string()))?;
+    let response = client
+        .post(&config.token_url)
+        .form(&form)
+        .header(reqwest::header::ACCEPT, "application/json")
+        .send()
+        .await
+        .map_err(|err| RelayIdentityTokenError::Request(err.to_string()))?;
+    if !response.status().is_success() {
+        return Err(RelayIdentityTokenError::Request(format!(
+            "token endpoint returned {}",
+            response.status()
+        )));
+    }
+    let payload = response
+        .json::<Value>()
+        .await
+        .map_err(|err| RelayIdentityTokenError::Request(err.to_string()))?;
+    payload
+        .get("access_token")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or(RelayIdentityTokenError::MissingAccessToken)
+}
+
 /// Resolve the platform-neutral relay scope discriminator.
 ///
 /// `scope_id` is canonical; `guild_id` is a deprecated compatibility alias
@@ -197,6 +343,14 @@ fn normalize_relay_urlish(value: &str) -> Option<String> {
     (!value.is_empty()).then(|| value.to_string())
 }
 
+fn first_nonempty(primary: String, fallback: String) -> String {
+    if primary.trim().is_empty() {
+        fallback
+    } else {
+        primary
+    }
+}
+
 /// Connector-side relevance policy projected from platform mention controls.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -250,6 +404,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use wiremock::matchers::{body_string_contains, header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[test]
     fn passthrough_forward_decodes_exact_body_and_headers() {
@@ -299,6 +455,148 @@ mod tests {
             json!({"type": "inbound_ack", "bufferId": "buf-9"})
         );
         assert!(relay_inbound_ack_frame("   ").is_none());
+    }
+
+    #[test]
+    fn relay_identity_token_mode_defaults_to_nous_portal() {
+        let cfg = RelayIdentityProviderConfig::default();
+        assert_eq!(
+            relay_identity_token_mode(&cfg),
+            RelayIdentityTokenMode::NousPortal
+        );
+    }
+
+    #[test]
+    fn relay_identity_provider_env_token_url_wins_over_config() {
+        let env = RelayIdentityProviderConfig::new(
+            " https://env-idp.example/token ",
+            "env-client",
+            "env-secret",
+            "env.scope",
+        );
+        let config = RelayIdentityProviderConfig::new(
+            "https://cfg-idp.example/token",
+            "cfg-client",
+            "cfg-secret",
+            "cfg.scope",
+        );
+
+        let resolved = relay_identity_provider_config_from_sources(env, config);
+
+        assert_eq!(resolved.token_url, "https://env-idp.example/token");
+        assert_eq!(resolved.client_id, "env-client");
+        assert_eq!(resolved.client_secret, "env-secret");
+        assert_eq!(resolved.scope, "env.scope");
+        assert_eq!(
+            relay_identity_token_mode(&resolved),
+            RelayIdentityTokenMode::GenericOidcClientCredentials
+        );
+    }
+
+    #[test]
+    fn relay_identity_provider_config_fills_from_config_and_env_overrides_creds() {
+        let env = RelayIdentityProviderConfig::new("", "env-client", "", "env.scope");
+        let config = RelayIdentityProviderConfig::new(
+            "https://cfg-idp.example/token",
+            "cfg-client",
+            "cfg-secret",
+            "cfg.scope",
+        );
+
+        let resolved = relay_identity_provider_config_from_sources(env, config);
+
+        assert_eq!(resolved.token_url, "https://cfg-idp.example/token");
+        assert_eq!(resolved.client_id, "env-client");
+        assert_eq!(resolved.client_secret, "cfg-secret");
+        assert_eq!(resolved.scope, "env.scope");
+    }
+
+    #[test]
+    fn relay_client_credentials_form_matches_oidc_contract() {
+        let form = relay_client_credentials_form(&RelayIdentityProviderConfig::new(
+            "https://idp.example/token",
+            "agent-client",
+            "shh",
+            "connector.provision",
+        ))
+        .expect("form");
+
+        assert_eq!(
+            form,
+            vec![
+                ("grant_type".to_string(), "client_credentials".to_string()),
+                ("client_id".to_string(), "agent-client".to_string()),
+                ("client_secret".to_string(), "shh".to_string()),
+                ("scope".to_string(), "connector.provision".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn relay_client_credentials_form_fails_closed_without_secret() {
+        let err = relay_client_credentials_form(&RelayIdentityProviderConfig::new(
+            "https://idp.example/token",
+            "agent-client",
+            "",
+            "",
+        ))
+        .expect_err("missing secret");
+
+        assert_eq!(err, RelayIdentityTokenError::MissingClientCredentials);
+        assert!(err.to_string().contains("client_id/client_secret missing"));
+    }
+
+    #[tokio::test]
+    async fn relay_client_credentials_fetch_posts_form_and_returns_token() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .and(header("accept", "application/json"))
+            .and(body_string_contains("grant_type=client_credentials"))
+            .and(body_string_contains("client_id=agent-client"))
+            .and(body_string_contains("client_secret=shh"))
+            .and(body_string_contains("scope=connector.provision"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "access_token": "idp-workload-token",
+                "token_type": "Bearer",
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let token =
+            relay_fetch_client_credentials_identity_token(&RelayIdentityProviderConfig::new(
+                format!("{}/token", server.uri()),
+                "agent-client",
+                "shh",
+                "connector.provision",
+            ))
+            .await
+            .expect("token");
+
+        assert_eq!(token, "idp-workload-token");
+        server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn relay_client_credentials_fetch_requires_access_token() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"token_type":"Bearer"})))
+            .mount(&server)
+            .await;
+
+        let err = relay_fetch_client_credentials_identity_token(&RelayIdentityProviderConfig::new(
+            format!("{}/token", server.uri()),
+            "c",
+            "s",
+            "",
+        ))
+        .await
+        .expect_err("missing token");
+
+        assert_eq!(err, RelayIdentityTokenError::MissingAccessToken);
     }
 
     #[test]

--- a/crates/hermes-provider-runtime/Cargo.toml
+++ b/crates/hermes-provider-runtime/Cargo.toml
@@ -11,7 +11,9 @@ hermes-core = { workspace = true }
 hermes-config = { workspace = true }
 hermes-agent = { workspace = true }
 async-trait = { workspace = true }
+base64 = { workspace = true }
 futures = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/hermes-provider-runtime/src/lib.rs
+++ b/crates/hermes-provider-runtime/src/lib.rs
@@ -6,6 +6,7 @@
 
 use std::sync::Arc;
 
+use base64::Engine as _;
 use futures::StreamExt;
 use hermes_agent::bedrock::{
     bedrock_runtime_base_url, resolve_bedrock_region, BedrockProvider, BEDROCK_AUTH_MARKER,
@@ -22,6 +23,7 @@ use hermes_agent::providers_extra::{
 use hermes_agent::CodexProvider;
 use hermes_config::{GatewayConfig, LlmProviderConfig};
 use hermes_core::{AgentError, LlmProvider};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 pub use hermes_agent::local_backends::LocalBackendSpec;
@@ -78,6 +80,45 @@ pub struct ProviderRuntimeDiagnostic {
     pub api_key_source: Option<String>,
     pub local_no_key_allowed: bool,
     pub uses_openai_pro_backend: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProviderAuthSmokeCase {
+    pub id: String,
+    pub model: String,
+    pub expected_runtime_provider: String,
+    pub expected_api_key_present: bool,
+    pub expected_api_key_source: Option<String>,
+    pub expected_local_no_key_allowed: bool,
+    pub expected_openai_pro_backend: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProviderAuthSmokeResult {
+    pub id: String,
+    pub model: String,
+    pub runtime_provider: String,
+    pub api_key_present: bool,
+    pub api_key_source: Option<String>,
+    pub local_no_key_allowed: bool,
+    pub uses_openai_pro_backend: bool,
+    pub pass: bool,
+    pub failures: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProviderAuthSmokeSummary {
+    pub total: usize,
+    pub passed: usize,
+    pub failed: usize,
+    pub covered_runtime_providers: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProviderAuthSmokeMatrix {
+    pub pass: bool,
+    pub summary: ProviderAuthSmokeSummary,
+    pub results: Vec<ProviderAuthSmokeResult>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -182,6 +223,235 @@ pub fn provider_runtime_diagnostic_with_auth_resolver(
         local_no_key_allowed,
         uses_openai_pro_backend,
     }
+}
+
+pub fn provider_auth_smoke_matrix_with_auth_resolver(
+    config: &GatewayConfig,
+    cases: &[ProviderAuthSmokeCase],
+    oauth_token_resolver: Option<&OAuthTokenResolver<'_>>,
+) -> ProviderAuthSmokeMatrix {
+    let mut results = Vec::with_capacity(cases.len());
+    for case in cases {
+        let diagnostic = provider_runtime_diagnostic_with_auth_resolver(
+            config,
+            case.model.as_str(),
+            oauth_token_resolver,
+        );
+        let mut failures = Vec::new();
+        if diagnostic.runtime_provider != case.expected_runtime_provider {
+            failures.push(format!(
+                "runtime_provider expected={} actual={}",
+                case.expected_runtime_provider, diagnostic.runtime_provider
+            ));
+        }
+        if diagnostic.api_key_present != case.expected_api_key_present {
+            failures.push(format!(
+                "api_key_present expected={} actual={}",
+                case.expected_api_key_present, diagnostic.api_key_present
+            ));
+        }
+        if diagnostic.api_key_source != case.expected_api_key_source {
+            failures.push(format!(
+                "api_key_source expected={:?} actual={:?}",
+                case.expected_api_key_source, diagnostic.api_key_source
+            ));
+        }
+        if diagnostic.local_no_key_allowed != case.expected_local_no_key_allowed {
+            failures.push(format!(
+                "local_no_key_allowed expected={} actual={}",
+                case.expected_local_no_key_allowed, diagnostic.local_no_key_allowed
+            ));
+        }
+        if diagnostic.uses_openai_pro_backend != case.expected_openai_pro_backend {
+            failures.push(format!(
+                "uses_openai_pro_backend expected={} actual={}",
+                case.expected_openai_pro_backend, diagnostic.uses_openai_pro_backend
+            ));
+        }
+
+        results.push(ProviderAuthSmokeResult {
+            id: case.id.clone(),
+            model: case.model.clone(),
+            runtime_provider: diagnostic.runtime_provider,
+            api_key_present: diagnostic.api_key_present,
+            api_key_source: diagnostic.api_key_source,
+            local_no_key_allowed: diagnostic.local_no_key_allowed,
+            uses_openai_pro_backend: diagnostic.uses_openai_pro_backend,
+            pass: failures.is_empty(),
+            failures,
+        });
+    }
+
+    let passed = results.iter().filter(|result| result.pass).count();
+    let mut covered_runtime_providers = results
+        .iter()
+        .map(|result| result.runtime_provider.clone())
+        .collect::<Vec<_>>();
+    covered_runtime_providers.sort();
+    covered_runtime_providers.dedup();
+    ProviderAuthSmokeMatrix {
+        pass: passed == results.len(),
+        summary: ProviderAuthSmokeSummary {
+            total: results.len(),
+            passed,
+            failed: results.len().saturating_sub(passed),
+            covered_runtime_providers,
+        },
+        results,
+    }
+}
+
+pub fn default_provider_auth_smoke_cases() -> Vec<ProviderAuthSmokeCase> {
+    vec![
+        provider_auth_smoke_case(
+            "openai_dynamic_chatgpt_oauth",
+            "openai:dynamic",
+            "openai",
+            true,
+            Some("config.api_key"),
+            false,
+            true,
+        ),
+        provider_auth_smoke_case(
+            "codex_oauth_resolver",
+            "codex:gpt-5.5",
+            "openai-codex",
+            true,
+            Some("oauth_resolver:codex"),
+            false,
+            true,
+        ),
+        provider_auth_smoke_case(
+            "nous_key",
+            "nous:Hermes-4",
+            "nous",
+            true,
+            Some("config.api_key"),
+            false,
+            false,
+        ),
+        provider_auth_smoke_case(
+            "anthropic_key",
+            "anthropic:claude-sonnet-4-6",
+            "anthropic",
+            true,
+            Some("config.api_key"),
+            false,
+            false,
+        ),
+        provider_auth_smoke_case(
+            "gemini_oauth_resolver",
+            "gemini-cli:gemini-2.5-pro",
+            "google-gemini-cli",
+            true,
+            Some("oauth_resolver:gemini-cli"),
+            false,
+            false,
+        ),
+        provider_auth_smoke_case(
+            "qwen_oauth_resolver",
+            "qwen-cli:qwen3-coder",
+            "qwen-oauth",
+            true,
+            Some("oauth_resolver:qwen-cli"),
+            false,
+            false,
+        ),
+        provider_auth_smoke_case(
+            "openrouter_key",
+            "openrouter:anthropic/claude-sonnet-4.6",
+            "openrouter",
+            true,
+            Some("config.api_key"),
+            false,
+            false,
+        ),
+        provider_auth_smoke_case(
+            "local_no_key_llamafile",
+            "llamafile:local-gguf",
+            "llama-cpp",
+            false,
+            None,
+            true,
+            false,
+        ),
+        provider_auth_smoke_case(
+            "moa_virtual_no_key",
+            "moa:default",
+            "moa",
+            false,
+            None,
+            true,
+            false,
+        ),
+    ]
+}
+
+pub fn deterministic_provider_auth_smoke_matrix() -> ProviderAuthSmokeMatrix {
+    let mut config = GatewayConfig::default();
+    config.llm_providers.insert(
+        "openai".to_string(),
+        LlmProviderConfig {
+            api_key: Some(chatgpt_oauth_fixture_token("matrix-openai-dynamic")),
+            ..LlmProviderConfig::default()
+        },
+    );
+    for (provider, key) in [
+        ("nous", "nous-smoke-key"),
+        ("anthropic", "anthropic-smoke-key"),
+        ("openrouter", "openrouter-smoke-key"),
+    ] {
+        config.llm_providers.insert(
+            provider.to_string(),
+            LlmProviderConfig {
+                api_key: Some(key.to_string()),
+                ..LlmProviderConfig::default()
+            },
+        );
+    }
+    let resolver = |provider: &str| match provider {
+        "codex" | "openai-codex" => Some("codex-oauth-smoke-token".to_string()),
+        "gemini-cli" | "google-gemini-cli" => Some("gemini-oauth-smoke-token".to_string()),
+        "qwen-cli" | "qwen-oauth" => Some("qwen-oauth-smoke-token".to_string()),
+        _ => None,
+    };
+    provider_auth_smoke_matrix_with_auth_resolver(
+        &config,
+        &default_provider_auth_smoke_cases(),
+        Some(&resolver),
+    )
+}
+
+fn provider_auth_smoke_case(
+    id: &str,
+    model: &str,
+    expected_runtime_provider: &str,
+    expected_api_key_present: bool,
+    expected_api_key_source: Option<&str>,
+    expected_local_no_key_allowed: bool,
+    expected_openai_pro_backend: bool,
+) -> ProviderAuthSmokeCase {
+    ProviderAuthSmokeCase {
+        id: id.to_string(),
+        model: model.to_string(),
+        expected_runtime_provider: expected_runtime_provider.to_string(),
+        expected_api_key_present,
+        expected_api_key_source: expected_api_key_source.map(ToString::to_string),
+        expected_local_no_key_allowed,
+        expected_openai_pro_backend,
+    }
+}
+
+fn chatgpt_oauth_fixture_token(account_id: &str) -> String {
+    let payload = base64_url_no_pad(format!(
+        r#"{{"sub":"user-smoke","https://api.openai.com/auth":{{"chatgpt_account_id":"{account_id}","chatgpt_plan_type":"plus"}}}}"#
+    )
+    .as_bytes());
+    format!("eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.{payload}.sig")
+}
+
+fn base64_url_no_pad(bytes: &[u8]) -> String {
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
 }
 
 fn provider_runtime_api_key_source(

--- a/crates/hermes-provider-runtime/src/lib_tests.rs
+++ b/crates/hermes-provider-runtime/src/lib_tests.rs
@@ -302,6 +302,119 @@ mod tests {
         assert!(moa.local_no_key_allowed);
     }
 
+    fn provider_smoke_env_vars() -> &'static [&'static str] {
+        &[
+            "HERMES_OPENAI_API_KEY",
+            "OPENAI_API_KEY",
+            "HERMES_OPENAI_CODEX_API_KEY",
+            "NOUS_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_TOKEN",
+            "CLAUDE_CODE_OAUTH_TOKEN",
+            "HERMES_GEMINI_OAUTH_API_KEY",
+            "GOOGLE_API_KEY",
+            "GEMINI_API_KEY",
+            "HERMES_QWEN_OAUTH_API_KEY",
+            "DASHSCOPE_API_KEY",
+            "OPENROUTER_API_KEY",
+            "OLLAMA_API_KEY",
+            "OLLAMA_LOCAL_API_KEY",
+            "LLAMA_CPP_API_KEY",
+        ]
+    }
+
+    #[test]
+    fn provider_auth_smoke_matrix_covers_requested_runtime_families() {
+        let _guard = env_test_lock();
+        let _env = EnvSnapshot::capture(provider_smoke_env_vars());
+        for key in provider_smoke_env_vars() {
+            std::env::remove_var(key);
+        }
+
+        let matrix = deterministic_provider_auth_smoke_matrix();
+
+        assert!(matrix.pass, "{matrix:#?}");
+        assert_eq!(matrix.summary.failed, 0);
+        assert_eq!(matrix.summary.total, 9);
+        for provider in [
+            "anthropic",
+            "google-gemini-cli",
+            "llama-cpp",
+            "moa",
+            "nous",
+            "openai",
+            "openai-codex",
+            "openrouter",
+            "qwen-oauth",
+        ] {
+            assert!(
+                matrix
+                    .summary
+                    .covered_runtime_providers
+                    .contains(&provider.to_string()),
+                "missing provider {provider}: {matrix:#?}"
+            );
+        }
+        let openai = matrix
+            .results
+            .iter()
+            .find(|result| result.id == "openai_dynamic_chatgpt_oauth")
+            .expect("openai dynamic case");
+        assert_eq!(openai.model, "openai:dynamic");
+        assert_eq!(openai.api_key_source.as_deref(), Some("config.api_key"));
+        assert!(openai.uses_openai_pro_backend);
+
+        let qwen = matrix
+            .results
+            .iter()
+            .find(|result| result.id == "qwen_oauth_resolver")
+            .expect("qwen oauth case");
+        assert_eq!(qwen.runtime_provider, "qwen-oauth");
+        assert_eq!(
+            qwen.api_key_source.as_deref(),
+            Some("oauth_resolver:qwen-cli")
+        );
+
+        let local = matrix
+            .results
+            .iter()
+            .find(|result| result.id == "local_no_key_llamafile")
+            .expect("local no-key case");
+        assert!(!local.api_key_present);
+        assert!(local.local_no_key_allowed);
+    }
+
+    #[test]
+    fn provider_auth_smoke_matrix_reports_actionable_failures() {
+        let _guard = env_test_lock();
+        let _env = EnvSnapshot::capture(provider_smoke_env_vars());
+        for key in provider_smoke_env_vars() {
+            std::env::remove_var(key);
+        }
+
+        let cfg = GatewayConfig::default();
+        let matrix = provider_auth_smoke_matrix_with_auth_resolver(
+            &cfg,
+            &[provider_auth_smoke_case(
+                "openrouter_missing_key",
+                "openrouter:anthropic/claude-sonnet-4.6",
+                "openrouter",
+                true,
+                Some("config.api_key"),
+                false,
+                false,
+            )],
+            None,
+        );
+
+        assert!(!matrix.pass);
+        assert_eq!(matrix.summary.failed, 1);
+        assert!(matrix.results[0]
+            .failures
+            .iter()
+            .any(|failure| failure.contains("api_key_present")));
+    }
+
     #[test]
     fn resolve_provider_and_model_uses_single_provider_fallback() {
         let mut cfg = GatewayConfig::default();

--- a/crates/hermes-tools/src/tools/mod.rs
+++ b/crates/hermes-tools/src/tools/mod.rs
@@ -46,6 +46,7 @@ pub mod transcription;
 pub mod tts;
 pub mod tts_premium;
 pub mod ultra_autonomy;
+pub mod ultra_autonomy_evals;
 pub mod ultra_features;
 pub mod url_safety;
 pub mod video;

--- a/crates/hermes-tools/src/tools/ultra_autonomy.rs
+++ b/crates/hermes-tools/src/tools/ultra_autonomy.rs
@@ -18,6 +18,11 @@ use serde_json::{json, Value};
 
 use hermes_core::{tool_schema, JsonSchema, ToolError, ToolHandler, ToolSchema};
 
+use crate::tools::ultra_autonomy_evals::{
+    evaluate_outcome_loop_rehearsal, evaluate_recall_quality, OutcomeLoopRehearsalInput,
+    RecallQualityInput,
+};
+
 const TOOL_NAME: &str = "ultra_autonomy";
 const LOOP_IDENTICAL_THRESHOLD: usize = 4;
 const LOOP_SIMILAR_FAILURE_THRESHOLD: usize = 6;
@@ -98,6 +103,8 @@ impl ToolHandler for UltraAutonomyHandler {
             "resource_plan" => resource_plan_action(&params),
             "memory_lifecycle" => memory_lifecycle_action(&params),
             "memory_resolve" => memory_resolve_action(&params)?,
+            "outcome_rehearsal" => outcome_rehearsal_action(&params)?,
+            "recall_quality" => recall_quality_action(&params)?,
             "service_plan" => service_plan_action(),
             "channel_surface" => channel_surface_action(),
             "events" => event_catalog_action(),
@@ -121,7 +128,8 @@ impl ToolHandler for UltraAutonomyHandler {
                 "enum": [
                     "status", "loop_record", "loop_evaluate", "board_create",
                     "board_add_card", "board_update", "board_plan", "objective_bridge",
-                    "resource_plan", "memory_lifecycle", "memory_resolve", "service_plan",
+                    "resource_plan", "memory_lifecycle", "memory_resolve",
+                    "outcome_rehearsal", "recall_quality", "service_plan",
                     "channel_surface", "events", "help"
                 ],
                 "description": "Autonomy cockpit action. Defaults to status."
@@ -144,6 +152,30 @@ impl ToolHandler for UltraAutonomyHandler {
         props.insert(
             "providers".into(),
             json!({"type":"array", "description":"Memory provider signals for memory_lifecycle."}),
+        );
+        props.insert(
+            "plan_steps".into(),
+            json!({"type":"array", "description":"Outcome rehearsal plan steps."}),
+        );
+        props.insert(
+            "tool_calls".into(),
+            json!({"type":"array", "description":"Outcome rehearsal tool-call evidence."}),
+        );
+        props.insert(
+            "verification".into(),
+            json!({"type":"array", "description":"Deterministic verification evidence."}),
+        );
+        props.insert(
+            "checkpoints".into(),
+            json!({"type":"array", "description":"Durable checkpoint, PR, commit, release, or ContextLattice evidence."}),
+        );
+        props.insert(
+            "recall_items".into(),
+            json!({"type":"array", "description":"Recall/synthesis pack items for recall_quality."}),
+        );
+        props.insert(
+            "outcome".into(),
+            json!({"type":"object", "description":"Task outcome evidence for recall_quality."}),
         );
         props.insert("cpu_cores".into(), int_schema("Available CPU cores."));
         props.insert("free_ram_mb".into(), int_schema("Free RAM in MB."));
@@ -770,6 +802,8 @@ fn autonomy_status_snapshot(state: &UltraAutonomyState) -> Value {
             "approval_laundering_regression_tests",
             "contextlattice_first_memory_lifecycle",
             "memory_conflict_reinforcement_resolution",
+            "deterministic_outcome_loop_rehearsal",
+            "contextlattice_recall_quality_outcome_eval",
             "one_command_service_plan",
             "channel_skill_permission_status_surface",
             "objective_to_board_bridge"
@@ -1053,6 +1087,18 @@ fn memory_resolve_action(params: &Value) -> Result<Value, ToolError> {
     Ok(json!({"resolution": resolve_memory_candidate(existing, candidate, overlap, conflict)}))
 }
 
+fn outcome_rehearsal_action(params: &Value) -> Result<Value, ToolError> {
+    let input = serde_json::from_value::<OutcomeLoopRehearsalInput>(params.clone())
+        .map_err(|err| ToolError::InvalidParams(format!("outcome_rehearsal: {err}")))?;
+    Ok(json!({"report": evaluate_outcome_loop_rehearsal(input)}))
+}
+
+fn recall_quality_action(params: &Value) -> Result<Value, ToolError> {
+    let input = serde_json::from_value::<RecallQualityInput>(params.clone())
+        .map_err(|err| ToolError::InvalidParams(format!("recall_quality: {err}")))?;
+    Ok(json!({"report": evaluate_recall_quality(input)}))
+}
+
 fn service_plan_action() -> Value {
     json!({
         "status": "ok",
@@ -1095,8 +1141,8 @@ fn help_action() -> Value {
         "actions": [
             "status", "loop_record", "loop_evaluate", "board_create", "board_add_card",
             "board_update", "board_plan", "objective_bridge", "resource_plan",
-            "memory_lifecycle", "memory_resolve", "service_plan", "channel_surface",
-            "events", "help"
+            "memory_lifecycle", "memory_resolve", "outcome_rehearsal", "recall_quality",
+            "service_plan", "channel_surface", "events", "help"
         ]
     })
 }
@@ -1109,6 +1155,8 @@ fn event_catalog() -> Vec<Value> {
         json!({"event":"board.plan.updated", "consumer":"dashboard SSE", "purpose":"ready/blocked execution plan changed"}),
         json!({"event":"objective.board.created", "consumer":"ContextLattice checkpoint", "purpose":"objective materialized into durable cards"}),
         json!({"event":"memory.lifecycle.updated", "consumer":"harness cockpit", "purpose":"hot/warm/archive memory projection changed"}),
+        json!({"event":"eval.outcome_rehearsal.scored", "consumer":"harness cockpit", "purpose":"plan/tool/verification/checkpoint/recovery gates scored"}),
+        json!({"event":"eval.recall_quality.scored", "consumer":"ContextLattice synthesis pack", "purpose":"recall tied to implementation and verification outcomes"}),
         json!({"event":"subagent.resource.plan", "consumer":"delegate_task", "purpose":"admission control changed"}),
     ]
 }

--- a/crates/hermes-tools/src/tools/ultra_autonomy_evals.rs
+++ b/crates/hermes-tools/src/tools/ultra_autonomy_evals.rs
@@ -1,0 +1,548 @@
+//! Deterministic autonomy evals for outcome loops and memory recall quality.
+//!
+//! These helpers are deliberately pure: callers provide the turn evidence and
+//! the report scores whether the work would satisfy Hermes' runtime contract.
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+
+const PASS_SCORE: u8 = 80;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct OutcomeLoopRehearsalInput {
+    #[serde(default)]
+    pub objective: String,
+    #[serde(default)]
+    pub plan_steps: Vec<String>,
+    #[serde(default)]
+    pub tool_calls: Vec<RehearsalToolUse>,
+    #[serde(default)]
+    pub verification: Vec<String>,
+    #[serde(default)]
+    pub checkpoints: Vec<String>,
+    #[serde(default)]
+    pub recovery_events: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct RehearsalToolUse {
+    #[serde(default)]
+    pub tool: String,
+    #[serde(default)]
+    pub purpose: String,
+    #[serde(default)]
+    pub outcome: String,
+    #[serde(default)]
+    pub evidence: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EvalGate {
+    pub id: String,
+    pub label: String,
+    pub score: u8,
+    pub max_score: u8,
+    pub passed: bool,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OutcomeLoopRehearsalReport {
+    pub score: u8,
+    pub max_score: u8,
+    pub pass: bool,
+    pub gates: Vec<EvalGate>,
+    pub failed_gates: Vec<String>,
+    pub next_action: String,
+}
+
+pub fn evaluate_outcome_loop_rehearsal(
+    input: OutcomeLoopRehearsalInput,
+) -> OutcomeLoopRehearsalReport {
+    let mut gates = Vec::new();
+
+    let plan_steps = non_empty(&input.plan_steps);
+    gates.push(gate(
+        "plan",
+        "Objective and execution plan",
+        if !input.objective.trim().is_empty() && plan_steps.len() >= 2 {
+            20
+        } else if !input.objective.trim().is_empty() && !plan_steps.is_empty() {
+            12
+        } else {
+            0
+        },
+        if !input.objective.trim().is_empty() && plan_steps.len() >= 2 {
+            "objective plus at least two concrete plan steps"
+        } else if !input.objective.trim().is_empty() {
+            "objective present but plan is too shallow"
+        } else {
+            "missing objective or actionable plan"
+        },
+    ));
+
+    let useful_tools = input
+        .tool_calls
+        .iter()
+        .filter(|call| !call.tool.trim().is_empty())
+        .count();
+    let grounded_tools = input
+        .tool_calls
+        .iter()
+        .filter(|call| tool_grounded(call))
+        .count();
+    gates.push(gate(
+        "tool_use",
+        "Purposeful tool use with evidence",
+        if useful_tools > 0 && grounded_tools == useful_tools {
+            20
+        } else if useful_tools > 0 {
+            12
+        } else {
+            0
+        },
+        if useful_tools > 0 && grounded_tools == useful_tools {
+            "every tool call has purpose and outcome evidence"
+        } else if useful_tools > 0 {
+            "tool calls exist but some lack purpose or evidence"
+        } else {
+            "no tool-backed evidence"
+        },
+    ));
+
+    let verification = non_empty(&input.verification);
+    let verification_grounded = verification
+        .iter()
+        .any(|item| contains_any(item, VERIFICATION_TERMS));
+    gates.push(gate(
+        "verification",
+        "Deterministic verification",
+        if verification_grounded {
+            20
+        } else if !verification.is_empty() {
+            12
+        } else {
+            0
+        },
+        if verification_grounded {
+            "verification includes deterministic pass/check evidence"
+        } else if !verification.is_empty() {
+            "verification notes exist but lack deterministic pass/check terms"
+        } else {
+            "missing verification evidence"
+        },
+    ));
+
+    let checkpoints = non_empty(&input.checkpoints);
+    let checkpoint_grounded = checkpoints
+        .iter()
+        .any(|item| contains_any(item, CHECKPOINT_TERMS));
+    gates.push(gate(
+        "checkpoint",
+        "Durable checkpoint or handoff",
+        if checkpoint_grounded {
+            20
+        } else if !checkpoints.is_empty() {
+            12
+        } else {
+            0
+        },
+        if checkpoint_grounded {
+            "checkpoint is tied to durable PR/commit/release/ContextLattice evidence"
+        } else if !checkpoints.is_empty() {
+            "checkpoint exists but is weakly grounded"
+        } else {
+            "missing durable checkpoint"
+        },
+    ));
+
+    let failed_tools = input
+        .tool_calls
+        .iter()
+        .filter(|call| contains_any(&call.outcome, FAILURE_TERMS))
+        .count();
+    let recovery = non_empty(&input.recovery_events);
+    gates.push(gate(
+        "recovery",
+        "Recovery from failures or clean no-failure proof",
+        if failed_tools == 0 || !recovery.is_empty() {
+            20
+        } else {
+            0
+        },
+        if failed_tools == 0 {
+            "no failed tool outcomes requiring recovery"
+        } else if !recovery.is_empty() {
+            "failed tool outcomes have explicit recovery events"
+        } else {
+            "failed tool outcomes lack recovery evidence"
+        },
+    ));
+
+    finish_report(gates)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct RecallQualityInput {
+    #[serde(default)]
+    pub query: String,
+    #[serde(default)]
+    pub recall_items: Vec<RecallQualityItem>,
+    #[serde(default)]
+    pub outcome: TaskOutcomeEvidence,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct RecallQualityItem {
+    #[serde(default)]
+    pub source: String,
+    #[serde(default)]
+    pub summary: String,
+    #[serde(default)]
+    pub relevance: f64,
+    #[serde(default)]
+    pub used_for: Vec<String>,
+    #[serde(default)]
+    pub outcome_links: Vec<String>,
+    #[serde(default)]
+    pub provenance: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct TaskOutcomeEvidence {
+    #[serde(default)]
+    pub objective: String,
+    #[serde(default)]
+    pub implemented_items: Vec<String>,
+    #[serde(default)]
+    pub checks: Vec<String>,
+    #[serde(default)]
+    pub checkpoint: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RecallQualityReport {
+    pub score: u8,
+    pub max_score: u8,
+    pub pass: bool,
+    pub gates: Vec<EvalGate>,
+    pub failed_gates: Vec<String>,
+    pub next_action: String,
+}
+
+pub fn evaluate_recall_quality(input: RecallQualityInput) -> RecallQualityReport {
+    let mut gates = Vec::new();
+    let items = input
+        .recall_items
+        .iter()
+        .filter(|item| {
+            !item.source.trim().is_empty()
+                || !item.summary.trim().is_empty()
+                || item.relevance > 0.0
+        })
+        .collect::<Vec<_>>();
+
+    gates.push(gate(
+        "recall_available",
+        "Recall returned usable items",
+        if items.is_empty() { 0 } else { 20 },
+        if items.is_empty() {
+            "no usable recall items"
+        } else {
+            "recall items are available"
+        },
+    ));
+
+    let provenance_count = items
+        .iter()
+        .filter(|item| !item.source.trim().is_empty() && !item.provenance.trim().is_empty())
+        .count();
+    gates.push(gate(
+        "provenance",
+        "Recall has source provenance",
+        if !items.is_empty() && provenance_count == items.len() {
+            20
+        } else if provenance_count > 0 {
+            12
+        } else {
+            0
+        },
+        if !items.is_empty() && provenance_count == items.len() {
+            "every recall item has source and provenance"
+        } else if provenance_count > 0 {
+            "some recall items have source provenance"
+        } else {
+            "recall is not source/provenance grounded"
+        },
+    ));
+
+    let query_terms = terms(&input.query)
+        .into_iter()
+        .chain(terms(&input.outcome.objective))
+        .collect::<BTreeSet<_>>();
+    let aligned = items.iter().any(|item| {
+        item.relevance >= 0.65
+            || !query_terms.is_empty() && !terms(&item.summary).is_disjoint(&query_terms)
+    });
+    gates.push(gate(
+        "objective_alignment",
+        "Recall aligns with the objective",
+        if aligned { 20 } else { 0 },
+        if aligned {
+            "recall overlaps the query/objective or carries high relevance"
+        } else {
+            "recall availability is not enough without objective alignment"
+        },
+    ));
+
+    let implementation_evidence = !non_empty(&input.outcome.implemented_items).is_empty();
+    let implementation_linked = implementation_evidence
+        && items.iter().any(|item| {
+            item.used_for
+                .iter()
+                .chain(item.outcome_links.iter())
+                .any(|value| contains_any(value, IMPLEMENTATION_TERMS))
+        });
+    gates.push(gate(
+        "implementation_impact",
+        "Recall influenced implementation outcome",
+        if implementation_linked { 20 } else { 0 },
+        if implementation_linked {
+            "recall is linked to implemented items"
+        } else {
+            "recall was not tied to any implementation outcome"
+        },
+    ));
+
+    let verification_evidence = !non_empty(&input.outcome.checks).is_empty();
+    let verification_linked = verification_evidence
+        && items.iter().any(|item| {
+            item.used_for
+                .iter()
+                .chain(item.outcome_links.iter())
+                .any(|value| contains_any(value, VERIFICATION_TERMS))
+        });
+    gates.push(gate(
+        "verification_impact",
+        "Recall influenced verification outcome",
+        if verification_linked { 20 } else { 0 },
+        if verification_linked {
+            "recall is linked to deterministic checks"
+        } else {
+            "recall was not tied to verification evidence"
+        },
+    ));
+
+    let outcome = finish_report(gates);
+    RecallQualityReport {
+        score: outcome.score,
+        max_score: outcome.max_score,
+        pass: outcome.pass,
+        gates: outcome.gates,
+        failed_gates: outcome.failed_gates,
+        next_action: outcome.next_action,
+    }
+}
+
+fn finish_report(gates: Vec<EvalGate>) -> OutcomeLoopRehearsalReport {
+    let score = gates.iter().map(|gate| gate.score).sum::<u8>();
+    let max_score = gates.iter().map(|gate| gate.max_score).sum::<u8>();
+    let failed_gates = gates
+        .iter()
+        .filter(|gate| !gate.passed)
+        .map(|gate| gate.id.clone())
+        .collect::<Vec<_>>();
+    let pass = score >= PASS_SCORE && failed_gates.is_empty();
+    let next_action = if pass {
+        "promote to implementation/merge gate; continue recording deterministic evidence"
+            .to_string()
+    } else {
+        format!(
+            "repair failed eval gates before promotion: {}",
+            failed_gates.join(", ")
+        )
+    };
+    OutcomeLoopRehearsalReport {
+        score,
+        max_score,
+        pass,
+        gates,
+        failed_gates,
+        next_action,
+    }
+}
+
+fn gate(id: &str, label: &str, score: u8, reason: &str) -> EvalGate {
+    EvalGate {
+        id: id.to_string(),
+        label: label.to_string(),
+        score,
+        max_score: 20,
+        passed: score == 20,
+        reason: reason.to_string(),
+    }
+}
+
+fn tool_grounded(call: &RehearsalToolUse) -> bool {
+    !call.tool.trim().is_empty()
+        && !call.purpose.trim().is_empty()
+        && (!call.outcome.trim().is_empty() || !call.evidence.trim().is_empty())
+}
+
+fn non_empty(values: &[String]) -> Vec<&str> {
+    values
+        .iter()
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .collect()
+}
+
+fn terms(value: &str) -> BTreeSet<String> {
+    value
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .map(str::trim)
+        .filter(|part| part.len() >= 3)
+        .map(str::to_ascii_lowercase)
+        .collect()
+}
+
+fn contains_any(value: &str, needles: &[&str]) -> bool {
+    let lower = value.to_ascii_lowercase();
+    needles.iter().any(|needle| lower.contains(needle))
+}
+
+const VERIFICATION_TERMS: &[&str] = &[
+    "pass", "passed", "green", "ok", "check", "checked", "verified", "test", "cargo", "pytest",
+    "ci",
+];
+
+const CHECKPOINT_TERMS: &[&str] = &[
+    "contextlattice",
+    "checkpoint",
+    "commit",
+    "pr #",
+    "pull request",
+    "merged",
+    "tag",
+    "release",
+];
+
+const FAILURE_TERMS: &[&str] = &["fail", "failed", "error", "timeout", "timed out", "blocked"];
+
+const IMPLEMENTATION_TERMS: &[&str] = &[
+    "implement",
+    "implemented",
+    "code",
+    "patch",
+    "rust",
+    "provider",
+    "release",
+    "ci",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn outcome_loop_rehearsal_passes_with_recovery_and_checkpoint() {
+        let report = evaluate_outcome_loop_rehearsal(OutcomeLoopRehearsalInput {
+            objective: "Close provider and release smoke gaps".to_string(),
+            plan_steps: vec![
+                "Inspect repo state".to_string(),
+                "Implement Rust matrix".to_string(),
+            ],
+            tool_calls: vec![
+                RehearsalToolUse {
+                    tool: "rg".to_string(),
+                    purpose: "find provider auth code".to_string(),
+                    outcome: "passed with matching files".to_string(),
+                    evidence: "crates/hermes-provider-runtime/src/lib.rs".to_string(),
+                },
+                RehearsalToolUse {
+                    tool: "cargo test".to_string(),
+                    purpose: "verify new evals".to_string(),
+                    outcome: "failed before import fix".to_string(),
+                    evidence: "compiler error captured".to_string(),
+                },
+            ],
+            verification: vec!["cargo test -p hermes-tools ultra_autonomy passed".to_string()],
+            checkpoints: vec!["ContextLattice checkpoint recorded for PR #720".to_string()],
+            recovery_events: vec!["fixed import and reran test green".to_string()],
+        });
+
+        assert!(report.pass);
+        assert_eq!(report.score, 100);
+    }
+
+    #[test]
+    fn outcome_loop_rehearsal_rejects_unverified_work() {
+        let report = evaluate_outcome_loop_rehearsal(OutcomeLoopRehearsalInput {
+            objective: "Ship change".to_string(),
+            plan_steps: vec!["Patch".to_string(), "Report".to_string()],
+            tool_calls: vec![RehearsalToolUse {
+                tool: "apply_patch".to_string(),
+                purpose: "edit code".to_string(),
+                outcome: "ok".to_string(),
+                evidence: "diff exists".to_string(),
+            }],
+            ..OutcomeLoopRehearsalInput::default()
+        });
+
+        assert!(!report.pass);
+        assert!(report.failed_gates.contains(&"verification".to_string()));
+        assert!(report.failed_gates.contains(&"checkpoint".to_string()));
+    }
+
+    #[test]
+    fn recall_quality_requires_outcome_linkage_not_just_items() {
+        let report = evaluate_recall_quality(RecallQualityInput {
+            query: "provider auth smoke".to_string(),
+            recall_items: vec![RecallQualityItem {
+                source: "contextlattice_synthesis_pack".to_string(),
+                summary: "Provider auth smoke matrix exists".to_string(),
+                relevance: 0.95,
+                provenance: "runbooks/codex-integration".to_string(),
+                ..RecallQualityItem::default()
+            }],
+            outcome: TaskOutcomeEvidence::default(),
+        });
+
+        assert!(!report.pass);
+        assert!(report
+            .failed_gates
+            .contains(&"implementation_impact".to_string()));
+        assert!(report
+            .failed_gates
+            .contains(&"verification_impact".to_string()));
+    }
+
+    #[test]
+    fn recall_quality_passes_when_synthesis_pack_drives_checked_outcome() {
+        let report = evaluate_recall_quality(RecallQualityInput {
+            query: "ContextLattice synthesis pack outcome eval".to_string(),
+            recall_items: vec![RecallQualityItem {
+                source: "contextlattice_synthesis_pack".to_string(),
+                summary: "Use synthesis pack as guardrail for outcome eval implementation"
+                    .to_string(),
+                relevance: 0.91,
+                used_for: vec!["implementation".to_string(), "verification".to_string()],
+                outcome_links: vec![
+                    "implemented Rust recall quality eval".to_string(),
+                    "cargo test verification passed".to_string(),
+                ],
+                provenance: "runbooks/codex-integration".to_string(),
+            }],
+            outcome: TaskOutcomeEvidence {
+                objective: "Implement outcome eval tied to ContextLattice recall".to_string(),
+                implemented_items: vec!["Rust recall quality eval".to_string()],
+                checks: vec!["cargo test -p hermes-tools ultra_autonomy_evals passed".to_string()],
+                checkpoint: "ContextLattice checkpoint".to_string(),
+            },
+        });
+
+        assert!(report.pass);
+        assert_eq!(report.score, 100);
+    }
+}

--- a/docs/parity/adapter-feature-matrix.json
+++ b/docs/parity/adapter-feature-matrix.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-07-07T21:51:23.676108+00:00",
+  "generated_at_utc": "2026-07-08T09:23:41.672641+00:00",
   "items": [
     {
       "category": "memory_plugin",

--- a/docs/parity/adapter-feature-matrix.md
+++ b/docs/parity/adapter-feature-matrix.md
@@ -1,6 +1,6 @@
 # Adapter Feature Matrix
 
-Generated: `2026-07-07T21:51:23.676108+00:00`
+Generated: `2026-07-08T09:23:41.672641+00:00`
 
 | Category | Name | Feature Flag | Status |
 | --- | --- | --- | --- |

--- a/docs/parity/divergence-validation.json
+++ b/docs/parity/divergence-validation.json
@@ -1,6 +1,6 @@
 {
   "divergence_file": "/Volumes/wd_black/hermes-agent-ultra/repo/docs/parity/intentional-divergence.json",
-  "generated_at_utc": "2026-07-07T21:51:24.786179+00:00",
+  "generated_at_utc": "2026-07-08T09:23:42.769078+00:00",
   "items": [
     {
       "errors": [],
@@ -297,10 +297,10 @@
   "summary": {
     "errors": 0,
     "items": 13,
-    "local_paths": 4072,
+    "local_paths": 4074,
     "review_overdue": 0,
     "unowned": 0,
-    "upstream_paths": 6159,
+    "upstream_paths": 6177,
     "warnings": 1
   }
 }

--- a/docs/parity/global-parity-proof.json
+++ b/docs/parity/global-parity-proof.json
@@ -58,7 +58,7 @@
         "status": "pass"
       },
       {
-        "actual": 3422.0,
+        "actual": 3439.0,
         "limit": 2600,
         "metric": "max_files_only_upstream",
         "status": "fail"
@@ -248,7 +248,7 @@
       "unverified_cases": 0
     }
   },
-  "generated_at_utc": "2026-07-07T21:51:26.217875+00:00",
+  "generated_at_utc": "2026-07-08T09:23:44.209378+00:00",
   "gpar_completion": {
     "GPAR-01": true,
     "GPAR-02": true,
@@ -273,7 +273,7 @@
     "max_deep_problem_solving_regressions": 0.0,
     "max_deep_problem_solving_unverified_cases": 0.0,
     "max_divergence_review_overdue": 0.0,
-    "max_files_only_upstream": 3422.0,
+    "max_files_only_upstream": 3439.0,
     "max_queue_pending_commits": 0.0,
     "max_sota_harness_critical_gaps": 0.0,
     "max_sota_harness_missing_rust_refs": 0.0,
@@ -516,9 +516,9 @@
       "divergence_unowned": 0,
       "missing_rust_test_refs": 0,
       "queue_pending": 0,
-      "queue_total": 1,
-      "rust_test_files": 422,
-      "rust_test_functions": 7391,
+      "queue_total": 51,
+      "rust_test_files": 423,
+      "rust_test_functions": 7412,
       "test_intent_mapping_ratio": 1.0,
       "test_intents_mapped": 10,
       "test_intents_total": 10,

--- a/docs/parity/global-parity-proof.md
+++ b/docs/parity/global-parity-proof.md
@@ -1,6 +1,6 @@
 # Global Parity Proof
 
-Generated: `2026-07-07T21:51:26.217875+00:00`
+Generated: `2026-07-08T09:23:44.209378+00:00`
 
 ## Gate Status
 
@@ -15,7 +15,7 @@ Generated: `2026-07-07T21:51:26.217875+00:00`
 | --- | ---: |
 | `max_commits_behind` | 1.0 |
 | `max_upstream_patch_missing` | 1.0 |
-| `max_files_only_upstream` | 3422.0 |
+| `max_files_only_upstream` | 3439.0 |
 | `max_unowned_divergences` | 0.0 |
 | `max_divergence_review_overdue` | 0.0 |
 | `min_test_intent_mapping_ratio` | 1.0 |

--- a/docs/parity/parity-matrix.json
+++ b/docs/parity/parity-matrix.json
@@ -1,25 +1,25 @@
 {
-  "generated_at_utc": "2026-07-07T21:51:21.663142+00:00",
+  "generated_at_utc": "2026-07-08T09:23:39.924163+00:00",
   "refs": {
     "local_ref": "HEAD",
-    "local_sha": "8c58db72e5e53c349a77cd59efe3e5b86b001adf",
+    "local_sha": "4f83eedf9cfafa82d81b3f2ea8ada0027536c99a",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "5e51b123f32b7f6a51fbd5759e89ba5146ce4003",
+    "upstream_sha": "f64e4f4f5768c18a53f44890747653bafcab2796",
     "merge_base": null
   },
   "summary": {
     "commits_behind": 1,
-    "commits_ahead": 1334,
+    "commits_ahead": 1337,
     "upstream_patch_missing": 1,
     "upstream_patch_represented": 0,
-    "local_patch_unique": 1068,
-    "files_only_upstream": 3422,
-    "files_only_local": 1335,
+    "local_patch_unique": 1071,
+    "files_only_upstream": 3439,
+    "files_only_local": 1336,
     "files_shared_identical": 1458,
-    "files_shared_different": 1279,
-    "tree_files_changed": 5934,
-    "tree_insertions": 1360345,
-    "tree_deletions": 602812
+    "files_shared_different": 1280,
+    "tree_files_changed": 5953,
+    "tree_insertions": 1369575,
+    "tree_deletions": 606983
   },
   "top_upstream_only": [
     {
@@ -32,15 +32,15 @@
     },
     {
       "path": "tests/hermes_cli",
-      "count": 227
+      "count": 229
     },
     {
       "path": "tests/gateway",
-      "count": 221
+      "count": 226
     },
     {
       "path": "tests/agent",
-      "count": 152
+      "count": 153
     },
     {
       "path": "web/src",
@@ -48,7 +48,7 @@
     },
     {
       "path": "tests/tools",
-      "count": 101
+      "count": 104
     },
     {
       "path": "optional-skills/creative",
@@ -100,14 +100,14 @@
     },
     {
       "path": "tests/tui_gateway",
-      "count": 18
-    },
-    {
-      "path": ".github/workflows",
-      "count": 14
+      "count": 19
     },
     {
       "path": "tests/cron",
+      "count": 15
+    },
+    {
+      "path": ".github/workflows",
       "count": 14
     },
     {
@@ -395,11 +395,11 @@
       "count": 18
     },
     {
-      "path": "crates/hermes-eval",
-      "count": 16
+      "path": "docs/releases",
+      "count": 17
     },
     {
-      "path": "docs/releases",
+      "path": "crates/hermes-eval",
       "count": 16
     },
     {
@@ -518,15 +518,15 @@
     },
     {
       "path": "tests/hermes_cli",
-      "count": 227
+      "count": 229
     },
     {
       "path": "tests/gateway",
-      "count": 221
+      "count": 226
     },
     {
       "path": "tests/agent",
-      "count": 152
+      "count": 153
     },
     {
       "path": "web/src",
@@ -534,7 +534,7 @@
     },
     {
       "path": "tests/tools",
-      "count": 101
+      "count": 104
     },
     {
       "path": "optional-skills/creative",
@@ -586,14 +586,14 @@
     },
     {
       "path": "tests/tui_gateway",
-      "count": 18
-    },
-    {
-      "path": ".github/workflows",
-      "count": 14
+      "count": 19
     },
     {
       "path": "tests/cron",
+      "count": 15
+    },
+    {
+      "path": ".github/workflows",
       "count": 14
     },
     {
@@ -719,11 +719,11 @@
       "count": 18
     },
     {
-      "path": "crates/hermes-eval",
-      "count": 16
+      "path": "docs/releases",
+      "count": 17
     },
     {
-      "path": "docs/releases",
+      "path": "crates/hermes-eval",
       "count": 16
     },
     {
@@ -836,7 +836,7 @@
       "workstream": "WS6",
       "issue": 10,
       "name": "Tests and CI parity",
-      "upstream_only": 1004,
+      "upstream_only": 1019,
       "shared_different": 798,
       "local_only": 43,
       "risk": "critical",
@@ -846,8 +846,8 @@
       "workstream": "WS8",
       "issue": 12,
       "name": "Compatibility and divergence policy",
-      "upstream_only": 1421,
-      "shared_different": 12,
+      "upstream_only": 1422,
+      "shared_different": 13,
       "local_only": 454,
       "risk": "critical",
       "effort": "XL"
@@ -858,7 +858,7 @@
       "name": "UX parity",
       "upstream_only": 587,
       "shared_different": 328,
-      "local_only": 137,
+      "local_only": 138,
       "risk": "high",
       "effort": "XL"
     },
@@ -866,7 +866,7 @@
       "workstream": "WS3",
       "issue": 7,
       "name": "Tools and adapters parity",
-      "upstream_only": 180,
+      "upstream_only": 181,
       "shared_different": 102,
       "local_only": 161,
       "risk": "high",
@@ -906,10 +906,10 @@
   "commit_mapping": {
     "upstream_patch_missing": 1,
     "upstream_patch_represented": 0,
-    "local_patch_unique": 1068,
+    "local_patch_unique": 1071,
     "local_patch_equivalent_to_upstream": 0,
     "upstream_patch_missing_sample": [
-      "5e51b123f32b7f6a51fbd5759e89ba5146ce4003"
+      "f64e4f4f5768c18a53f44890747653bafcab2796"
     ],
     "upstream_patch_represented_sample": [],
     "local_patch_unique_sample": [

--- a/docs/parity/parity-matrix.md
+++ b/docs/parity/parity-matrix.md
@@ -1,11 +1,11 @@
 # Parity Matrix
 
-Generated: `2026-07-07T21:51:21.663142+00:00`
+Generated: `2026-07-08T09:23:39.924163+00:00`
 
 ## Scope
 
-- Local ref: `HEAD` (`8c58db72e5e53c349a77cd59efe3e5b86b001adf`)
-- Upstream ref: `upstream/main` (`5e51b123f32b7f6a51fbd5759e89ba5146ce4003`)
+- Local ref: `HEAD` (`4f83eedf9cfafa82d81b3f2ea8ada0027536c99a`)
+- Upstream ref: `upstream/main` (`f64e4f4f5768c18a53f44890747653bafcab2796`)
 - Merge base: `none (history divergence)`
 
 ## Summary
@@ -13,17 +13,17 @@ Generated: `2026-07-07T21:51:21.663142+00:00`
 | Metric | Value |
 | --- | ---: |
 | Commits behind local (`upstream` ancestry only) | 1 |
-| Commits ahead local (`local` ancestry only) | 1334 |
+| Commits ahead local (`local` ancestry only) | 1337 |
 | Upstream commits missing by patch-id (`git cherry local upstream`, `+`) | 1 |
 | Upstream commits represented by patch-id (`git cherry local upstream`, `-`) | 0 |
-| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 1068 |
-| Files only in upstream tree | 3422 |
-| Files only in local tree | 1335 |
+| Local commits unique by patch-id (`git cherry upstream local`, `+`) | 1071 |
+| Files only in upstream tree | 3439 |
+| Files only in local tree | 1336 |
 | Shared files identical content | 1458 |
-| Shared files different content | 1279 |
-| Total files changed (`local` vs `upstream`) | 5934 |
-| Insertions (`local` vs `upstream`) | 1360345 |
-| Deletions (`local` vs `upstream`) | 602812 |
+| Shared files different content | 1280 |
+| Total files changed (`local` vs `upstream`) | 5953 |
+| Insertions (`local` vs `upstream`) | 1369575 |
+| Deletions (`local` vs `upstream`) | 606983 |
 
 ## Top 40 upstream-only buckets
 
@@ -31,11 +31,11 @@ Generated: `2026-07-07T21:51:21.663142+00:00`
 | --- | ---: |
 | `apps/desktop` | 833 |
 | `website/i18n` | 313 |
-| `tests/hermes_cli` | 227 |
-| `tests/gateway` | 221 |
-| `tests/agent` | 152 |
+| `tests/hermes_cli` | 229 |
+| `tests/gateway` | 226 |
+| `tests/agent` | 153 |
 | `web/src` | 110 |
-| `tests/tools` | 101 |
+| `tests/tools` | 104 |
 | `optional-skills/creative` | 70 |
 | `optional-skills/security` | 65 |
 | `website/docs` | 61 |
@@ -48,9 +48,9 @@ Generated: `2026-07-07T21:51:21.663142+00:00`
 | `tests/cli` | 33 |
 | `gateway/platforms` | 27 |
 | `tests/docker` | 26 |
-| `tests/tui_gateway` | 18 |
+| `tests/tui_gateway` | 19 |
+| `tests/cron` | 15 |
 | `.github/workflows` | 14 |
-| `tests/cron` | 14 |
 | `website/static` | 13 |
 | `hermes_cli/dashboard_auth` | 12 |
 | `scripts/whatsapp-bridge` | 12 |
@@ -131,8 +131,8 @@ Generated: `2026-07-07T21:51:21.663142+00:00`
 | `website/docs` | 26 |
 | `crates/hermes-acp` | 22 |
 | `crates/hermes-core` | 18 |
+| `docs/releases` | 17 |
 | `crates/hermes-eval` | 16 |
-| `docs/releases` | 16 |
 | `crates/hermes-environments` | 15 |
 | `crates/hermes-parity-tests` | 13 |
 | `crates/hermes-source-parity-tests` | 13 |
@@ -164,10 +164,10 @@ Generated: `2026-07-07T21:51:21.663142+00:00`
 
 | Workstream | Issue | Name | Upstream-only | Shared-different | Risk | Effort |
 | --- | ---: | --- | ---: | ---: | --- | --- |
-| `WS6` | #10 | Tests and CI parity | 1004 | 798 | critical | XL |
-| `WS8` | #12 | Compatibility and divergence policy | 1421 | 12 | critical | XL |
+| `WS6` | #10 | Tests and CI parity | 1019 | 798 | critical | XL |
+| `WS8` | #12 | Compatibility and divergence policy | 1422 | 13 | critical | XL |
 | `WS5` | #9 | UX parity | 587 | 328 | high | XL |
-| `WS3` | #7 | Tools and adapters parity | 180 | 102 | high | L |
+| `WS3` | #7 | Tools and adapters parity | 181 | 102 | high | L |
 | `WS4` | #8 | Skills parity | 157 | 39 | medium | L |
 | `WS2` | #6 | Core runtime parity | 73 | 0 | critical | M |
 | `WS7` | #11 | Security/secrets/store/webhook parity | 0 | 0 | critical | S |
@@ -176,7 +176,7 @@ Generated: `2026-07-07T21:51:21.663142+00:00`
 
 - Upstream missing by patch-id: `1`
 - Upstream represented by patch-id: `0`
-- Local unique by patch-id: `1068`
+- Local unique by patch-id: `1071`
 - Intentional divergence tracked items: `13` (covered files: `1344`)
 - Merge base is absent; patch-id mapping is used as primary commit equivalence signal.
 

--- a/docs/parity/queue-overrides.json
+++ b/docs/parity/queue-overrides.json
@@ -1825,6 +1825,11 @@
       "disposition": "ported",
       "notes": "Rust port implements upstream coding-context posture through crates/hermes-agent/src/coding_context.rs, AgentConfig/GatewayConfig agent.coding_context, prompt injection with workspace/verify facts, model-family edit-format guidance, prompt-only non-coding skill pruning, a lean coding toolset, ACP default toolset registration, and focus-mode platform tool collapse with live MCP inclusion. Tests cover detection, prompt gating, skill pruning, coding/hermes-acp toolsets, and platform focus behavior."
     },
+    "3e7ade418d030d241bda4c6352ff52409f4582ec": {
+      "disposition": "ported",
+      "notes": "Ported in Rust gateway policy: Discord Allowlist mode with no access configuration now has a deterministic fail-closed diagnostic through PlatformAccessPolicy::fail_closed_default_warning and one-shot gateway warning emission; regression coverage validates the message and scoping.",
+      "owner": "rust-runtime"
+    },
     "3e7ed0c53b59174c86cd7ff945c745a35e8c4e51": {
       "disposition": "superseded",
       "notes": "Upstream Electron/React/Tauri desktop delta is superseded by Hermes Ultra Rust-first CLI/TUI/gateway/dashboard surfaces; this repo intentionally does not ship apps/desktop or the bootstrap installer as runtime products.",
@@ -2158,6 +2163,11 @@
       "disposition": "ported",
       "notes": "Rust Nous provider request shaping now centralizes Portal attribution tags as product=hermes-agent plus client=hermes-client-v<workspace version>, and request-body tests prove the versioned tag is applied to actual Nous chat completion payloads."
     },
+    "48788032da2e88f0a010791a61667539272df65b": {
+      "disposition": "superseded",
+      "notes": "Upstream Python tui_gateway source-enum derivation is superseded by the Rust runtime surface: platform session ownership lives in typed Rust gateway/platform code rather than Python TUI hardcoded source lists.",
+      "owner": "rust-runtime"
+    },
     "488ae376dbef8e411f30e844e8b40ba55fc97e19": {
       "disposition": "superseded",
       "notes": "Upstream Electron desktop/bootstrap-only delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: the local repo does not ship apps/desktop or apps/bootstrap-installer as runtime products, while Rust CLI/TUI/gateway/provider surfaces own operator UX, model/tool visibility, update/status behavior, preview rendering, pet UX, project/coding panes, and platform integration. Mixed commits touching gateway/provider/install/runtime files remain pending for separate Rust evidence.",
@@ -2346,6 +2356,11 @@
       "notes": "Upstream Python/Electron CI or Docker-test orchestration delta is superseded by Hermes Agent Ultra's Rust-first CI surface: the local workflows build/test the Rust workspace, run parity gates, and use the distinct Rust Docker image/entrypoint contracts rather than upstream uv/s6/Electron docker jobs.",
       "owner": "rust-runtime"
     },
+    "4d7f8ade3e586d83003d61be76e909f364040fba": {
+      "disposition": "superseded",
+      "notes": "Upstream unsupported pip/Homebrew warning is intentionally not ported: Hermes Agent Ultra supports its own Rust installer/release artifact path, installs hermes-agent-ultra/hermes-ultra without clobbering upstream Nous hermes, and documents that coexistence in README/install contracts.",
+      "owner": "rust-runtime"
+    },
     "4da744ef9b6182982684c6b46bd5f41569e907ee": {
       "disposition": "superseded",
       "notes": "Upstream Electron/React desktop-web delta is superseded by Hermes Agent Ultra's Rust-first shipped surfaces: this repo has no apps/desktop, apps/shared, or web runtime tree, while Rust CLI/TUI/gateway/tool surfaces own operator UX, session, terminal, voice, status, and gateway behavior. Mixed commits touching Rust/runtime/provider/platform files remain pending for separate evidence.",
@@ -2389,6 +2404,11 @@
     "4ed2f3399418": {
       "disposition": "superseded",
       "notes": "Long user-message scrolling is a desktop React thread presentation fix. Ultra uses Rust terminal/TUI history rendering instead of apps/desktop thread components.",
+      "owner": "rust-runtime"
+    },
+    "4f620a0bbc11f41f241145a8dad3f70989507559": {
+      "disposition": "superseded",
+      "notes": "Upstream WhatsApp dashboard QR onboarding is Python/web/Baileys dashboard surface. Hermes Agent Ultra ships the Rust WhatsApp Cloud API adapter plus Rust DM pairing/allowlist policy and does not port Python dashboard onboarding flows into the Rust runtime.",
       "owner": "rust-runtime"
     },
     "4ffdedd369c1": {
@@ -4655,6 +4675,11 @@
       "disposition": "superseded",
       "notes": "documentation-only upstream delta superseded by local docs and rust parity guides"
     },
+    "9de9c25f620ff7f1ce0fd5457d596052d5159596": {
+      "disposition": "superseded",
+      "notes": "Upstream Python package release v0.18.2 metadata is superseded by the local Rust release train, currently beyond that version with Rust workspace/Cargo release artifacts and repo-local release gates.",
+      "owner": "rust-runtime"
+    },
     "9e02b18828a2": {
       "disposition": "superseded",
       "notes": "Upstream desktop/Electron/bootstrap-installer GUI delta is superseded by the approved rust-cli-tui-primary-ux-surface divergence: this Rust repo has no apps/desktop or apps/bootstrap-installer tree, and Rust CLI/TUI/gateway/install paths own runtime UX instead."
@@ -5847,6 +5872,11 @@
       "notes": "Rust already provides Home Assistant as first-class native runtime surface: REST backend, ha_list_entities/ha_get_state/ha_list_services/ha_call_service handlers, homeassistant toolset and aliases, send-message platform routing, and gateway adapter coverage. The upstream Python bundled-plugin migration is represented by Rust-native built-in registration and platform contract tests rather than a Python plugin package.",
       "owner": "rust-runtime"
     },
+    "c3808cfc1409e20e2ee0422f1428436465bbda6d": {
+      "disposition": "ported",
+      "notes": "Ported in Rust gateway auth: route_message now treats DmManager-authorized platform sources as approved pairing/source grants for Discord group and slash user-allowlist checks while preserving channel/ignored-channel gates. Regression coverage includes gateway_discord_group_allowlist_honors_authorized_source_pairing and gateway_discord_slash_requires_allowlist.",
+      "owner": "rust-runtime"
+    },
     "c38dac742b22": {
       "disposition": "ported",
       "notes": "Rust Hindsight flushes buffered turns before adopting a new session_id, clears stale prefetch context, resets counters, and has regression coverage for session switch behavior."
@@ -6891,6 +6921,11 @@
       "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
       "owner": "rust-runtime"
     },
+    "e5ac169c2877966689288f067b49c111d5b96380": {
+      "disposition": "ported",
+      "notes": "Ported/superseded by the Rust terminal/process surface: terminal exposes pty/background/stdin_data, process exposes list/poll/log/wait/kill/write/submit/close, and process_registry records durable metadata. This covers the drain/attach/detach/EOF lifecycle intent without depending on the upstream Python dashboard WebSocket PTY session.",
+      "owner": "rust-runtime"
+    },
     "e5d22ab80d979d38d8062e666af418ed847618a9": {
       "disposition": "superseded",
       "notes": "Upstream Daytona fix quotes a Python SDK shell mkdir in the single-upload path. Hermes Agent Ultra's Rust DaytonaBackend does not run mkdir for writes; it sends PUT /workspace/{id}/file with the remote path URL-encoded, so the shell-metacharacter injection class is absent.",
@@ -7403,9 +7438,19 @@
       "notes": "Upstream Python gateway/platform/TUI delta is superseded by Hermes Ultra Rust gateway adapters, async reqwest/Tokio runtime, typed media/cache/auth paths, and focused Rust gateway tests; Python-specific GIL/aiohttp/discord.py failure modes are absent.",
       "owner": "rust-runtime"
     },
+    "f5ef7ee9da66cff764296ed9da9c69b70105a90f": {
+      "disposition": "superseded",
+      "notes": "Upstream Python tui_gateway ws_orphan_reap fix is superseded by the Rust CLI/TUI/gateway runtime boundary: Ultra does not rely on the Python TUI gateway reaper to own platform session lifecycle, and Rust gateway/session routing owns platform-originated sessions directly.",
+      "owner": "rust-runtime"
+    },
     "f6275a59e790477092e6c70b06ba4a5d1d882615": {
       "disposition": "superseded",
       "notes": "Documentation-only upstream delta is superseded by local Rust-first docs/parity/release surfaces; it does not add or change a shipped Rust runtime behavior. Skills/docs/config-mixed items remain pending for separate evidence.",
+      "owner": "rust-runtime"
+    },
+    "f64e4f4f5768c18a53f44890747653bafcab2796": {
+      "disposition": "ported",
+      "notes": "Ported as Rust relay identity-token contract coverage: hermes_gateway::relay now models generic OIDC client_credentials relay provisioning with env/config precedence, Nous-Portal default mode selection, client_credentials form shape, fail-closed missing client credentials, async access_token fetch, and focused relay tests. The experimental relay adapter remains inactive by default in Ultra.",
       "owner": "rust-runtime"
     },
     "f6574978de39": {
@@ -7505,6 +7550,11 @@
     "f9c6c5ab8472": {
       "disposition": "ported",
       "notes": "Rust Hindsight now creates a per-initialization document_id and includes it in auto-retain batch bodies, with tests proving resumed sessions get distinct document IDs."
+    },
+    "f9eca7e15f1c2bfe5194aae5aa489af53c0a1a23": {
+      "disposition": "superseded",
+      "notes": "Upstream Python package release v0.18.1 metadata is superseded by the local Rust release train, currently beyond that version with Rust workspace/Cargo release artifacts and repo-local release gates.",
+      "owner": "rust-runtime"
     },
     "f9ffe0bc3f61": {
       "disposition": "superseded",

--- a/docs/parity/shared-diff-backlog.json
+++ b/docs/parity/shared-diff-backlog.json
@@ -125,7 +125,7 @@
       "classification": "intentional_divergence",
       "classification_path": "README.md",
       "existing_coverage": "claimed_by_shared_diff_classification",
-      "local_blob": "9f519632dd2d7b684b1d6f412ab9319a900f6e83",
+      "local_blob": "0a1d0c8bb4b0503d5adbd66e2f95fa58104c7d37",
       "necessity": "approved_divergence",
       "owner": "sheawinkler",
       "path": "README.md",
@@ -133,6 +133,21 @@
       "status": "cleared_intentional_divergence",
       "ticket": 305,
       "upstream_blob": "ba1322a389207c79032386e4053ac0e69a3c199d",
+      "workstream": "WS8"
+    },
+    {
+      "action": "No vendoring; verify approved divergence remains current.",
+      "classification": "intentional_divergence",
+      "classification_path": "cli-config.yaml.example",
+      "existing_coverage": "claimed_by_shared_diff_classification",
+      "local_blob": "d35aa10b034554b5239ec27ac365adf383ce5e2b",
+      "necessity": "approved_divergence",
+      "owner": "sheawinkler",
+      "path": "cli-config.yaml.example",
+      "rust_requirement": "not_required_for_runtime",
+      "status": "cleared_intentional_divergence",
+      "ticket": 305,
+      "upstream_blob": "5e4bc2331771e1f81f8db9cf19c138fadbc2cb97",
       "workstream": "WS8"
     },
     {
@@ -1572,7 +1587,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 304,
-      "upstream_blob": "8a83f8805ed9afafa4fed5a39404e0be7e1396ab",
+      "upstream_blob": "ddaac7ab074aa5eba51315e643f8a51ebc188932",
       "workstream": "WS3"
     },
     {
@@ -4737,7 +4752,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "b9d4993b5f0604905b08daf6e8de9b13af2baecf",
+      "upstream_blob": "6dc246e83db476c46c1168b536fd001bb9f373b4",
       "workstream": "WS6"
     },
     {
@@ -5112,7 +5127,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "f9bb7f40ca813c943f1a87e5428891412a3764c3",
+      "upstream_blob": "a8d7e21e0a8db4dc1c7a4692e88bf185bd29b1be",
       "workstream": "WS6"
     },
     {
@@ -6477,7 +6492,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "1b122a0d105a5801bf9c41db7fbb33c5d8e628b4",
+      "upstream_blob": "e03f651c9628b1d2f03cfbc69adf26bcaf2656db",
       "workstream": "WS6"
     },
     {
@@ -7587,7 +7602,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "561009d096cee65516804f240dc408df5283f19d",
+      "upstream_blob": "d379bdd262d4cbe2d190d04507609a84d268def8",
       "workstream": "WS6"
     },
     {
@@ -8727,7 +8742,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "0df9790c31abae03b3fe70faaefcc55e365a090f",
+      "upstream_blob": "3fdb6d1812d2016a182383163f472cde61cfabe0",
       "workstream": "WS6"
     },
     {
@@ -9342,7 +9357,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "dbe95a0cb5d55aaed9f77ac0cd68cac1c41474cd",
+      "upstream_blob": "8a14fba3c6fdac3f78832286f50cd08c59662102",
       "workstream": "WS6"
     },
     {
@@ -9372,7 +9387,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "34de95b826d2fd46989299194254a376586901b8",
+      "upstream_blob": "7c83ff2a5029ddc3fff905a319146481911da1e5",
       "workstream": "WS6"
     },
     {
@@ -9477,7 +9492,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "18f5facbb6b64c808d3f43c839dbc7185cd9616b",
+      "upstream_blob": "ae732bcaba262fb31d082490b503615725c2116a",
       "workstream": "WS6"
     },
     {
@@ -10752,7 +10767,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "da8a446bf8d8aee905b7383c1cdcf506ebfe2eb0",
+      "upstream_blob": "171a7c11255d4b77860a2fafb9de1eb208673541",
       "workstream": "WS6"
     },
     {
@@ -10962,7 +10977,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "e7ab376281ad2e25ec61647349f14eae16065f0f",
+      "upstream_blob": "36ced43c7956ce04e3b2bb04f7c8149f1111d028",
       "workstream": "WS6"
     },
     {
@@ -11757,7 +11772,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "3286363dfd23f76f7776909afd2f8cb936113c14",
+      "upstream_blob": "6f58d35d82c991f8eba05ce493d686ff420c990b",
       "workstream": "WS6"
     },
     {
@@ -12372,7 +12387,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "5830706bf95dd0d05283f678c285dbbc8d95f3af",
+      "upstream_blob": "43c8089f1127a59892fff6b4e3b7e6602ebbba60",
       "workstream": "WS6"
     },
     {
@@ -12942,7 +12957,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "116af9397cdfa80a8867215477eb6e343e9f89b5",
+      "upstream_blob": "f356c94e1280a3010d53044c059468216bbc0e57",
       "workstream": "WS6"
     },
     {
@@ -13062,7 +13077,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "796dbed913d20aba49b229962653664b132841f4",
+      "upstream_blob": "b9a1b92c9cdeaaa6ce49af45f371b3bbc9205512",
       "workstream": "WS6"
     },
     {
@@ -13092,7 +13107,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "eeeeef7e48cbd087e0f2b9cef7e228d5a1d228bc",
+      "upstream_blob": "be41088e4eb7a6d0facc61abfa7ccd94c0f0fadc",
       "workstream": "WS6"
     },
     {
@@ -13107,7 +13122,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "c258cd570c764db0df74b5980beaf80ce21adfcb",
+      "upstream_blob": "eadb7397a409d1840286459a2539b260437f6f26",
       "workstream": "WS6"
     },
     {
@@ -15552,7 +15567,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "136b97db90ccf4913a7c8f6fd22222db49427772",
+      "upstream_blob": "3c9cdd5f2512ccd11d4cde83cf54be80cae9dd9e",
       "workstream": "WS5"
     },
     {
@@ -15612,7 +15627,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "8752dd371a23a5335746c361012d7e4654c5309f",
+      "upstream_blob": "149047e4002e0704f6ed9cc515eae5fcb872cdf1",
       "workstream": "WS5"
     },
     {
@@ -16152,7 +16167,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_intentional_divergence",
       "ticket": 25,
-      "upstream_blob": "4f7ffa225d2935fe231634919de03873c17846da",
+      "upstream_blob": "14ab98ca18ddd2c45a8a5c307688fc9357cc9823",
       "workstream": "WS5"
     },
     {
@@ -17532,7 +17547,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "fc0c27301f86e461999551c1accc17c9ba542e9f",
+      "upstream_blob": "bf946fde10ec37ae2f4cbf6c5a1bdd779ee21a9b",
       "workstream": "WS5"
     },
     {
@@ -17832,7 +17847,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "030e69681e5e64a22e431e9049aea7ae98f76e2f",
+      "upstream_blob": "5835430c2342dd334e2ff654697287568754ace6",
       "workstream": "WS5"
     },
     {
@@ -18237,7 +18252,7 @@
       "rust_requirement": "not_required_for_runtime",
       "status": "cleared_non_runtime",
       "ticket": 25,
-      "upstream_blob": "e2ae75ea7d4adc977c6f7bde80b5d630a29a21ac",
+      "upstream_blob": "daece81f48292e7c6d5e14b42c8ee96cf4e9394f",
       "workstream": "WS5"
     },
     {
@@ -19186,24 +19201,24 @@
       "workstream": "WS5"
     }
   ],
-  "generated_at_utc": "2026-07-07T21:51:25.017721+00:00",
+  "generated_at_utc": "2026-07-08T09:23:42.991939+00:00",
   "refs": {
     "local_ref": "HEAD",
-    "local_sha": "8c58db72e5e53c349a77cd59efe3e5b86b001adf",
+    "local_sha": "4f83eedf9cfafa82d81b3f2ea8ada0027536c99a",
     "upstream_ref": "upstream/main",
-    "upstream_sha": "5e51b123f32b7f6a51fbd5759e89ba5146ce4003"
+    "upstream_sha": "f64e4f4f5768c18a53f44890747653bafcab2796"
   },
   "summary": {
     "by_classification": {
       "branding_only": 1,
-      "intentional_divergence": 1055,
+      "intentional_divergence": 1056,
       "policy_only": 223
     },
     "by_rust_requirement": {
-      "not_required_for_runtime": 1279
+      "not_required_for_runtime": 1280
     },
     "by_status": {
-      "cleared_intentional_divergence": 1055,
+      "cleared_intentional_divergence": 1056,
       "cleared_non_runtime": 224
     },
     "by_workstream": {
@@ -19211,12 +19226,12 @@
       "WS4": 39,
       "WS5": 321,
       "WS6": 798,
-      "WS8": 19
+      "WS8": 20
     },
-    "cleared_intentional_divergence": 1055,
+    "cleared_intentional_divergence": 1056,
     "cleared_non_runtime": 224,
     "pending_classification": 0,
     "pending_review": 0,
-    "total_shared_different": 1279
+    "total_shared_different": 1280
   }
 }

--- a/docs/parity/shared-diff-backlog.md
+++ b/docs/parity/shared-diff-backlog.md
@@ -1,20 +1,20 @@
 # Shared-Different Backlog
 
-Generated: `2026-07-07T21:51:25.017721+00:00`
+Generated: `2026-07-08T09:23:42.991939+00:00`
 
 ## Summary
 
-- Total shared-different paths: `1279`
+- Total shared-different paths: `1280`
 - Pending classification: `0`
 - Pending functional review: `0`
 - Cleared non-runtime: `224`
-- Cleared intentional divergence: `1055`
+- Cleared intentional divergence: `1056`
 
 ## Status Counts
 
 | Status | Count |
 | --- | ---: |
-| `cleared_intentional_divergence` | 1055 |
+| `cleared_intentional_divergence` | 1056 |
 | `cleared_non_runtime` | 224 |
 
 ## Workstream Counts
@@ -25,7 +25,7 @@ Generated: `2026-07-07T21:51:25.017721+00:00`
 | `WS4` | 39 |
 | `WS5` | 321 |
 | `WS6` | 798 |
-| `WS8` | 19 |
+| `WS8` | 20 |
 
 ## Pending Classification
 

--- a/docs/parity/shared-different-classification.json
+++ b/docs/parity/shared-different-classification.json
@@ -74,6 +74,13 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
+      "path": "cli-config.yaml.example",
+      "rationale": "Ultra intentionally ships a Rust/provider config example centered on openai-codex:dynamic and local Rust provider runtime behavior rather than upstream Python provider defaults/examples; this preserves the project rule that the terminal default model stays dynamic and avoids stale 4o-era examples.",
+      "ticket": 305
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "docker-compose.yml",
       "rationale": "Compose defaults intentionally target the Ultra Rust image, /data volume, and hermes-agent-ultra naming while preserving localhost dashboard and UID/GID runtime controls.",
       "ticket": 305
@@ -478,13 +485,6 @@
       "ticket": 25
     },
     {
-      "classification": "intentional_divergence",
-      "owner": "sheawinkler",
-      "path": "plugins/memory/retaindb/__init__.py",
-      "rationale": "RetainDB runtime behavior is owned by the Rust RetainDbMemoryPlugin: core profile/search/context/remember/forget tools, shared file-store upload/list/read/ingest/delete tools, SOUL.md agent seeding, context plus user-synthesis/self-model prefetch, and durable SQLite queued turn ingest are implemented and covered by focused hermes-agent tests; the Python plugin remains reference-only in the Rust runtime.",
-      "ticket": 25
-    },
-    {
       "classification": "policy_only",
       "owner": "sheawinkler",
       "path": "plugins/memory/byterover/__init__.py",
@@ -608,6 +608,13 @@
       "owner": "sheawinkler",
       "path": "plugins/memory/openviking/plugin.yaml",
       "rationale": "OpenViking plugin metadata is reference catalog material; Rust OpenViking MemoryProviderPlugin implements REST context operations, uploads, session commits, writer drains, and focused regression tests.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/memory/retaindb/__init__.py",
+      "rationale": "RetainDB runtime behavior is owned by the Rust RetainDbMemoryPlugin: core profile/search/context/remember/forget tools, shared file-store upload/list/read/ingest/delete tools, SOUL.md agent seeding, context plus user-synthesis/self-model prefetch, and durable SQLite queued turn ingest are implemented and covered by focused hermes-agent tests; the Python plugin remains reference-only in the Rust runtime.",
       "ticket": 25
     },
     {
@@ -956,20 +963,6 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
-      "path": "plugins/web/exa/provider.py",
-      "rationale": "Exa search and extraction are implemented by Rust ExaSearchBackend and ExaExtractBackend with EXA_API_KEY/EXA_BASE_URL config, /search and /contents request contracts, source-quality result normalization, explicit/generic extract routing, auto-detect, and focused mocked web backend tests; the Python SDK plugin remains reference-only.",
-      "ticket": 25
-    },
-    {
-      "classification": "intentional_divergence",
-      "owner": "sheawinkler",
-      "path": "plugins/web/parallel/provider.py",
-      "rationale": "Parallel search and extraction are implemented by Rust ParallelWebBackend with PARALLEL_API_KEY/PARALLEL_BASE_URL/PARALLEL_SEARCH_MODE config, /v1/search and /v1/extract REST payloads, full-content extraction, result/error normalization, explicit/generic backend routing, auto-detect, and focused mocked web backend tests; the Python SDK plugin remains reference-only.",
-      "ticket": 25
-    },
-    {
-      "classification": "intentional_divergence",
-      "owner": "sheawinkler",
       "path": "plugins/web/ddgs/provider.py",
       "rationale": "DuckDuckGo search is implemented by Rust DuckDuckGoSearchBackend with HERMES_WEB_SEARCH_BACKEND=ddgs selection, timeout/env aliases, result normalization, and web backend tests; the Python DDGS provider is reference-only.",
       "ticket": 25
@@ -977,8 +970,22 @@
     {
       "classification": "intentional_divergence",
       "owner": "sheawinkler",
+      "path": "plugins/web/exa/provider.py",
+      "rationale": "Exa search and extraction are implemented by Rust ExaSearchBackend and ExaExtractBackend with EXA_API_KEY/EXA_BASE_URL config, /search and /contents request contracts, source-quality result normalization, explicit/generic extract routing, auto-detect, and focused mocked web backend tests; the Python SDK plugin remains reference-only.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
       "path": "plugins/web/firecrawl/provider.py",
       "rationale": "Rust-native Firecrawl search/extract backends now cover direct, self-hosted, and Nous-managed routing; the Python plugin remains reference/compatibility code in the Rust-only runtime.",
+      "ticket": 25
+    },
+    {
+      "classification": "intentional_divergence",
+      "owner": "sheawinkler",
+      "path": "plugins/web/parallel/provider.py",
+      "rationale": "Parallel search and extraction are implemented by Rust ParallelWebBackend with PARALLEL_API_KEY/PARALLEL_BASE_URL/PARALLEL_SEARCH_MODE config, /v1/search and /v1/extract REST payloads, full-content extraction, result/error normalization, explicit/generic backend routing, auto-detect, and focused mocked web backend tests; the Python SDK plugin remains reference-only.",
       "ticket": 25
     },
     {

--- a/docs/parity/test-coverage-audit.json
+++ b/docs/parity/test-coverage-audit.json
@@ -16,7 +16,7 @@
       "kind": "nonzero_tree_drift",
       "message": "max_files_only_upstream remains nonzero in parity matrix",
       "metric": "max_files_only_upstream",
-      "value": 3422.0
+      "value": 3439.0
     }
   ],
   "audit_gate": {
@@ -90,7 +90,7 @@
     }
   ],
   "critical_gaps": [],
-  "generated_at_utc": "2026-07-07T21:51:23.613081+00:00",
+  "generated_at_utc": "2026-07-08T09:23:41.617774+00:00",
   "intent_domains": [
     {
       "classification": "direct_rust_test",
@@ -156,7 +156,7 @@
     },
     {
       "classification": "direct_rust_test",
-      "direct_test_evidence_count": 100,
+      "direct_test_evidence_count": 101,
       "direct_test_evidence_sample": [
         "crates/hermes-tools/src/approval.rs",
         "crates/hermes-tools/src/approval/tests.rs",
@@ -184,7 +184,7 @@
         "crates/hermes-tools/src/backends/vision.rs",
         "crates/hermes-tools/src/backends/web.rs"
       ],
-      "evidence_count": 122,
+      "evidence_count": 123,
       "evidence_sample": [
         "crates/hermes-tools/src/approval.rs",
         "crates/hermes-tools/src/approval/patterns.rs",
@@ -632,9 +632,9 @@
     "divergence_unowned": 0,
     "missing_rust_test_refs": 0,
     "queue_pending": 0,
-    "queue_total": 1,
-    "rust_test_files": 422,
-    "rust_test_functions": 7391,
+    "queue_total": 51,
+    "rust_test_files": 423,
+    "rust_test_functions": 7412,
     "test_intent_mapping_ratio": 1.0,
     "test_intents_mapped": 10,
     "test_intents_total": 10,

--- a/docs/parity/test-coverage-audit.md
+++ b/docs/parity/test-coverage-audit.md
@@ -1,6 +1,6 @@
 # Test Coverage Audit
 
-Generated: `2026-07-07T21:51:23.613081+00:00`
+Generated: `2026-07-08T09:23:41.617774+00:00`
 
 ## Gate
 
@@ -15,13 +15,13 @@ Generated: `2026-07-07T21:51:23.613081+00:00`
 | `tracked_behavior_rows` | 477 |
 | `covered_behavior_rows` | 477 |
 | `tracked_behavior_coverage_ratio` | 1.0 |
-| `rust_test_files` | 422 |
-| `rust_test_functions` | 7391 |
+| `rust_test_files` | 423 |
+| `rust_test_functions` | 7412 |
 | `coverage_manifest_entries` | 467 |
 | `coverage_manifest_entries_with_valid_rust_tests` | 467 |
 | `missing_rust_test_refs` | 0 |
 | `queue_pending` | 0 |
-| `queue_total` | 1 |
+| `queue_total` | 51 |
 | `test_intents_total` | 10 |
 | `test_intents_mapped` | 10 |
 
@@ -38,7 +38,7 @@ Generated: `2026-07-07T21:51:23.613081+00:00`
 | Intent | Classification | Evidence files | Direct test evidence |
 | --- | --- | ---: | ---: |
 | `gateway-platform-behavior` | `direct_rust_test` | 25 | 22 |
-| `tool-runtime-behavior` | `direct_rust_test` | 122 | 100 |
+| `tool-runtime-behavior` | `direct_rust_test` | 123 | 101 |
 | `cli-command-surface` | `direct_rust_test` | 178 | 47 |
 | `agent-loop-and-runtime` | `direct_rust_test` | 106 | 71 |
 | `acp-protocol-and-transport` | `direct_rust_test` | 21 | 15 |

--- a/docs/parity/test-intent-mapping.json
+++ b/docs/parity/test-intent-mapping.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-07-07T21:51:22.927789+00:00",
+  "generated_at_utc": "2026-07-08T09:23:41.104345+00:00",
   "intent_unit": "domain_intent",
   "intents": [
     {
@@ -39,7 +39,7 @@
       ]
     },
     {
-      "evidence_count": 122,
+      "evidence_count": 123,
       "evidence_sample": [
         "crates/hermes-tools/src/approval.rs",
         "crates/hermes-tools/src/approval/patterns.rs",

--- a/docs/parity/test-intent-mapping.md
+++ b/docs/parity/test-intent-mapping.md
@@ -1,11 +1,11 @@
 # Test Intent Mapping
 
-Generated: `2026-07-07T21:51:22.927789+00:00`
+Generated: `2026-07-08T09:23:41.104345+00:00`
 
 | Intent | Mapped | Evidence Count |
 | --- | --- | ---: |
 | `gateway-platform-behavior` | yes | 25 |
-| `tool-runtime-behavior` | yes | 122 |
+| `tool-runtime-behavior` | yes | 123 |
 | `cli-command-surface` | yes | 178 |
 | `agent-loop-and-runtime` | yes | 106 |
 | `acp-protocol-and-transport` | yes | 21 |

--- a/docs/parity/upstream-missing-queue.json
+++ b/docs/parity/upstream-missing-queue.json
@@ -25,8 +25,8 @@
         ".github/pr-screenshots/45449/billing-overview.png",
         ".github/pr-screenshots/telegram-overflow/topic-final-response-clipped.jpg"
       ],
-      "files_touched": 6159,
-      "notes": "Ported in Rust Mem0 setup: hermes memory setup mem0 accepts --mode selfhosted --host ... [--api-key ...] [--dry-run], interactive prompts expose platform/selfhosted/oss, self-hosted hosts are persisted to mem0.json, optional secrets route to $HERMES_HOME/.env, reachability checks are non-fatal, and focused Rust tests plus a CLI dry-run prove the surface.",
+      "files_touched": 6177,
+      "notes": "Ported as Rust relay identity-token contract coverage: hermes_gateway::relay now models generic OIDC client_credentials relay provisioning with env/config precedence, Nous-Portal default mode selection, client_credentials form shape, fail-closed missing client credentials, async access_token fetch, and focused relay tests. The experimental relay adapter remains inactive by default in Ultra.",
       "owner": "rust-runtime",
       "rust_only_guard": {
         "allow_python_test_surfaces": false,
@@ -34,15 +34,15 @@
         "rust_primary_surface_only_commit": false,
         "superseded_by_guard": false
       },
-      "sha": "5e51b123f32b7f6a51fbd5759e89ba5146ce4003",
-      "subject": "feat(mem0): add self-hosted mode to the setup wizard",
+      "sha": "f64e4f4f5768c18a53f44890747653bafcab2796",
+      "subject": "feat(gateway): generic OIDC client-credentials relay provisioning (NAS-free) (#60730)",
       "target_ticket": 20,
       "target_ticket_name": "GPAR-01 tests+CI parity"
     }
   ],
-  "generated_at_utc": "2026-07-07T21:51:26.151224+00:00",
+  "generated_at_utc": "2026-07-08T09:23:44.151496+00:00",
   "refs": {
-    "baseline_start_sha": "5445e42b87b9918d5b1bfa9f4eadd8e4bb10ff37",
+    "baseline_start_sha": "5e51b123f32b7f6a51fbd5759e89ba5146ce4003",
     "local_ref": "HEAD",
     "prior_ref": "HEAD",
     "prior_source": "HEAD",

--- a/docs/parity/upstream-missing-queue.md
+++ b/docs/parity/upstream-missing-queue.md
@@ -1,6 +1,6 @@
 # Upstream Missing Patch Queue
 
-Generated: `2026-07-07T21:51:26.151224+00:00`
+Generated: `2026-07-08T09:23:44.151496+00:00`
 
 - Range: `HEAD..upstream/main`; total commits tracked: `1`.
 

--- a/docs/parity/workstream-status.json
+++ b/docs/parity/workstream-status.json
@@ -1,12 +1,12 @@
 {
-  "generated_at_utc": "2026-07-06T03:37:43-06:00",
-  "head_sha": "8c58db72e5e53c349a77cd59efe3e5b86b001adf",
+  "generated_at_utc": "2026-07-07T16:03:18-06:00",
+  "head_sha": "4f83eedf9cfafa82d81b3f2ea8ada0027536c99a",
   "states": {
     "complete": 6,
     "in_progress": 1
   },
   "upstream_ref": "upstream/main",
-  "upstream_sha": "5e51b123f32b7f6a51fbd5759e89ba5146ce4003",
+  "upstream_sha": "f64e4f4f5768c18a53f44890747653bafcab2796",
   "workstreams": [
     {
       "evidence": [

--- a/docs/parity/workstream-status.md
+++ b/docs/parity/workstream-status.md
@@ -1,7 +1,7 @@
 # Workstream Status
 
-- Local HEAD: `8c58db72e5e53c349a77cd59efe3e5b86b001adf`
-- Upstream: `upstream/main` (`5e51b123f32b7f6a51fbd5759e89ba5146ce4003`)
+- Local HEAD: `4f83eedf9cfafa82d81b3f2ea8ada0027536c99a`
+- Upstream: `upstream/main` (`f64e4f4f5768c18a53f44890747653bafcab2796`)
 
 | Workstream | Title | State |
 | --- | --- | --- |

--- a/docs/relay-connector-contract.md
+++ b/docs/relay-connector-contract.md
@@ -17,6 +17,10 @@ upstream invariants:
 
 - The gateway dials out; hosted gateways do not need a public inbound port.
 - The connector returns a capability descriptor before events flow.
+- Relay identity-token provisioning supports generic OIDC
+  `client_credentials` request contracts for self-hosted IdPs, while preserving
+  Nous Portal as the default identity mode when no IdP token endpoint is
+  configured.
 - Inbound events use the same session-key discriminators as native platform
   adapters.
 - Relay source metadata uses `scope_id` as the canonical platform-neutral
@@ -28,5 +32,7 @@ upstream invariants:
   session.
 - Unknown additive descriptor fields are ignored for forward compatibility.
 
-Until a Rust relay adapter is scoped, this document is a parity reference rather
-than an active runtime API.
+Until a Rust relay adapter is scoped, the transport itself remains a parity
+reference rather than an active runtime API. The Rust gateway crate does own the
+stable relay protocol and identity-token request contracts used to evaluate
+future activation safely.

--- a/docs/ultra-autonomy-surfaces.md
+++ b/docs/ultra-autonomy-surfaces.md
@@ -18,6 +18,8 @@ ContextLattice, approval, and tool registry paths remain authoritative.
 | 8 | `hermes-ultra up` | One-command always-on service contract using existing gateway service management. |
 | 9 | `ultra_autonomy action=channel_surface` | CLI/dashboard/gateway/Telegram skill, status, and permission surface map. |
 | 10 | `ultra_autonomy action=objective_bridge` | Materialize durable objectives into dependency-tracked board cards with verification gates. |
+| 11 | `ultra_autonomy action=outcome_rehearsal` | Deterministically score plan, tool use, verification, checkpoint, and recovery evidence before promotion. |
+| 12 | `ultra_autonomy action=recall_quality` | Score ContextLattice/synthesis recall against implementation and verification outcomes, not just retrieval availability. |
 
 ## Dashboard Contract
 
@@ -43,6 +45,7 @@ Targeted checks:
 
 ```bash
 CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target CARGO_INCREMENTAL=0 cargo test -p hermes-tools ultra_autonomy --lib
+CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target CARGO_INCREMENTAL=0 cargo test -p hermes-tools ultra_autonomy_evals --lib
 CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target CARGO_INCREMENTAL=0 cargo test -p hermes-tools test_shell_substitution_and_chain_laundering_are_guarded --lib
 CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target CARGO_INCREMENTAL=0 cargo test -p hermes-tools harness_cockpit --lib
 CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target CARGO_INCREMENTAL=0 cargo test -p hermes-tools builtin_registry_registers_core_tool_surfaces_for_parity --lib

--- a/scripts/generate-release-readiness-summary.py
+++ b/scripts/generate-release-readiness-summary.py
@@ -38,6 +38,59 @@ def as_bool(value: Any) -> bool:
     return bool(value)
 
 
+def build_upstream_delta_watch(
+    proof: dict[str, Any],
+    thresholds: dict[str, Any],
+    queue_pending: int,
+    release_gate_pass: bool,
+) -> dict[str, Any]:
+    metrics = proof.get("metrics", {}) if isinstance(proof.get("metrics"), dict) else {}
+    ci_gate = proof.get("ci_gate", {}) if isinstance(proof.get("ci_gate"), dict) else {}
+    drift_thresholds = (
+        thresholds.get("drift_alert_thresholds", {})
+        if isinstance(thresholds.get("drift_alert_thresholds"), dict)
+        else {}
+    )
+    alerts: list[dict[str, Any]] = []
+    for metric_name, threshold_key in [
+        ("max_commits_behind", "warn_commits_behind"),
+        ("max_upstream_patch_missing", "warn_upstream_patch_missing"),
+        ("max_files_only_upstream", "warn_files_only_upstream"),
+    ]:
+        actual = as_int(metrics.get(metric_name))
+        limit = as_int(drift_thresholds.get(threshold_key))
+        if limit > 0 and actual > limit:
+            alerts.append(
+                {
+                    "metric": metric_name,
+                    "actual": actual,
+                    "warn_threshold": limit,
+                    "status": "watch",
+                }
+            )
+
+    ci_gate_pass = bool(ci_gate.get("pass", False))
+    pass_gate = queue_pending == 0 and release_gate_pass
+    return {
+        "schema_version": 1,
+        "pass": pass_gate,
+        "status": (
+            "PASS"
+            if pass_gate and ci_gate_pass and not alerts
+            else ("WATCH" if pass_gate else "FAIL")
+        ),
+        "queue_pending": queue_pending,
+        "release_gate_pass": release_gate_pass,
+        "ci_gate_pass": ci_gate_pass,
+        "alerts": alerts,
+        "source_artifacts": [
+            "docs/parity/global-parity-proof.json",
+            "docs/parity/upstream-missing-queue.json",
+            "docs/parity/global-parity-thresholds.json",
+        ],
+    }
+
+
 def workspace_version(repo_root: Path) -> str:
     cargo = repo_root / "Cargo.toml"
     text = cargo.read_text(encoding="utf-8") if cargo.exists() else ""
@@ -62,6 +115,7 @@ def build_summary(repo_root: Path) -> dict[str, Any]:
     shared = load_json(repo_root / "docs/parity/shared-diff-backlog.json")
     coverage = load_json(repo_root / "docs/parity/test-coverage-audit.json")
     sota = load_json(repo_root / "docs/parity/sota-harness-matrix.json")
+    thresholds = load_json(repo_root / "docs/parity/global-parity-thresholds.json")
 
     queue_pending = as_int(metric(queue, "summary", "by_disposition", "pending", default=0))
     shared_pending_classification = as_int(metric(shared, "summary", "pending_classification", default=0))
@@ -71,6 +125,9 @@ def build_summary(repo_root: Path) -> dict[str, Any]:
     sota_critical = as_int(metric(sota, "gate", "critical_gaps", default=0))
     sota_missing_refs = as_int(metric(sota, "gate", "missing_rust_test_refs", default=0))
     release_gate_pass = as_bool(metric(proof, "release_gate", "pass", default=False))
+    upstream_delta_watch = build_upstream_delta_watch(
+        proof, thresholds, queue_pending, release_gate_pass
+    )
 
     checks = [
         {
@@ -128,6 +185,13 @@ def build_summary(repo_root: Path) -> dict[str, Any]:
             "limit": 0,
             "pass": sota_missing_refs == 0,
         },
+        {
+            "id": "upstream_delta_watch",
+            "label": "Upstream delta watch",
+            "actual": upstream_delta_watch["status"],
+            "limit": "PASS|WATCH",
+            "pass": bool(upstream_delta_watch["pass"]),
+        },
     ]
 
     return {
@@ -143,6 +207,7 @@ def build_summary(repo_root: Path) -> dict[str, Any]:
             "shared_diff_backlog": "docs/parity/shared-diff-backlog.json",
             "test_coverage_audit": "docs/parity/test-coverage-audit.json",
             "sota_harness_matrix": "docs/parity/sota-harness-matrix.json",
+            "global_parity_thresholds": "docs/parity/global-parity-thresholds.json",
         },
         "summary": {
             "queue_pending": queue_pending,
@@ -153,7 +218,11 @@ def build_summary(repo_root: Path) -> dict[str, Any]:
             "sota_critical_gaps": sota_critical,
             "sota_missing_rust_refs": sota_missing_refs,
             "release_gate_pass": release_gate_pass,
+            "upstream_delta_watch_pass": bool(upstream_delta_watch["pass"]),
+            "upstream_delta_watch_status": upstream_delta_watch["status"],
+            "upstream_delta_watch_alerts": len(upstream_delta_watch["alerts"]),
         },
+        "upstream_delta_watch": upstream_delta_watch,
     }
 
 
@@ -188,6 +257,17 @@ def render_markdown(summary: dict[str, Any]) -> str:
     ])
     for label, path in summary["source_artifacts"].items():
         lines.append(f"- `{label}`: `{path}`")
+    watch = summary.get("upstream_delta_watch", {})
+    lines.extend([
+        "",
+        "## Upstream Delta Watch",
+        "",
+        f"- Status: `{watch.get('status', 'unknown')}`",
+        f"- Queue pending: `{watch.get('queue_pending', 0)}`",
+        f"- CI gate pass: `{watch.get('ci_gate_pass', False)}`",
+        f"- Release gate pass: `{watch.get('release_gate_pass', False)}`",
+        f"- Drift alerts: `{len(watch.get('alerts', []))}`",
+    ])
     lines.append("")
     return "\n".join(lines)
 

--- a/scripts/run-repo-ci.sh
+++ b/scripts/run-repo-ci.sh
@@ -74,6 +74,7 @@ run python3 scripts/validate-intentional-divergence.py --check --allow-warnings
 run python3 scripts/generate-shared-diff-backlog.py --local-ref HEAD --no-fetch
 run python3 scripts/generate-upstream-patch-queue.py --local-ref HEAD --max-commits 0
 run python3 scripts/generate-global-parity-proof.py
+run python3 scripts/generate-release-readiness-summary.py --check
 
 run cargo fmt --all --check
 run bash scripts/clippy-warning-gate.sh --check

--- a/scripts/smoke-release-artifact.sh
+++ b/scripts/smoke-release-artifact.sh
@@ -2,14 +2,15 @@
 set -euo pipefail
 
 REPO="${REPO:-sheawinkler/hermes-agent-ultra}"
-VERSION="${VERSION:-v0.21.3}"
+VERSION="${VERSION:-v0.22.0}"
 KEEP_TMP="${KEEP_TMP:-false}"
 RUN_SETUP_HELP="${RUN_SETUP_HELP:-true}"
 HERMES_SMOKE_COMMAND_TIMEOUT_SECONDS="${HERMES_SMOKE_COMMAND_TIMEOUT_SECONDS:-30}"
+OUTPUT_JSON="${OUTPUT_JSON:-}"
 
 usage() {
   cat <<'USAGE'
-Usage: scripts/smoke-release-artifact.sh [--version TAG] [--repo OWNER/REPO] [--keep-tmp]
+Usage: scripts/smoke-release-artifact.sh [--version TAG] [--repo OWNER/REPO] [--output-json PATH] [--keep-tmp]
 
 Install Hermes Agent Ultra from published GitHub release artifacts into a
 throwaway directory, then verify the released binary surfaces without touching
@@ -27,6 +28,7 @@ Environment:
   HERMES_SMOKE_COMMAND_TIMEOUT_SECONDS
                          Per-command probe timeout in seconds (default: 30;
                          0 disables)
+  OUTPUT_JSON            Optional path for a machine-readable PASS report.
 USAGE
 }
 
@@ -38,6 +40,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --repo)
       REPO="${2:?--repo requires owner/repo}"
+      shift 2
+      ;;
+    --output-json)
+      OUTPUT_JSON="${2:?--output-json requires a path}"
       shift 2
       ;;
     --keep-tmp)
@@ -226,6 +232,22 @@ done
 
 INSTALL_SHA="$(sha256_file "${INSTALLER}")"
 BIN_SHA="$(sha256_file "${BIN_DIR}/hermes-agent-ultra")"
+if [[ -n "${OUTPUT_JSON}" ]]; then
+  mkdir -p "$(dirname "${OUTPUT_JSON}")"
+  cat >"${OUTPUT_JSON}" <<JSON
+{
+  "schema_version": 1,
+  "status": "PASS",
+  "version": "${VERSION}",
+  "repo": "${REPO}",
+  "installer_sha256": "${INSTALL_SHA}",
+  "binary_sha256": "${BIN_SHA}",
+  "canonical_bin": "${BIN_DIR}/hermes-agent-ultra",
+  "primary_bin": "${BIN_DIR}/hermes-ultra",
+  "legacy_hermes": "$(${BIN_DIR}/hermes)"
+}
+JSON
+fi
 cat <<REPORT
 [release-smoke] PASS
 version=${VERSION}
@@ -236,4 +258,5 @@ binary_sha256=${BIN_SHA}
 canonical_bin=${BIN_DIR}/hermes-agent-ultra
 primary_bin=${BIN_DIR}/hermes-ultra
 legacy_hermes=$(${BIN_DIR}/hermes)
+report_json=${OUTPUT_JSON:-none}
 REPORT

--- a/tests/test_release_artifact_smoke_contract.py
+++ b/tests/test_release_artifact_smoke_contract.py
@@ -49,6 +49,17 @@ def test_release_smoke_bounds_each_runtime_probe() -> None:
     assert "Command timed out after ${HERMES_SMOKE_COMMAND_TIMEOUT_SECONDS}s: $*" in text
 
 
+def test_release_smoke_can_emit_machine_readable_report() -> None:
+    text = SCRIPT.read_text()
+    assert 'OUTPUT_JSON="${OUTPUT_JSON:-}"' in text
+    assert "--output-json PATH" in text
+    assert '"schema_version": 1' in text
+    assert '"status": "PASS"' in text
+    assert '"installer_sha256": "${INSTALL_SHA}"' in text
+    assert '"binary_sha256": "${BIN_SHA}"' in text
+    assert "report_json=${OUTPUT_JSON:-none}" in text
+
+
 def test_release_smoke_covers_public_runtime_surfaces() -> None:
     text = SCRIPT.read_text()
     for surface in [
@@ -76,3 +87,10 @@ def test_release_workflow_packages_canonical_binary_not_legacy_wrapper() -> None
     assert "release/hermes-agent-ultra dist/hermes" in text
     assert "binary: hermes\n" not in text
     assert "release/hermes dist/" not in text
+
+
+def test_release_workflow_uploads_published_artifact_smoke_report() -> None:
+    text = RELEASE_WORKFLOW.read_text()
+    assert "--output-json .sync-reports/release-artifact-smoke.json" in text
+    assert "name: release-artifact-smoke" in text
+    assert "path: .sync-reports/release-artifact-smoke.json" in text

--- a/tests/test_release_readiness_summary.py
+++ b/tests/test_release_readiness_summary.py
@@ -6,6 +6,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = REPO_ROOT / "scripts" / "generate-release-readiness-summary.py"
 PARITY_AUDIT = REPO_ROOT / ".github" / "workflows" / "parity-audit.yml"
+RUN_REPO_CI = REPO_ROOT / "scripts" / "run-repo-ci.sh"
 
 
 def test_release_readiness_summary_reports_zero_backlog(tmp_path: Path) -> None:
@@ -35,9 +36,13 @@ def test_release_readiness_summary_reports_zero_backlog(tmp_path: Path) -> None:
     assert payload["summary"]["shared_pending_review"] == 0
     assert payload["summary"]["coverage_critical_gaps"] == 0
     assert payload["summary"]["sota_critical_gaps"] == 0
+    assert payload["summary"]["upstream_delta_watch_pass"] is True
+    assert payload["upstream_delta_watch"]["queue_pending"] == 0
+    assert payload["upstream_delta_watch"]["status"] in {"PASS", "WATCH"}
     text = out_md.read_text()
     assert "Status: **PASS**" in text
     assert "Upstream queue pending" in text
+    assert "Upstream Delta Watch" in text
 
 
 def test_release_readiness_summary_uses_public_artifacts_only() -> None:
@@ -47,7 +52,17 @@ def test_release_readiness_summary_uses_public_artifacts_only() -> None:
     assert "docs/parity/shared-diff-backlog.json" in text
     assert "docs/parity/test-coverage-audit.json" in text
     assert "docs/parity/sota-harness-matrix.json" in text
+    assert "docs/parity/global-parity-thresholds.json" in text
     assert "contextlattice" not in text.lower()
+
+
+def test_repo_ci_runs_readiness_summary_after_global_parity_proof() -> None:
+    text = RUN_REPO_CI.read_text()
+    assert "python3 scripts/generate-global-parity-proof.py" in text
+    assert "python3 scripts/generate-release-readiness-summary.py --check" in text
+    assert text.index("python3 scripts/generate-global-parity-proof.py") < text.index(
+        "python3 scripts/generate-release-readiness-summary.py --check"
+    )
 
 
 def test_parity_audit_emits_readiness_summary_before_enforcing_ci_gate() -> None:


### PR DESCRIPTION
## Summary
- Adds deterministic Ultra autonomy evals for outcome-loop rehearsal and ContextLattice recall-quality scoring.
- Adds provider auth smoke matrix coverage for dynamic OpenAI/Codex-style auth, CLI providers, local providers, and configured key providers.
- Adds release artifact smoke JSON output and publishes it from the release workflow.
- Adds upstream delta watch telemetry to the release readiness summary and repo-local CI gate.
- Ports current upstream gateway deltas for generic OIDC relay identity provisioning and Discord pairing/fail-closed allowlist behavior.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `python3 -m py_compile scripts/generate-release-readiness-summary.py`
- `bash -n scripts/smoke-release-artifact.sh scripts/run-repo-ci.sh`
- `cargo test -p hermes-gateway relay_ --lib`
- `cargo test -p hermes-gateway gateway_discord_group_allowlist_honors_authorized_source_pairing --lib`
- `cargo test -p hermes-gateway gateway_discord_slash_requires_allowlist --lib`
- `cargo test -p hermes-gateway discord_fail_closed_default_warning_is_precise --lib`
- `cargo test -p hermes-provider-runtime --lib`
- `cargo test -p hermes-tools ultra_autonomy --lib`
- `pytest tests/test_release_artifact_smoke_contract.py tests/test_release_readiness_summary.py -q`
- `CARGO_TARGET_DIR=/Volumes/wd_black/hermes-agent-ultra/target CARGO_INCREMENTAL=0 bash scripts/run-repo-ci.sh` -> `[repo-ci] PASS`

## Parity/readiness
- `docs/parity/global-parity-proof.json`: `release_gate.pass=true`
- `docs/parity/upstream-missing-queue.json`: visible upstream queue classified/ported, pending=0
- `docs/parity/shared-diff-backlog.json`: `pending_classification=0`, `pending_review=0`
